### PR TITLE
Allow commands being send via intents

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -96,6 +96,9 @@
 	<!-- Prompt for the password to unlock a certain pubkey. -->
 	<string name="prompt_pubkey_password">"Password for key '%1$s'"</string>
 
+	<!-- Prompt for the password to unlock a certain pubkey. -->
+	<string name="prompt_allow_command">"Execute command?"\n"%1$s"</string>
+
 	<!-- Prompt for whether to allow SSH Authentication Agent to use the specified key. Note that the '\n' means split the line so it's actually "host to use key" -->
 	<string name="prompt_allow_agent_to_use_key">"Allow remote host to"\n"use key '%1$s'?"</string>
 
@@ -192,6 +195,11 @@
 	<string name="pref_conn_persist_title">"Persist connections"</string>
 	<!-- Summary for the preference that forces the service to stay running in the background. -->
 	<string name="pref_conn_persist_summary">"Force connections to stay connected while in background"</string>
+
+	<!-- Name for the preference that allows receiving commands.-->
+	<string name="pref_intent_extra_command_title">"Always allow commands from intents"</string>
+	<!-- Summary for the preference that allows receiving commands. -->
+	<string name="pref_intent_extra_command_summary">"Don't ask anymore when receiving commands as extra data string in intents."</string>
 
 	<!-- Name for the keyboard shortcuts preference -->
 	<string name="pref_keymode_title">"Directory shortcuts"</string>

--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -43,6 +43,13 @@
 		android:defaultValue="true"
 		/>
 
+	<CheckBoxPreference
+		android:key="allowIntentExtraCmd"
+		android:title="@string/pref_intent_extra_command_title"
+		android:summary="@string/pref_intent_extra_command_summary"
+		android:defaultValue="false"
+		/>
+
 	<PreferenceCategory
 		android:title="@string/pref_emulation_category">
 

--- a/src/org/connectbot/ConsoleActivity.java
+++ b/src/org/connectbot/ConsoleActivity.java
@@ -160,7 +160,7 @@ public class ConsoleActivity extends Activity {
 			TerminalBridge requestedBridge = bound.getConnectedBridge(requestedNickname);
 
 			// If we didn't find the requested connection, try opening it
-			if (requestedNickname != null && requestedBridge == null) {
+			if (requestedBridge == null) {
 				try {
 					Log.d(TAG, String.format("We couldnt find an existing bridge with URI=%s (nickname=%s), so creating one now", requested.toString(), requestedNickname));
 					requestedBridge = bound.openConnection(requested);

--- a/src/org/connectbot/util/PreferenceConstants.java
+++ b/src/org/connectbot/util/PreferenceConstants.java
@@ -81,6 +81,7 @@ public class PreferenceConstants {
 	public static final float DEFAULT_BELL_VOLUME = 0.25f;
 
 	public static final String CONNECTION_PERSIST = "connPersist";
+	public static final String INTENT_EXTRA_COMMAND = "allowIntentExtraCmd";
 
 	public static final String SHIFT_FKEYS = "shiftfkeys";
 	public static final String CTRL_FKEYS = "ctrlfkeys";


### PR DESCRIPTION
Since Intents can already open a (possibly new) connection, I added support for adding a little extra. With this PR it's possible to execute a command within a connection (newly created or already opened, doesn't matter).
The user gets prompted if the command should be executed as a security feature. And of course the prompt can be disabled via preferences.

While testing the new feature i found a small bug (NullPointerException), when opening a connection with no nickname provided.

This would solve #57.
