### PR TITLE
Fix possible NPE in HostListActivity.onCreateContextMenu

### DIFF
--- a/src/org/connectbot/HostListActivity.java
+++ b/src/org/connectbot/HostListActivity.java
@@ -333,7 +333,9 @@ public class HostListActivity extends ListActivity {
 
 		// edit, disconnect, delete
 		MenuItem connect = menu.add(R.string.list_host_disconnect);
-		final TerminalBridge bridge = bound.getConnectedBridge(host);
+		TerminalBridge bridge = null;
+                if (bound != null)
+                        bridge = bound.getConnectedBridge(host);
 		connect.setEnabled((bridge != null));
 		connect.setOnMenuItemClickListener(new OnMenuItemClickListener() {
 			public boolean onMenuItemClick(MenuItem item) {


### PR DESCRIPTION
The HostListActivity lifecycle and the ServiceConnection lifecycle are independent. In the case that the `onCreateContextMenu` callback fires before the `onServiceConnected` callback, the `bound` field will be null in `onCreateContextMenu` and can throw an exception. This pull request fixes the issue by checking for `bound` for null before dereferencing it.