### PR TITLE
Add portforward to a connection with an intent, and possibility to save it to database

### DIFF
--- a/res/values/notrans.xml
+++ b/res/values/notrans.xml
@@ -22,4 +22,6 @@
 
 	<string name="copyright_info" translatable="false">Before we get started, we need to get some legal information out of the way.  ConnectBot is provided under the Apache License, Version 2.0 (the &#x201C;License&#x201D;).  Here are a few key points:\n\nYou may not use this program except in compliance with the License. You may obtain a copy of the License at\n\nhttp://www.apache.org/licenses/LICENSE-2.0\n\nUnless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &#x201C;AS IS&#x201D; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.</string>
 
+	<string name="EXTRA_PORTFORWARD" translatable="false">org.connectbot.extra.PORTFORWARD</string>
+
 </resources>

--- a/res/values/notrans.xml
+++ b/res/values/notrans.xml
@@ -23,5 +23,6 @@
 	<string name="copyright_info" translatable="false">Before we get started, we need to get some legal information out of the way.  ConnectBot is provided under the Apache License, Version 2.0 (the &#x201C;License&#x201D;).  Here are a few key points:\n\nYou may not use this program except in compliance with the License. You may obtain a copy of the License at\n\nhttp://www.apache.org/licenses/LICENSE-2.0\n\nUnless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &#x201C;AS IS&#x201D; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.</string>
 
 	<string name="EXTRA_PORTFORWARD" translatable="false">org.connectbot.extra.PORTFORWARD</string>
+	<string name="EXTRA_SAVEHOST" translatable="false">org.connectbot.extra.SAVEHOST</string>
 
 </resources>

--- a/src/org/connectbot/ConsoleActivity.java
+++ b/src/org/connectbot/ConsoleActivity.java
@@ -20,6 +20,7 @@ package org.connectbot;
 import java.lang.ref.WeakReference;
 import java.util.List;
 
+import org.connectbot.bean.PortForwardBean;
 import org.connectbot.bean.SelectionArea;
 import org.connectbot.service.PromptHelper;
 import org.connectbot.service.TerminalBridge;
@@ -170,9 +171,7 @@ public class ConsoleActivity extends Activity {
 
 			// create views for all bridges on this service
 			for (TerminalBridge bridge : bound.bridges) {
-
 				final int currentIndex = addNewTerminalView(bridge);
-
 				// check to see if this bridge was requested
 				if (bridge == requestedBridge)
 					requestedIndex = currentIndex;
@@ -750,6 +749,7 @@ public class ConsoleActivity extends Activity {
 
 				Intent intent = new Intent(ConsoleActivity.this, PortForwardListActivity.class);
 				intent.putExtra(Intent.EXTRA_TITLE, bridge.host.getId());
+				intent.putExtra(Intent.EXTRA_TEXT, bridge.host.getNickname());
 				ConsoleActivity.this.startActivityForResult(intent, REQUEST_EDIT);
 				return true;
 			}

--- a/src/org/connectbot/ConsoleActivity.java
+++ b/src/org/connectbot/ConsoleActivity.java
@@ -169,6 +169,27 @@ public class ConsoleActivity extends Activity {
 				}
 			}
 
+			if(requestedBridge != null) {
+
+				// handling portforward add from intent
+				String[] portForwardData = getIntent().getStringArrayExtra(getString(R.string.EXTRA_PORTFORWARD));
+				if (requestedBridge.canFowardPorts() && portForwardData != null && portForwardData.length == 4) {
+					try {
+						PortForwardBean portFwd = new PortForwardBean(requestedBridge.host.getId(), portForwardData);
+
+						// look for the portforward in the bridge first to avoid duplicate source ports
+						if(!requestedBridge.findPortForwardConflict(portFwd)) {
+							requestedBridge.addPortForward(portFwd);
+							requestedBridge.enablePortForward(portFwd);
+						}
+
+					} catch (NumberFormatException e) {
+						Log.e(TAG, "Wrong intent format");
+					}
+				}
+			}
+
+
 			// create views for all bridges on this service
 			for (TerminalBridge bridge : bound.bridges) {
 				final int currentIndex = addNewTerminalView(bridge);

--- a/src/org/connectbot/HostListActivity.java
+++ b/src/org/connectbot/HostListActivity.java
@@ -370,6 +370,7 @@ public class HostListActivity extends ListActivity {
 			public boolean onMenuItemClick(MenuItem item) {
 				Intent intent = new Intent(HostListActivity.this, PortForwardListActivity.class);
 				intent.putExtra(Intent.EXTRA_TITLE, host.getId());
+				intent.putExtra(Intent.EXTRA_TEXT, host.getNickname());
 				HostListActivity.this.startActivityForResult(intent, REQUEST_EDIT);
 				return true;
 			}

--- a/src/org/connectbot/PortForwardListActivity.java
+++ b/src/org/connectbot/PortForwardListActivity.java
@@ -105,6 +105,7 @@ public class PortForwardListActivity extends ListActivity {
 		super.onCreate(icicle);
 
 		long hostId = this.getIntent().getLongExtra(Intent.EXTRA_TITLE, -1);
+		final String hostName = this.getIntent().getStringExtra(Intent.EXTRA_TEXT);
 
 		setContentView(R.layout.act_portforwardlist);
 
@@ -132,7 +133,7 @@ public class PortForwardListActivity extends ListActivity {
 			public void onServiceConnected(ComponentName className, IBinder service) {
 				TerminalManager bound = ((TerminalManager.TerminalBinder) service).getService();
 
-				hostBridge = bound.getConnectedBridge(host);
+				hostBridge = (host == null ? bound.getConnectedBridge(hostName) : bound.getConnectedBridge(host));
 				updateHandler.sendEmptyMessage(-1);
 			}
 

--- a/src/org/connectbot/bean/PortForwardBean.java
+++ b/src/org/connectbot/bean/PortForwardBean.java
@@ -74,6 +74,18 @@ public class PortForwardBean extends AbstractBean {
 		setDest(dest);
 	}
 
+	/**
+	 * @param data String array containing the different parameters nickname / type / sourceport / destination
+	 */
+	public PortForwardBean(long hostId, String[] data) throws NumberFormatException {
+		this.hostId = hostId;
+		this.nickname = data[0];
+		this.type = data[1];
+		this.sourcePort = Integer.parseInt(data[2]);
+
+		setDest(data[3]);
+	}
+
 	public String getBeanName() {
 		return BEAN_NAME;
 	}

--- a/src/org/connectbot/bean/PortForwardBean.java
+++ b/src/org/connectbot/bean/PortForwardBean.java
@@ -173,6 +173,13 @@ public class PortForwardBean extends AbstractBean {
 	}
 
 	/**
+	 * @return the hostId
+	 */
+	public long getHostId() {
+		return hostId;
+	}
+
+	/**
 	 * @param enabled the enabled to set
 	 */
 	public void setEnabled(boolean enabled) {

--- a/src/org/connectbot/service/TerminalBridge.java
+++ b/src/org/connectbot/service/TerminalBridge.java
@@ -881,6 +881,14 @@ public class TerminalBridge implements VDUDisplay {
 		return transport.getPortForwards();
 	}
 
+	public boolean findPortForwardConflict(PortForwardBean pfbeanToFind) {
+		for(PortForwardBean pfbean : transport.getPortForwards()) {
+			if(pfbeanToFind.getSourcePort() == pfbean.getSourcePort()
+					&& pfbeanToFind.getType().equals(pfbean.getType())) return true;
+		}
+		return false;
+	}
+
 	/**
 	 * Enables a port forward member. After calling this method, the port forward should
 	 * be operational.

--- a/src/org/connectbot/transport/TransportFactory.java
+++ b/src/org/connectbot/transport/TransportFactory.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.connectbot.bean.HostBean;
+import org.connectbot.bean.PortForwardBean;
 import org.connectbot.util.HostDatabase;
 
 import android.content.Context;
@@ -128,5 +129,20 @@ public class TransportFactory {
 		}
 
 		return hostdb.findHost(selection);
+	}
+
+	/**
+	 * @param hostdb Handle to HostDatabase
+	 * @param portForward PortForwardBean to find
+	 * @return true when port forward was found
+	 */
+	public static boolean findPortForwardConflict(HostDatabase hostdb, PortForwardBean portForward) {
+
+		Map<String, String> selection = new HashMap<String, String>();
+		selection.put(HostDatabase.FIELD_PORTFORWARD_HOSTID, String.valueOf(portForward.getHostId()));
+		selection.put(HostDatabase.FIELD_PORTFORWARD_TYPE, portForward.getType());
+		selection.put(HostDatabase.FIELD_PORTFORWARD_SOURCEPORT, String.valueOf(portForward.getSourcePort()));
+
+		return hostdb.findPortForward(selection);
 	}
 }

--- a/src/org/connectbot/util/HostDatabase.java
+++ b/src/org/connectbot/util/HostDatabase.java
@@ -628,6 +628,54 @@ public class HostDatabase extends RobustSQLiteOpenHelper {
 	}
 
 	/**
+	 * @param selection parameters describing the desired portforward to look for
+	 * @return true if such a portforward was found
+	 */
+	public boolean findPortForward(Map<String, String> selection) {
+		StringBuilder selectionBuilder = new StringBuilder();
+
+		Iterator<Entry<String, String>> i = selection.entrySet().iterator();
+
+		List<String> selectionValuesList = new LinkedList<String>();
+		int n = 0;
+		while (i.hasNext()) {
+			Entry<String, String> entry = i.next();
+
+			if (entry.getValue() == null)
+				continue;
+
+			if (n++ > 0)
+				selectionBuilder.append(" AND ");
+
+			selectionBuilder.append(entry.getKey())
+				.append(" = ?");
+
+			selectionValuesList.add(entry.getValue());
+		}
+
+		String selectionValues[] = new String[selectionValuesList.size()];
+		selectionValuesList.toArray(selectionValues);
+		selectionValuesList = null;
+
+		boolean res;
+
+		synchronized (dbLock) {
+			SQLiteDatabase db = getReadableDatabase();
+
+			Cursor c = db.query(TABLE_PORTFORWARDS,
+					new String[] { "_id" },
+					selectionBuilder.toString(),
+					selectionValues,
+					null, null, null);
+
+			res = c.getCount() > 0;
+			c.close();
+		}
+
+		return res;
+	}
+
+	/**
 	 * Update the parameters of a port forward in the database.
 	 * @param pfb {@link PortForwardBean} to save
 	 * @return true on success

--- a/src/org/connectbot/util/HostDatabase.java
+++ b/src/org/connectbot/util/HostDatabase.java
@@ -633,6 +633,12 @@ public class HostDatabase extends RobustSQLiteOpenHelper {
 	 * @return true on success
 	 */
 	public boolean savePortForward(PortForwardBean pfb) {
+
+		if(pfb.getHostId() == -1) {
+			Log.d(TAG, "Not saving an anonymous port forward");
+			return false;
+		}
+
 		boolean success = false;
 
 		synchronized (dbLock) {


### PR DESCRIPTION
First commit is a fix for issue #71. The port forward adding activity can now refer to a host with its nickname instead of its id when it's -1 (which happens when a connection is opened from an external intent).

Second commit adds the ability to open port forwarding with an intent. Conflicts are checked with the port forwards available in the TerminalBridge.

The last commit adds an option for a connection opened with an external intent (and the eventual port forwarding) to be saved to the database. Conflicts in port forwarding are looked for in the database this time.

Feel free to cherry pick if interested in just one or two of these commits.