### PR TITLE
retry connection patch

### DIFF
--- a/src/org/connectbot/service/ConnectivityReceiver.java
+++ b/src/org/connectbot/service/ConnectivityReceiver.java
@@ -65,22 +65,20 @@ public class ConnectivityReceiver extends BroadcastReceiver {
             Log.w(TAG, "onReceived() called: " + intent);
             return;
 		}
+		NetworkInfo info = intent.getParcelableExtra(ConnectivityManager.EXTRA_NETWORK_INFO);
+		Log.d(TAG, "onReceived() called; " + info.toString());
+		Log.d(TAG, "onReceived() called; mIsConnected: " + mIsConnected + ", StateConnected?: " +(info.getState()==State.CONNECTED));
 
-		boolean noConnectivity = intent.getBooleanExtra(ConnectivityManager.EXTRA_NO_CONNECTIVITY, false);
-		boolean isFailover = intent.getBooleanExtra(ConnectivityManager.EXTRA_IS_FAILOVER, false);
-
-		Log.d(TAG, "onReceived() called; noConnectivity? " + noConnectivity + "; isFailover? " + isFailover);
-
-		if (noConnectivity && !isFailover && mIsConnected) {
-			mIsConnected = false;
-			mTerminalManager.onConnectivityLost();
-		} else if (!mIsConnected) {
-			NetworkInfo info = (NetworkInfo) intent.getExtras()
-					.get(ConnectivityManager.EXTRA_NETWORK_INFO);
-
-			if (mIsConnected = (info.getState() == State.CONNECTED)) {
+		if (info.getState()==State.CONNECTED) {
+			if (!mIsConnected) {
 				mTerminalManager.onConnectivityRestored();
 			}
+			mIsConnected = true;
+		} else {
+			if (mIsConnected) {
+				mTerminalManager.onConnectivityLost();
+			}
+			mIsConnected = false;
 		}
 	}
 

--- a/src/org/connectbot/service/TerminalBridge.java
+++ b/src/org/connectbot/service/TerminalBridge.java
@@ -407,7 +407,7 @@ public class TerminalBridge implements VDUDisplay {
 
 			disconnected = true;
 		}
-
+		Log.i(TAG, "dispatchDisconnect");
 		// Cancel any pending prompts.
 		promptHelper.cancelPrompt();
 
@@ -432,6 +432,12 @@ public class TerminalBridge implements VDUDisplay {
 				((vt320) buffer).putString("\r\n" + line + "\r\n");
 			}
 			if (host.getStayConnected()) {
+				try {
+					Thread.sleep(5000);
+				} catch (InterruptedException e) {
+					// TODO Auto-generated catch block
+					e.printStackTrace();
+				}
 				manager.requestReconnect(this);
 				return;
 			}

--- a/src/org/connectbot/service/TerminalManager.java
+++ b/src/org/connectbot/service/TerminalManager.java
@@ -691,8 +691,10 @@ public class TerminalManager extends Service implements BridgeDisconnectedListen
 	public void requestReconnect(TerminalBridge bridge) {
 		synchronized (mPendingReconnect) {
 			mPendingReconnect.add(new WeakReference<TerminalBridge>(bridge));
+			Log.i(TAG, "requestReconnect()");
 			if (!bridge.isUsingNetwork() ||
 					connectivityManager.isConnected()) {
+				Log.i(TAG, "requestReconnect()->ReconnectPending()");
 				reconnectPending();
 			}
 		}
@@ -704,12 +706,14 @@ public class TerminalManager extends Service implements BridgeDisconnectedListen
 	 */
 	private void reconnectPending() {
 		synchronized (mPendingReconnect) {
+
 			for (WeakReference<TerminalBridge> ref : mPendingReconnect) {
 				TerminalBridge bridge = ref.get();
 				if (bridge == null) {
 					continue;
 				}
 				bridge.startConnection();
+				Log.i(TAG, "ReconnectPending()");
 			}
 			mPendingReconnect.clear();
 		}

--- a/src/org/connectbot/transport/SSH.java
+++ b/src/org/connectbot/transport/SSH.java
@@ -108,6 +108,7 @@ public class SSH extends AbsTransport implements ConnectionMonitor, InteractiveC
 
 	private boolean pubkeysExhausted = false;
 	private boolean interactiveCanContinue = true;
+	private boolean connect_try_failed = false;
 
 	private Connection connection;
 	private Session session;
@@ -402,7 +403,24 @@ public class SSH extends AbsTransport implements ConnectionMonitor, InteractiveC
 	}
 
 	@Override
-	public void connect() {
+	public void connect () {
+		int tries = 0;
+		connect_try_failed = true;
+		while (tries++ < AUTH_TRIES) {
+			connection_try ();
+			if (!connect_try_failed) {
+				return;
+			}
+			try {
+				// wait a bit before retry
+				Thread.sleep(1000);
+			} catch (InterruptedException e) {}
+		}
+		Log.d(TAG, "Could not connect - out of retries");
+		onDisconnect();
+	}
+
+	public void connection_try() {
 		connection = new Connection(host.getHostname(), host.getPort());
 		connection.addConnectionMonitor(this);
 
@@ -446,27 +464,27 @@ public class SSH extends AbsTransport implements ConnectionMonitor, InteractiveC
 						connectionInfo.serverToClientMACAlgorithm));
 			}
 		} catch (IOException e) {
-			Log.e(TAG, "Problem in SSH connection thread during authentication", e);
+			Log.e(TAG, "Problem in SSH connection thread during authentication, retrying", e);
 
 			// Display the reason in the text.
 			bridge.outputLine(e.getCause().getMessage());
-
-			onDisconnect();
+			connect_try_failed = true;
 			return;
 		}
 
-		try {
-			// enter a loop to keep trying until authentication
-			int tries = 0;
-			while (connected && !connection.isAuthenticationComplete() && tries++ < AUTH_TRIES) {
+		// enter a loop to keep trying until authentication
+		int tries = 0;
+		while (connected && !connection.isAuthenticationComplete() && tries++ < AUTH_TRIES) {
+			try {
 				authenticate();
 
 				// sleep to make sure we dont kill system
 				Thread.sleep(1000);
+			} catch(Exception e) {
+				Log.e(TAG, "Problem in SSH connection thread during authentication, ("+connected+","+connection.isAuthenticationComplete()+","+tries+")", e);
 			}
-		} catch(Exception e) {
-			Log.e(TAG, "Problem in SSH connection thread during authentication", e);
 		}
+		connect_try_failed = false;
 	}
 
 	@Override


### PR DESCRIPTION
This patch adds several retries to connect before giving up. This came up because when switching from wifi to 3G, it takes some time for the 3G network to come up, and the first reconnect attempt fails with the "host unreachable" error. With this patch connectbot becomes quite robust with regards to connections.

I'm not sure if this patch has any undesirable side effects, but in such a case I would be happy to add it as a configuration option to be enabled only by those who need it.

And lastly, this is my first time writing java, and only after looking at the SDK for a few days, so I apologize if I made any glaring mistakes, and would be happy to hear any criticism and imporve.

Oh, and thanks for connectbot!

Shai
