### PR TITLE
Use unicode symbols for arrow buttons

### DIFF
--- a/app/src/main/res/values/notrans.xml
+++ b/app/src/main/res/values/notrans.xml
@@ -22,4 +22,12 @@
 
 	<string name="copyright_info" translatable="false">Before we get started, we need to get some legal information out of the way.  ConnectBot is provided under the Apache License, Version 2.0 (the &#x201C;License&#x201D;).  Here are a few key points:\n\nYou may not use this program except in compliance with the License. You may obtain a copy of the License at\n\nhttp://www.apache.org/licenses/LICENSE-2.0\n\nUnless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &#x201C;AS IS&#x201D; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.</string>
 
+	<!-- "Up" button in virtual keyboard. -->
+	<string name="button_key_up">\u25B2</string>
+	<!-- "Down" button in virtual keyboard. -->
+	<string name="button_key_down">\u25BC</string>
+	<!-- "Left" button in virtual keyboard. -->
+	<string name="button_key_left">\u25C0</string>
+	<!-- "Right" button in virtual keyboard. -->
+	<string name="button_key_right">\u25B6</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -521,10 +521,10 @@
 	<!-- Describes the icon of the "send escape character" button in the terminal view for
 	     accessibility purposes. -->
 	<string name="image_description_send_escape_character">Send escape character.</string>
-  
-  <!-- Describes the icon of the "send tab character" button in the terminal view for
-       accessibility purposes. -->
-  <string name="image_description_send_tab_character">Send TAB character.</string>
+
+	<!-- Describes the icon of the "send tab character" button in the terminal view for
+	     accessibility purposes. -->
+	<string name="image_description_send_tab_character">Send TAB character.</string>
 
 	<!-- Describes the icon of the "show keyboard" button in the terminal view for accessibility
 	     purposes. -->
@@ -552,12 +552,4 @@
 	<string name="button_key_ctrl">Ctrl</string>
 	<!-- Text for the "Tab" button in virtual keyboard. -->
 	<string name="button_key_tab">Tab</string>
-	<!-- Text for the "up" button in virtual keyboard. -->
-	<string name="button_key_up">Up</string>
-	<!-- Text for the "down" button in virtual keyboard. -->
-	<string name="button_key_down">Down</string>
-	<!-- Text for the "left" button in virtual keyboard. -->
-	<string name="button_key_left">Left</string>
-	<!-- Text for the "right" button in virtual keyboard. -->
-	<string name="button_key_right">Right</string>
 </resources>


### PR DESCRIPTION
This relieves some need for translations to many languages.