### PR TITLE
Add support for closing the connection automatically on disconnect

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -497,4 +497,6 @@
 	<!-- Describes the icon of the "show keyboard" button in the terminal view for accessibility
 	     purposes. -->
 	<string name="image_description_show_keyboard">Show keyboard.</string>
+    <string name="hostpref_closeondisconnect_title">Close on disconnect</string>
+    <string name="hostpref_closeondisconnect_summary">Automatically close the connection when the remote host disconnects</string>
 </resources>

--- a/res/xml/host_prefs.xml
+++ b/res/xml/host_prefs.xml
@@ -85,6 +85,12 @@
 		android:summary="@string/hostpref_stayconnected_summary"
 		/>
 
+    <CheckBoxPreference
+        android:key="closeondisconnect"
+        android:title="@string/hostpref_closeondisconnect_title"
+        android:summary="@string/hostpref_closeondisconnect_summary"
+        />
+
 	<ListPreference
 		android:key="delkey"
 		android:title="@string/hostpref_delkey_title"

--- a/src/org/connectbot/bean/HostBean.java
+++ b/src/org/connectbot/bean/HostBean.java
@@ -50,6 +50,7 @@ public class HostBean extends AbstractBean {
 	private boolean compression = false;
 	private String encoding = HostDatabase.ENCODING_DEFAULT;
 	private boolean stayConnected = false;
+	private boolean closeOnDisconnect = false;
 
 	public HostBean() {
 
@@ -202,6 +203,14 @@ public class HostBean extends AbstractBean {
 		return stayConnected;
 	}
 
+	public boolean getCloseOnDisconnect() {
+		return closeOnDisconnect;
+	}
+
+	public void setCloseOnDisconnect(boolean closeOnDisconnect) {
+		this.closeOnDisconnect = closeOnDisconnect;
+	}
+
 	public String getDescription() {
 		String description = String.format("%s@%s", username, hostname);
 
@@ -234,6 +243,7 @@ public class HostBean extends AbstractBean {
 		values.put(HostDatabase.FIELD_HOST_COMPRESSION, Boolean.toString(compression));
 		values.put(HostDatabase.FIELD_HOST_ENCODING, encoding);
 		values.put(HostDatabase.FIELD_HOST_STAYCONNECTED, stayConnected);
+		values.put(HostDatabase.FIELD_HOST_CLOSEONDISCONNECT, closeOnDisconnect);
 
 		return values;
 	}

--- a/src/org/connectbot/service/TerminalBridge.java
+++ b/src/org/connectbot/service/TerminalBridge.java
@@ -442,6 +442,16 @@ public class TerminalBridge implements VDUDisplay {
 				manager.requestReconnect(this);
 				return;
 			}
+			if (host.getCloseOnDisconnect()) {
+				awaitingClose = true;
+
+				// Tell the TerminalManager that we can be destroyed now.
+				if (disconnectListener != null) {
+					disconnectListener.onDisconnected(TerminalBridge.this);
+				}
+
+				return;
+			}
 			Thread disconnectPromptThread = new Thread(new Runnable() {
 				public void run() {
 					Boolean result = promptHelper.requestBooleanPrompt(null,

--- a/src/org/connectbot/util/HostDatabase.java
+++ b/src/org/connectbot/util/HostDatabase.java
@@ -47,7 +47,7 @@ public class HostDatabase extends RobustSQLiteOpenHelper {
 	public final static String TAG = "ConnectBot.HostDatabase";
 
 	public final static String DB_NAME = "hosts";
-	public final static int DB_VERSION = 22;
+	public final static int DB_VERSION = 23;
 
 	public final static String TABLE_HOSTS = "hosts";
 	public final static String FIELD_HOST_NICKNAME = "nickname";
@@ -69,6 +69,7 @@ public class HostDatabase extends RobustSQLiteOpenHelper {
 	public final static String FIELD_HOST_COMPRESSION = "compression";
 	public final static String FIELD_HOST_ENCODING = "encoding";
 	public final static String FIELD_HOST_STAYCONNECTED = "stayconnected";
+	public final static String FIELD_HOST_CLOSEONDISCONNECT = "closeondisconnect";
 
 	public final static String TABLE_PORTFORWARDS = "portforwards";
 	public final static String FIELD_PORTFORWARD_HOSTID = "hostid";
@@ -169,7 +170,8 @@ public class HostDatabase extends RobustSQLiteOpenHelper {
 				+ FIELD_HOST_WANTSESSION + " TEXT DEFAULT '" + Boolean.toString(true) + "', "
 				+ FIELD_HOST_COMPRESSION + " TEXT DEFAULT '" + Boolean.toString(false) + "', "
 				+ FIELD_HOST_ENCODING + " TEXT DEFAULT '" + ENCODING_DEFAULT + "', "
-				+ FIELD_HOST_STAYCONNECTED + " TEXT)");
+				+ FIELD_HOST_STAYCONNECTED + " TEXT,"
+				+ FIELD_HOST_CLOSEONDISCONNECT + " TEXT)");
 
 		db.execSQL("CREATE TABLE " + TABLE_PORTFORWARDS
 				+ " (_id INTEGER PRIMARY KEY, "
@@ -259,6 +261,9 @@ public class HostDatabase extends RobustSQLiteOpenHelper {
 			db.execSQL("DROP TABLE " + TABLE_COLOR_DEFAULTS);
 			db.execSQL(CREATE_TABLE_COLOR_DEFAULTS);
 			db.execSQL(CREATE_TABLE_COLOR_DEFAULTS_INDEX);
+		case 22:
+			db.execSQL("ALTER TABLE " + TABLE_HOSTS
+					+ " ADD COLUMN " + FIELD_HOST_CLOSEONDISCONNECT + " TEXT");
 		}
 	}
 
@@ -376,7 +381,8 @@ public class HostDatabase extends RobustSQLiteOpenHelper {
 			COL_FONTSIZE = c.getColumnIndexOrThrow(FIELD_HOST_FONTSIZE),
 			COL_COMPRESSION = c.getColumnIndexOrThrow(FIELD_HOST_COMPRESSION),
 			COL_ENCODING = c.getColumnIndexOrThrow(FIELD_HOST_ENCODING),
-			COL_STAYCONNECTED = c.getColumnIndexOrThrow(FIELD_HOST_STAYCONNECTED);
+			COL_STAYCONNECTED = c.getColumnIndexOrThrow(FIELD_HOST_STAYCONNECTED),
+			COL_CLOSEONDISCONNECT = c.getColumnIndexOrThrow(FIELD_HOST_CLOSEONDISCONNECT);
 
 
 		while (c.moveToNext()) {
@@ -400,6 +406,7 @@ public class HostDatabase extends RobustSQLiteOpenHelper {
 			host.setCompression(Boolean.valueOf(c.getString(COL_COMPRESSION)));
 			host.setEncoding(c.getString(COL_ENCODING));
 			host.setStayConnected(Boolean.valueOf(c.getString(COL_STAYCONNECTED)));
+			host.setCloseOnDisconnect(Boolean.valueOf(c.getString(COL_CLOSEONDISCONNECT)));
 
 			hosts.add(host);
 		}


### PR DESCRIPTION
This setting is specifically useful for me (see below) and I understand if you don't want to merge it back but I figured I would send the PR incase you did (since it is just an extra setting). Also, I don't have translations for any of the other languages (nor a good way to acquire them). 

**Full story:** I use connectbot to connect to a beagleboard that opens my garage and front door. I have separate users on the beagleboard that run appropriate commands (i.e. open garage) and then exit (dropping the connection). I keep widgets on my homescreen for these tasks/users and it's annoying that I have to click "Yes" to close the connect after clicking one of the widgets. This setting solves that.