### PR TITLE
Reltime

### DIFF
--- a/res/values-af/strings.xml
+++ b/res/values-af/strings.xml
@@ -291,12 +291,6 @@
 
 	<!-- Displayed to indicate a host has never been connected to. -->
 	<string name="bind_never">Never connected</string>
-	<!-- The time that has elapsed since a host was connected to when it has been less than an hour. -->
-	<string name="bind_minutes">%1$s minutes ago</string>
-	<!-- The time that has elapsed since a host was connected to when it has been less than a day. -->
-	<string name="bind_hours">%1$s hours ago</string>
-	<!-- The time that has elapsed since a host was connected to when it has been a day or more. -->
-	<string name="bind_days">%1$s days ago</string>
 
 	<!-- Message given when user copies from the terminal. -->
 	<string name="console_copy_done">Copied %1$d bytes to clipboard</string>

--- a/res/values-be/strings.xml
+++ b/res/values-be/strings.xml
@@ -291,12 +291,6 @@
 
 	<!-- Displayed to indicate a host has never been connected to. -->
 	<string name="bind_never">Never connected</string>
-	<!-- The time that has elapsed since a host was connected to when it has been less than an hour. -->
-	<string name="bind_minutes">%1$s minutes ago</string>
-	<!-- The time that has elapsed since a host was connected to when it has been less than a day. -->
-	<string name="bind_hours">%1$s hours ago</string>
-	<!-- The time that has elapsed since a host was connected to when it has been a day or more. -->
-	<string name="bind_days">%1$s days ago</string>
 
 	<!-- Message given when user copies from the terminal. -->
 	<string name="console_copy_done">Copied %1$d bytes to clipboard</string>

--- a/res/values-bg/strings.xml
+++ b/res/values-bg/strings.xml
@@ -291,12 +291,6 @@
 
 	<!-- Displayed to indicate a host has never been connected to. -->
 	<string name="bind_never">Never connected</string>
-	<!-- The time that has elapsed since a host was connected to when it has been less than an hour. -->
-	<string name="bind_minutes">%1$s minutes ago</string>
-	<!-- The time that has elapsed since a host was connected to when it has been less than a day. -->
-	<string name="bind_hours">%1$s hours ago</string>
-	<!-- The time that has elapsed since a host was connected to when it has been a day or more. -->
-	<string name="bind_days">%1$s days ago</string>
 
 	<!-- Message given when user copies from the terminal. -->
 	<string name="console_copy_done">Копирани %1$d байта в клипборда</string>

--- a/res/values-ca/strings.xml
+++ b/res/values-ca/strings.xml
@@ -291,12 +291,6 @@
 
 	<!-- Displayed to indicate a host has never been connected to. -->
 	<string name="bind_never">Mai connectat</string>
-	<!-- The time that has elapsed since a host was connected to when it has been less than an hour. -->
-	<string name="bind_minutes">Fa %1$s minuts</string>
-	<!-- The time that has elapsed since a host was connected to when it has been less than a day. -->
-	<string name="bind_hours">Fa %1$s hores</string>
-	<!-- The time that has elapsed since a host was connected to when it has been a day or more. -->
-	<string name="bind_days">Fa %1$s dies</string>
 
 	<!-- Message given when user copies from the terminal. -->
 	<string name="console_copy_done">Copiats %1$d bytes al porta-retalls</string>

--- a/res/values-cs/strings.xml
+++ b/res/values-cs/strings.xml
@@ -291,12 +291,6 @@
 
 	<!-- Displayed to indicate a host has never been connected to. -->
 	<string name="bind_never">Nikdy nepřipojen</string>
-	<!-- The time that has elapsed since a host was connected to when it has been less than an hour. -->
-	<string name="bind_minutes">Před %1$s minutami</string>
-	<!-- The time that has elapsed since a host was connected to when it has been less than a day. -->
-	<string name="bind_hours">Před %1$s hodinami</string>
-	<!-- The time that has elapsed since a host was connected to when it has been a day or more. -->
-	<string name="bind_days">Před %1$s dny</string>
 
 	<!-- Message given when user copies from the terminal. -->
 	<string name="console_copy_done">Zkopírováno %1$d bajtů do schránky</string>

--- a/res/values-da/strings.xml
+++ b/res/values-da/strings.xml
@@ -291,12 +291,6 @@
 
 	<!-- Displayed to indicate a host has never been connected to. -->
 	<string name="bind_never">Aldrig forbundet</string>
-	<!-- The time that has elapsed since a host was connected to when it has been less than an hour. -->
-	<string name="bind_minutes">%1$s minutter siden</string>
-	<!-- The time that has elapsed since a host was connected to when it has been less than a day. -->
-	<string name="bind_hours">%1$s timer siden</string>
-	<!-- The time that has elapsed since a host was connected to when it has been a day or more. -->
-	<string name="bind_days">%1$s dage siden</string>
 
 	<!-- Message given when user copies from the terminal. -->
 	<string name="console_copy_done">Kopier %1$d bytes til udklipsholder</string>

--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -291,12 +291,6 @@
 
 	<!-- Displayed to indicate a host has never been connected to. -->
 	<string name="bind_never">Nie verbunden</string>
-	<!-- The time that has elapsed since a host was connected to when it has been less than an hour. -->
-	<string name="bind_minutes">vor %1$s Minuten</string>
-	<!-- The time that has elapsed since a host was connected to when it has been less than a day. -->
-	<string name="bind_hours">vor %1$s Stunden</string>
-	<!-- The time that has elapsed since a host was connected to when it has been a day or more. -->
-	<string name="bind_days">vor %1$s Tagen</string>
 
 	<!-- Message given when user copies from the terminal. -->
 	<string name="console_copy_done">%1$d Byte in die Zwischenablage kopiert</string>

--- a/res/values-es/strings.xml
+++ b/res/values-es/strings.xml
@@ -291,12 +291,6 @@
 
 	<!-- Displayed to indicate a host has never been connected to. -->
 	<string name="bind_never">Nunca fué conectado</string>
-	<!-- The time that has elapsed since a host was connected to when it has been less than an hour. -->
-	<string name="bind_minutes">Hace %1$s minutos</string>
-	<!-- The time that has elapsed since a host was connected to when it has been less than a day. -->
-	<string name="bind_hours">Hace %1$s horas</string>
-	<!-- The time that has elapsed since a host was connected to when it has been a day or more. -->
-	<string name="bind_days">Hace %1$s días</string>
 
 	<!-- Message given when user copies from the terminal. -->
 	<string name="console_copy_done">%1$d bytes copiados al portapaleles</string>

--- a/res/values-eu/strings.xml
+++ b/res/values-eu/strings.xml
@@ -291,12 +291,6 @@
 
 	<!-- Displayed to indicate a host has never been connected to. -->
 	<string name="bind_never">Never connected</string>
-	<!-- The time that has elapsed since a host was connected to when it has been less than an hour. -->
-	<string name="bind_minutes">%1$s minutes ago</string>
-	<!-- The time that has elapsed since a host was connected to when it has been less than a day. -->
-	<string name="bind_hours">%1$s hours ago</string>
-	<!-- The time that has elapsed since a host was connected to when it has been a day or more. -->
-	<string name="bind_days">%1$s days ago</string>
 
 	<!-- Message given when user copies from the terminal. -->
 	<string name="console_copy_done">Copied %1$d bytes to clipboard</string>

--- a/res/values-fi/strings.xml
+++ b/res/values-fi/strings.xml
@@ -291,12 +291,6 @@
 
 	<!-- Displayed to indicate a host has never been connected to. -->
 	<string name="bind_never">Never connected</string>
-	<!-- The time that has elapsed since a host was connected to when it has been less than an hour. -->
-	<string name="bind_minutes">%1$s minutes ago</string>
-	<!-- The time that has elapsed since a host was connected to when it has been less than a day. -->
-	<string name="bind_hours">%1$s hours ago</string>
-	<!-- The time that has elapsed since a host was connected to when it has been a day or more. -->
-	<string name="bind_days">%1$s days ago</string>
 
 	<!-- Message given when user copies from the terminal. -->
 	<string name="console_copy_done">Copied %1$d bytes to clipboard</string>

--- a/res/values-fr/strings.xml
+++ b/res/values-fr/strings.xml
@@ -291,12 +291,6 @@
 
 	<!-- Displayed to indicate a host has never been connected to. -->
 	<string name="bind_never">jamais connecté</string>
-	<!-- The time that has elapsed since a host was connected to when it has been less than an hour. -->
-	<string name="bind_minutes">Il ya %1$s minutes</string>
-	<!-- The time that has elapsed since a host was connected to when it has been less than a day. -->
-	<string name="bind_hours">Il y a %1$s heures</string>
-	<!-- The time that has elapsed since a host was connected to when it has been a day or more. -->
-	<string name="bind_days">Il y a %1$s jours</string>
 
 	<!-- Message given when user copies from the terminal. -->
 	<string name="console_copy_done">%1$d octets copié dans le presse-papier</string>

--- a/res/values-gl/strings.xml
+++ b/res/values-gl/strings.xml
@@ -291,12 +291,6 @@
 
 	<!-- Displayed to indicate a host has never been connected to. -->
 	<string name="bind_never">Nunca conectado</string>
-	<!-- The time that has elapsed since a host was connected to when it has been less than an hour. -->
-	<string name="bind_minutes">Hai %1$s minutos</string>
-	<!-- The time that has elapsed since a host was connected to when it has been less than a day. -->
-	<string name="bind_hours">Hai %1$s horas</string>
-	<!-- The time that has elapsed since a host was connected to when it has been a day or more. -->
-	<string name="bind_days">Hai %1$s días</string>
 
 	<!-- Message given when user copies from the terminal. -->
 	<string name="console_copy_done">Copiados %1$d bytes ao portapapeis</string>

--- a/res/values-hu/strings.xml
+++ b/res/values-hu/strings.xml
@@ -291,12 +291,6 @@
 
 	<!-- Displayed to indicate a host has never been connected to. -->
 	<string name="bind_never">Még nem csatlakozott</string>
-	<!-- The time that has elapsed since a host was connected to when it has been less than an hour. -->
-	<string name="bind_minutes">%1$s perce</string>
-	<!-- The time that has elapsed since a host was connected to when it has been less than a day. -->
-	<string name="bind_hours">%1$s órája</string>
-	<!-- The time that has elapsed since a host was connected to when it has been a day or more. -->
-	<string name="bind_days">%1$s napja</string>
 
 	<!-- Message given when user copies from the terminal. -->
 	<string name="console_copy_done">%1$d bájt a vágólapra másolva</string>

--- a/res/values-id/strings.xml
+++ b/res/values-id/strings.xml
@@ -291,12 +291,6 @@
 
 	<!-- Displayed to indicate a host has never been connected to. -->
 	<string name="bind_never">Tidak pernah terhubung</string>
-	<!-- The time that has elapsed since a host was connected to when it has been less than an hour. -->
-	<string name="bind_minutes">%1$s menit yang lalu</string>
-	<!-- The time that has elapsed since a host was connected to when it has been less than a day. -->
-	<string name="bind_hours">%1$s jam yang lalu</string>
-	<!-- The time that has elapsed since a host was connected to when it has been a day or more. -->
-	<string name="bind_days">%1$s hari yang lalu</string>
 
 	<!-- Message given when user copies from the terminal. -->
 	<string name="console_copy_done">Tersalin %1$d bytes ke papan klip</string>

--- a/res/values-it/strings.xml
+++ b/res/values-it/strings.xml
@@ -291,12 +291,6 @@
 
 	<!-- Displayed to indicate a host has never been connected to. -->
 	<string name="bind_never">Mai connesso</string>
-	<!-- The time that has elapsed since a host was connected to when it has been less than an hour. -->
-	<string name="bind_minutes">%1$s minuti fa</string>
-	<!-- The time that has elapsed since a host was connected to when it has been less than a day. -->
-	<string name="bind_hours">%1$s ore fa</string>
-	<!-- The time that has elapsed since a host was connected to when it has been a day or more. -->
-	<string name="bind_days">%1$s giorni fa</string>
 
 	<!-- Message given when user copies from the terminal. -->
 	<string name="console_copy_done">%1$d byte copiati</string>

--- a/res/values-ja/strings.xml
+++ b/res/values-ja/strings.xml
@@ -291,12 +291,6 @@
 
 	<!-- Displayed to indicate a host has never been connected to. -->
 	<string name="bind_never">未接続</string>
-	<!-- The time that has elapsed since a host was connected to when it has been less than an hour. -->
-	<string name="bind_minutes">%1$s 分前</string>
-	<!-- The time that has elapsed since a host was connected to when it has been less than a day. -->
-	<string name="bind_hours">%1$s 時間前</string>
-	<!-- The time that has elapsed since a host was connected to when it has been a day or more. -->
-	<string name="bind_days">%1$s 日前</string>
 
 	<!-- Message given when user copies from the terminal. -->
 	<string name="console_copy_done">クリップボードに %1$d バイトコピーしました．</string>

--- a/res/values-ko/strings.xml
+++ b/res/values-ko/strings.xml
@@ -291,12 +291,6 @@
 
 	<!-- Displayed to indicate a host has never been connected to. -->
 	<string name="bind_never">Never connected</string>
-	<!-- The time that has elapsed since a host was connected to when it has been less than an hour. -->
-	<string name="bind_minutes">%1$s minutes ago</string>
-	<!-- The time that has elapsed since a host was connected to when it has been less than a day. -->
-	<string name="bind_hours">%1$s hours ago</string>
-	<!-- The time that has elapsed since a host was connected to when it has been a day or more. -->
-	<string name="bind_days">%1$s days ago</string>
 
 	<!-- Message given when user copies from the terminal. -->
 	<string name="console_copy_done">Copied %1$d bytes to clipboard</string>

--- a/res/values-lt/strings.xml
+++ b/res/values-lt/strings.xml
@@ -291,12 +291,6 @@
 
 	<!-- Displayed to indicate a host has never been connected to. -->
 	<string name="bind_never">Never connected</string>
-	<!-- The time that has elapsed since a host was connected to when it has been less than an hour. -->
-	<string name="bind_minutes">%1$s minutes ago</string>
-	<!-- The time that has elapsed since a host was connected to when it has been less than a day. -->
-	<string name="bind_hours">%1$s hours ago</string>
-	<!-- The time that has elapsed since a host was connected to when it has been a day or more. -->
-	<string name="bind_days">%1$s days ago</string>
 
 	<!-- Message given when user copies from the terminal. -->
 	<string name="console_copy_done">Copied %1$d bytes to clipboard</string>

--- a/res/values-nb/strings.xml
+++ b/res/values-nb/strings.xml
@@ -291,12 +291,6 @@
 
 	<!-- Displayed to indicate a host has never been connected to. -->
 	<string name="bind_never">Never connected</string>
-	<!-- The time that has elapsed since a host was connected to when it has been less than an hour. -->
-	<string name="bind_minutes">%1$s minutt siden</string>
-	<!-- The time that has elapsed since a host was connected to when it has been less than a day. -->
-	<string name="bind_hours">%1$s timer siden</string>
-	<!-- The time that has elapsed since a host was connected to when it has been a day or more. -->
-	<string name="bind_days">%1$s dager siden</string>
 
 	<!-- Message given when user copies from the terminal. -->
 	<string name="console_copy_done">Copied %1$d bytes to clipboard</string>

--- a/res/values-nl/strings.xml
+++ b/res/values-nl/strings.xml
@@ -291,12 +291,6 @@
 
 	<!-- Displayed to indicate a host has never been connected to. -->
 	<string name="bind_never">Nooit verbonden</string>
-	<!-- The time that has elapsed since a host was connected to when it has been less than an hour. -->
-	<string name="bind_minutes">%1$s minuten geleden</string>
-	<!-- The time that has elapsed since a host was connected to when it has been less than a day. -->
-	<string name="bind_hours">%1$s uren geleden</string>
-	<!-- The time that has elapsed since a host was connected to when it has been a day or more. -->
-	<string name="bind_days">%1$s dagen geleden</string>
 
 	<!-- Message given when user copies from the terminal. -->
 	<string name="console_copy_done">%1$d bytes gekopieerd naar het klembord</string>

--- a/res/values-oc/strings.xml
+++ b/res/values-oc/strings.xml
@@ -291,12 +291,6 @@
 
 	<!-- Displayed to indicate a host has never been connected to. -->
 	<string name="bind_never">Never connected</string>
-	<!-- The time that has elapsed since a host was connected to when it has been less than an hour. -->
-	<string name="bind_minutes">%1$s minutes ago</string>
-	<!-- The time that has elapsed since a host was connected to when it has been less than a day. -->
-	<string name="bind_hours">%1$s hours ago</string>
-	<!-- The time that has elapsed since a host was connected to when it has been a day or more. -->
-	<string name="bind_days">%1$s days ago</string>
 
 	<!-- Message given when user copies from the terminal. -->
 	<string name="console_copy_done">Copied %1$d bytes to clipboard</string>

--- a/res/values-pl/strings.xml
+++ b/res/values-pl/strings.xml
@@ -291,12 +291,6 @@
 
 	<!-- Displayed to indicate a host has never been connected to. -->
 	<string name="bind_never">Nigdy nie połączono</string>
-	<!-- The time that has elapsed since a host was connected to when it has been less than an hour. -->
-	<string name="bind_minutes">%1$s minut temu</string>
-	<!-- The time that has elapsed since a host was connected to when it has been less than a day. -->
-	<string name="bind_hours">%1$s godzin temu</string>
-	<!-- The time that has elapsed since a host was connected to when it has been a day or more. -->
-	<string name="bind_days">%1$s dni temu</string>
 
 	<!-- Message given when user copies from the terminal. -->
 	<string name="console_copy_done">Skopiowano %1$d bajtów do schowka</string>

--- a/res/values-pt-rBR/strings.xml
+++ b/res/values-pt-rBR/strings.xml
@@ -291,12 +291,6 @@
 
 	<!-- Displayed to indicate a host has never been connected to. -->
 	<string name="bind_never">Never connected</string>
-	<!-- The time that has elapsed since a host was connected to when it has been less than an hour. -->
-	<string name="bind_minutes">%1$s minutes ago</string>
-	<!-- The time that has elapsed since a host was connected to when it has been less than a day. -->
-	<string name="bind_hours">%1$s hours ago</string>
-	<!-- The time that has elapsed since a host was connected to when it has been a day or more. -->
-	<string name="bind_days">%1$s days ago</string>
 
 	<!-- Message given when user copies from the terminal. -->
 	<string name="console_copy_done">Copied %1$d bytes to clipboard</string>

--- a/res/values-pt/strings.xml
+++ b/res/values-pt/strings.xml
@@ -291,12 +291,6 @@
 
 	<!-- Displayed to indicate a host has never been connected to. -->
 	<string name="bind_never">Never connected</string>
-	<!-- The time that has elapsed since a host was connected to when it has been less than an hour. -->
-	<string name="bind_minutes">%1$s minutes ago</string>
-	<!-- The time that has elapsed since a host was connected to when it has been less than a day. -->
-	<string name="bind_hours">%1$s hours ago</string>
-	<!-- The time that has elapsed since a host was connected to when it has been a day or more. -->
-	<string name="bind_days">%1$s days ago</string>
 
 	<!-- Message given when user copies from the terminal. -->
 	<string name="console_copy_done">Copied %1$d bytes to clipboard</string>

--- a/res/values-ru/strings.xml
+++ b/res/values-ru/strings.xml
@@ -291,12 +291,6 @@
 
 	<!-- Displayed to indicate a host has never been connected to. -->
 	<string name="bind_never">Не подключен</string>
-	<!-- The time that has elapsed since a host was connected to when it has been less than an hour. -->
-	<string name="bind_minutes">%1$s минут назад</string>
-	<!-- The time that has elapsed since a host was connected to when it has been less than a day. -->
-	<string name="bind_hours">%1$s час(ов) назад</string>
-	<!-- The time that has elapsed since a host was connected to when it has been a day or more. -->
-	<string name="bind_days">%1$s дней назад</string>
 
 	<!-- Message given when user copies from the terminal. -->
 	<string name="console_copy_done">Скопировано %1$d байт в буфер обмена</string>

--- a/res/values-sk/strings.xml
+++ b/res/values-sk/strings.xml
@@ -291,12 +291,6 @@
 
 	<!-- Displayed to indicate a host has never been connected to. -->
 	<string name="bind_never">Nikdy nebol pripojený</string>
-	<!-- The time that has elapsed since a host was connected to when it has been less than an hour. -->
-	<string name="bind_minutes">%1$s minutes ago</string>
-	<!-- The time that has elapsed since a host was connected to when it has been less than a day. -->
-	<string name="bind_hours">%1$s hours ago</string>
-	<!-- The time that has elapsed since a host was connected to when it has been a day or more. -->
-	<string name="bind_days">Pred %1$s dňami</string>
 
 	<!-- Message given when user copies from the terminal. -->
 	<string name="console_copy_done">Copied %1$d bytes to clipboard</string>

--- a/res/values-sl/strings.xml
+++ b/res/values-sl/strings.xml
@@ -291,12 +291,6 @@
 
 	<!-- Displayed to indicate a host has never been connected to. -->
 	<string name="bind_never">Never connected</string>
-	<!-- The time that has elapsed since a host was connected to when it has been less than an hour. -->
-	<string name="bind_minutes">%1$s minutes ago</string>
-	<!-- The time that has elapsed since a host was connected to when it has been less than a day. -->
-	<string name="bind_hours">%1$s hours ago</string>
-	<!-- The time that has elapsed since a host was connected to when it has been a day or more. -->
-	<string name="bind_days">%1$s days ago</string>
 
 	<!-- Message given when user copies from the terminal. -->
 	<string name="console_copy_done">Copied %1$d bytes to clipboard</string>

--- a/res/values-sv/strings.xml
+++ b/res/values-sv/strings.xml
@@ -291,12 +291,6 @@
 
 	<!-- Displayed to indicate a host has never been connected to. -->
 	<string name="bind_never">Never connected</string>
-	<!-- The time that has elapsed since a host was connected to when it has been less than an hour. -->
-	<string name="bind_minutes">%1$s minuter sedan</string>
-	<!-- The time that has elapsed since a host was connected to when it has been less than a day. -->
-	<string name="bind_hours">%1$s timmar sendan</string>
-	<!-- The time that has elapsed since a host was connected to when it has been a day or more. -->
-	<string name="bind_days">%1$s dagar sedan</string>
 
 	<!-- Message given when user copies from the terminal. -->
 	<string name="console_copy_done">Kopierade %1$d bytes till urklippshanteraren.</string>

--- a/res/values-tr/strings.xml
+++ b/res/values-tr/strings.xml
@@ -291,12 +291,6 @@
 
 	<!-- Displayed to indicate a host has never been connected to. -->
 	<string name="bind_never">Never connected</string>
-	<!-- The time that has elapsed since a host was connected to when it has been less than an hour. -->
-	<string name="bind_minutes">%1$s minutes ago</string>
-	<!-- The time that has elapsed since a host was connected to when it has been less than a day. -->
-	<string name="bind_hours">%1$s hours ago</string>
-	<!-- The time that has elapsed since a host was connected to when it has been a day or more. -->
-	<string name="bind_days">%1$s days ago</string>
 
 	<!-- Message given when user copies from the terminal. -->
 	<string name="console_copy_done">Copied %1$d bytes to clipboard</string>

--- a/res/values-uk/strings.xml
+++ b/res/values-uk/strings.xml
@@ -291,12 +291,6 @@
 
 	<!-- Displayed to indicate a host has never been connected to. -->
 	<string name="bind_never">Never connected</string>
-	<!-- The time that has elapsed since a host was connected to when it has been less than an hour. -->
-	<string name="bind_minutes">%1$s minutes ago</string>
-	<!-- The time that has elapsed since a host was connected to when it has been less than a day. -->
-	<string name="bind_hours">%1$s hours ago</string>
-	<!-- The time that has elapsed since a host was connected to when it has been a day or more. -->
-	<string name="bind_days">%1$s days ago</string>
 
 	<!-- Message given when user copies from the terminal. -->
 	<string name="console_copy_done">Copied %1$d bytes to clipboard</string>

--- a/res/values-vi/strings.xml
+++ b/res/values-vi/strings.xml
@@ -291,12 +291,6 @@
 
 	<!-- Displayed to indicate a host has never been connected to. -->
 	<string name="bind_never">Never connected</string>
-	<!-- The time that has elapsed since a host was connected to when it has been less than an hour. -->
-	<string name="bind_minutes">%1$s minutes ago</string>
-	<!-- The time that has elapsed since a host was connected to when it has been less than a day. -->
-	<string name="bind_hours">%1$s hours ago</string>
-	<!-- The time that has elapsed since a host was connected to when it has been a day or more. -->
-	<string name="bind_days">%1$s days ago</string>
 
 	<!-- Message given when user copies from the terminal. -->
 	<string name="console_copy_done">Copied %1$d bytes to clipboard</string>

--- a/res/values-zh-rCN/strings.xml
+++ b/res/values-zh-rCN/strings.xml
@@ -291,12 +291,6 @@
 
 	<!-- Displayed to indicate a host has never been connected to. -->
 	<string name="bind_never">从未连接</string>
-	<!-- The time that has elapsed since a host was connected to when it has been less than an hour. -->
-	<string name="bind_minutes">已连接 %1$s 分钟</string>
-	<!-- The time that has elapsed since a host was connected to when it has been less than a day. -->
-	<string name="bind_hours">已连接 %1$s 小时</string>
-	<!-- The time that has elapsed since a host was connected to when it has been a day or more. -->
-	<string name="bind_days">已连接 %1$s 天</string>
 
 	<!-- Message given when user copies from the terminal. -->
 	<string name="console_copy_done">复制 %1$d 字节到剪贴板</string>

--- a/res/values-zh-rTW/strings.xml
+++ b/res/values-zh-rTW/strings.xml
@@ -291,12 +291,6 @@
 
 	<!-- Displayed to indicate a host has never been connected to. -->
 	<string name="bind_never">從未連接</string>
-	<!-- The time that has elapsed since a host was connected to when it has been less than an hour. -->
-	<string name="bind_minutes">已連接 %1$s 分鐘</string>
-	<!-- The time that has elapsed since a host was connected to when it has been less than a day. -->
-	<string name="bind_hours">已連接 %1$s 小時</string>
-	<!-- The time that has elapsed since a host was connected to when it has been a day or more. -->
-	<string name="bind_days">已連接 %1$s 天</string>
 
 	<!-- Message given when user copies from the terminal. -->
 	<string name="console_copy_done">復制 %1$d 字節到剪貼板</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -293,12 +293,6 @@
 
 	<!-- Displayed to indicate a host has never been connected to. -->
 	<string name="bind_never">Never connected</string>
-	<!-- The time that has elapsed since a host was connected to when it has been less than an hour. -->
-	<string name="bind_minutes">%1$s minutes ago</string>
-	<!-- The time that has elapsed since a host was connected to when it has been less than a day. -->
-	<string name="bind_hours">%1$s hours ago</string>
-	<!-- The time that has elapsed since a host was connected to when it has been a day or more. -->
-	<string name="bind_days">%1$s days ago</string>
 
 	<!-- Message given when user copies from the terminal. -->
 	<string name="console_copy_done">Copied %1$d bytes to clipboard</string>

--- a/src/org/connectbot/HostListActivity.java
+++ b/src/org/connectbot/HostListActivity.java
@@ -45,6 +45,7 @@ import android.os.Handler;
 import android.os.IBinder;
 import android.os.Message;
 import android.preference.PreferenceManager;
+import android.text.format.DateUtils;
 import android.util.Log;
 import android.view.ContextMenu;
 import android.view.KeyEvent;
@@ -543,20 +544,9 @@ public class HostListActivity extends ListActivity {
 				holder.caption.setTextAppearance(context, android.R.attr.textAppearanceSmall);
 			}
 
-			long now = System.currentTimeMillis() / 1000;
-
-			String nice = context.getString(R.string.bind_never);
+			CharSequence nice = context.getString(R.string.bind_never);
 			if (host.getLastConnect() > 0) {
-				int minutes = (int)((now - host.getLastConnect()) / 60);
-				if (minutes >= 60) {
-					int hours = (minutes / 60);
-					if (hours >= 24) {
-						int days = (hours / 24);
-						nice = context.getString(R.string.bind_days, days);
-					} else
-						nice = context.getString(R.string.bind_hours, hours);
-				} else
-					nice = context.getString(R.string.bind_minutes, minutes);
+				nice = DateUtils.getRelativeTimeSpanString(host.getLastConnect() * 1000);
 			}
 
 			holder.caption.setText(nice);


### PR DESCRIPTION
This change would fix pluralisation issues (e.g. "1 minutes ago") across all languages but unfortunately would mean we end up losing the translation for a few languages (looking at the current Froyo frameworks/base repository we lose ca, gl, hu, id, sk but gain el, pt, tr). An alternative fix could be to fix the pluralisation issue in connectbot (code duplication), or possibly port our translations to frameworks/base.  Let me know what you think.