### PR TITLE
Switch the quick connect entry in the hostlist to a LinearLayout.

### DIFF
--- a/res/layout/act_hostlist.xml
+++ b/res/layout/act_hostlist.xml
@@ -25,8 +25,9 @@
 	android:layout_height="fill_parent"
 	>
 
-	<RelativeLayout
+	<LinearLayout
 		android:id="@+id/quickconnect"
+                android:orientation="horizontal"
 		android:layout_width="fill_parent"
 		android:layout_height="wrap_content"
 		android:layout_alignParentBottom="true"
@@ -37,7 +38,6 @@
 			android:id="@+id/transport_selection"
 			android:layout_height="wrap_content"
 			android:layout_width="wrap_content"
-			android:layout_alignParentLeft="true"
 			/>
 
 		<EditText
@@ -45,14 +45,12 @@
 			android:layout_width="fill_parent"
 			android:layout_height="wrap_content"
 			android:hint="username@hostname:port"
-			android:layout_toRightOf="@+id/transport_selection"
-			android:layout_alignBaseline="@+id/transport_selection"
 			android:inputType="textEmailAddress"
 			android:maxLines="1"
 			android:ellipsize="end"
 			android:focusableInTouchMode="true"
 			android:singleLine="true"/>
-	</RelativeLayout>
+	</LinearLayout>
 
 
 	<ListView


### PR DESCRIPTION
This fixes a bug in landscape where the input is not visible at all.
See
http://stackoverflow.com/questions/23982098/android-relativelayout-layout-above-appears-to-behave-incorrectly-with-layout-a.