### PR TITLE
Fix URL scan for flickr URLs with '@' in them.

### DIFF
--- a/src/org/connectbot/service/TerminalBridge.java
+++ b/src/org/connectbot/service/TerminalBridge.java
@@ -941,7 +941,7 @@ public class TerminalBridge implements VDUDisplay {
 			String host = "(?:" + ipLiteral + "|" + ipv4address + "|" + regName + ")";
 			String port = "[0-9]*";
 			String authority = "(?:" + userinfo + "@)?" + host + "(?::" + port + ")?";
-			String pchar = "(?:" + unreserved + "|" + pctEncoded + "|" + subDelims + ")";
+			String pchar = "(?:" + unreserved + "|" + pctEncoded + "|" + subDelims + "|@)";
 			String segment = pchar + "*";
 			String pathAbempty = "(?:/" + segment + ")*";
 			String segmentNz = pchar + "+";


### PR DESCRIPTION
URLs like "http://www.flickr.com/photos/34905206@N04/5763211556" were getting cut off just before the '@'. This adds '@' to the portion of the regex that matches paths in URLs.
