### PR TITLE
Change text and some translations of hostpref_nickname_title to "name".

### DIFF
--- a/res/values-da/strings.xml
+++ b/res/values-da/strings.xml
@@ -107,7 +107,7 @@
   <string name="list_update_daily">Dagligt</string>
   <string name="list_update_weekly">Ugenligt</string>
   <string name="list_update_never">Aldrig</string>
-  <string name="hostpref_nickname_title">Kaldenavn</string>
+  <string name="hostpref_nickname_title">Navn</string>
   <string name="hostpref_color_title">Farvekategori</string>
   <string name="hostpref_fontsize_title">Skriftstørrelse (pt)</string>
   <string name="hostpref_pubkeyid_title">Brug offentlig nøgleautorisering</string>

--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -107,7 +107,7 @@
   <string name="list_update_daily">Täglich</string>
   <string name="list_update_weekly">Wöchentlich</string>
   <string name="list_update_never">Niemals</string>
-  <string name="hostpref_nickname_title">Nutzername</string>
+  <string name="hostpref_nickname_title">Name</string>
   <string name="hostpref_color_title">Farbkategorie</string>
   <string name="hostpref_fontsize_title">Fontgröße (pt)</string>
   <string name="hostpref_pubkeyid_title">Verwende pubkey Authentisierung</string>

--- a/res/values-es/strings.xml
+++ b/res/values-es/strings.xml
@@ -107,7 +107,7 @@
   <string name="list_update_daily">Diariamente</string>
   <string name="list_update_weekly">Semanalmente</string>
   <string name="list_update_never">Nunca</string>
-  <string name="hostpref_nickname_title">Apodo</string>
+  <string name="hostpref_nickname_title">Nombre</string>
   <string name="hostpref_color_title">Categoria de colores</string>
   <string name="hostpref_fontsize_title">Tamaño de la fuente (pt)</string>
   <string name="hostpref_pubkeyid_title">Usar clave de autenticación pública</string>

--- a/res/values-fr/strings.xml
+++ b/res/values-fr/strings.xml
@@ -107,7 +107,7 @@
   <string name="list_update_daily">Journalière</string>
   <string name="list_update_weekly">Hebdomadaire</string>
   <string name="list_update_never">Jamais</string>
-  <string name="hostpref_nickname_title">Surnom</string>
+  <string name="hostpref_nickname_title">Nom</string>
   <string name="hostpref_color_title">Catégorie de couleur</string>
   <string name="hostpref_fontsize_title">Taille de police (pt)</string>
   <string name="hostpref_pubkeyid_title">Utiliser l\'authentification par clé publique</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -250,7 +250,7 @@
 	<string name="list_update_never">"Never"</string>
 
 	<!-- Host nickname field preference title -->
-	<string name="hostpref_nickname_title">"Nickname"</string>
+	<string name="hostpref_nickname_title">"Name"</string>
 
 	<!-- Host color category preference title -->
 	<string name="hostpref_color_title">"Color category"</string>


### PR DESCRIPTION
I changed them to (the translation of) just "name" (not "nickname"), as this is what Android uses in VPN settings.

For German and Frensh the translations have been completly wrong (not translating "nickname") and missleading.
