### PR TITLE
Added a "close on disconnect" option 

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -269,6 +269,10 @@
 	<!-- Summary for preference asking whether the host should be reconnected to when it disconnects -->
 	<string name="hostpref_stayconnected_summary">"Try to reconnect to host if disconnected"</string>
 
+    <!-- Setting for whether we should prompt to close after getting disconnected -->
+    <string name="hostpref_quickdisconnect_title">"Close on disconnect"</string>
+    <string name="hostpref_quickdisconnect_summary">"Close immediately after remote disconnect without prompting."</string>
+
 	<!-- Setting for what key code is sent to the server when DEL key is pressed. -->
 	<string name="hostpref_delkey_title">"DEL Key"</string>
 	<!-- Summary for field asking what key code is sent to the server when DEL key is pressed. -->

--- a/res/xml/host_prefs.xml
+++ b/res/xml/host_prefs.xml
@@ -85,7 +85,13 @@
 		android:summary="@string/hostpref_stayconnected_summary"
 		/>
 
-	<ListPreference
+    <CheckBoxPreference
+    	android:key="quickdisconnect"
+    	android:title="@string/hostpref_quickdisconnect_title"
+    	android:summary="@string/hostpref_quickdisconnect_summary"
+    	/>
+
+    <ListPreference
 		android:key="delkey"
 		android:title="@string/hostpref_delkey_title"
 		android:summary="@string/hostpref_delkey_summary"

--- a/src/org/connectbot/bean/HostBean.java
+++ b/src/org/connectbot/bean/HostBean.java
@@ -50,6 +50,7 @@ public class HostBean extends AbstractBean {
 	private boolean compression = false;
 	private String encoding = HostDatabase.ENCODING_DEFAULT;
 	private boolean stayConnected = false;
+    private boolean quickDisconnect = true;
 
 	public HostBean() {
 
@@ -202,6 +203,14 @@ public class HostBean extends AbstractBean {
 		return stayConnected;
 	}
 
+    public void setQuickDisconnect(boolean quickDisconnect) {
+        	this.quickDisconnect = quickDisconnect;
+        }
+
+        public boolean getQuickDisconnect() {
+        	return quickDisconnect;
+        }
+
 	public String getDescription() {
 		String description = String.format("%s@%s", username, hostname);
 
@@ -234,6 +243,7 @@ public class HostBean extends AbstractBean {
 		values.put(HostDatabase.FIELD_HOST_COMPRESSION, Boolean.toString(compression));
 		values.put(HostDatabase.FIELD_HOST_ENCODING, encoding);
 		values.put(HostDatabase.FIELD_HOST_STAYCONNECTED, stayConnected);
+        values.put(HostDatabase.FIELD_HOST_QUICKDISCONNECT, quickDisconnect);
 
 		return values;
 	}

--- a/src/org/connectbot/service/TerminalBridge.java
+++ b/src/org/connectbot/service/TerminalBridge.java
@@ -429,7 +429,7 @@ public class TerminalBridge implements VDUDisplay {
 		disconnectThread.setName("Disconnect");
 		disconnectThread.start();
 
-		if (immediate) {
+        if (immediate || (host.getQuickDisconnect() && !host.getStayConnected())) {
 			awaitingClose = true;
 			if (disconnectListener != null)
 				disconnectListener.onDisconnected(TerminalBridge.this);

--- a/src/org/connectbot/util/HostDatabase.java
+++ b/src/org/connectbot/util/HostDatabase.java
@@ -47,7 +47,7 @@ public class HostDatabase extends RobustSQLiteOpenHelper {
 	public final static String TAG = "ConnectBot.HostDatabase";
 
 	public final static String DB_NAME = "hosts";
-	public final static int DB_VERSION = 22;
+	public final static int DB_VERSION = 23;
 
 	public final static String TABLE_HOSTS = "hosts";
 	public final static String FIELD_HOST_NICKNAME = "nickname";
@@ -69,6 +69,7 @@ public class HostDatabase extends RobustSQLiteOpenHelper {
 	public final static String FIELD_HOST_COMPRESSION = "compression";
 	public final static String FIELD_HOST_ENCODING = "encoding";
 	public final static String FIELD_HOST_STAYCONNECTED = "stayconnected";
+    public final static String FIELD_HOST_QUICKDISCONNECT = "quickdisconnect";
 
 	public final static String TABLE_PORTFORWARDS = "portforwards";
 	public final static String FIELD_PORTFORWARD_HOSTID = "hostid";
@@ -169,7 +170,8 @@ public class HostDatabase extends RobustSQLiteOpenHelper {
 				+ FIELD_HOST_WANTSESSION + " TEXT DEFAULT '" + Boolean.toString(true) + "', "
 				+ FIELD_HOST_COMPRESSION + " TEXT DEFAULT '" + Boolean.toString(false) + "', "
 				+ FIELD_HOST_ENCODING + " TEXT DEFAULT '" + ENCODING_DEFAULT + "', "
-				+ FIELD_HOST_STAYCONNECTED + " TEXT)");
+                + FIELD_HOST_STAYCONNECTED + " TEXT, "
+                + FIELD_HOST_QUICKDISCONNECT + " TEXT)");
 
 		db.execSQL("CREATE TABLE " + TABLE_PORTFORWARDS
 				+ " (_id INTEGER PRIMARY KEY, "
@@ -259,6 +261,9 @@ public class HostDatabase extends RobustSQLiteOpenHelper {
 			db.execSQL("DROP TABLE " + TABLE_COLOR_DEFAULTS);
 			db.execSQL(CREATE_TABLE_COLOR_DEFAULTS);
 			db.execSQL(CREATE_TABLE_COLOR_DEFAULTS_INDEX);
+        case 22:
+            db.execSQL("ALTER TABLE " + TABLE_HOSTS
+				+ " ADD COLUMN " + FIELD_HOST_QUICKDISCONNECT + " TEXT");
 		}
 	}
 
@@ -376,7 +381,10 @@ public class HostDatabase extends RobustSQLiteOpenHelper {
 			COL_FONTSIZE = c.getColumnIndexOrThrow(FIELD_HOST_FONTSIZE),
 			COL_COMPRESSION = c.getColumnIndexOrThrow(FIELD_HOST_COMPRESSION),
 			COL_ENCODING = c.getColumnIndexOrThrow(FIELD_HOST_ENCODING),
-			COL_STAYCONNECTED = c.getColumnIndexOrThrow(FIELD_HOST_STAYCONNECTED);
+            COL_STAYCONNECTED = c.getColumnIndexOrThrow(FIELD_HOST_STAYCONNECTED),
+            COL_QUICKDISCONNECT = c.getColumnIndexOrThrow(FIELD_HOST_QUICKDISCONNECT);
+
+
 
 
 		while (c.moveToNext()) {
@@ -400,6 +408,7 @@ public class HostDatabase extends RobustSQLiteOpenHelper {
 			host.setCompression(Boolean.valueOf(c.getString(COL_COMPRESSION)));
 			host.setEncoding(c.getString(COL_ENCODING));
 			host.setStayConnected(Boolean.valueOf(c.getString(COL_STAYCONNECTED)));
+            host.setQuickDisconnect(Boolean.valueOf(c.getString(COL_QUICKDISCONNECT)));
 
 			hosts.add(host);
 		}


### PR DESCRIPTION
Added a close-on-disconnect option.  This enables/facilitates automation (for example: you can invoke a connectbot shortcut from tasker and this will ensure that the screen isn't stuck on the disconnect prompt).

Close-on-disconnect will not take effect if stay-connected is checked.

![screenshot_2013-06-19-07-02-29](https://f.cloud.github.com/assets/746276/673056/3f85343a-d8a6-11e2-9a5f-70935c9f2154.png)

Slightly modified from [peffreyking's branch](https://code.google.com/r/peffreyking-connectbot/source/detail?r=6db98fe935581f27fd86a50748497a45ce53b9f3&name=quick-disconnect).