### PR TITLE
Try to show new lint issues in check-lint-count.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,6 @@ android:
 
 script:
   - ./gradlew build check jacocoUnitTestDebugReport
-  - ./scripts/check-lint-count.sh app/build/outputs/lint-results.xml $HOME/.cache/lint/issue-count.txt $HOME/.cache/lint/issue-count.txt
+  - ./scripts/check-lint-count.sh app/build/outputs/lint-results.xml $HOME/.cache/lint/lint-results.xml
 
 after_success: ./gradlew coveralls

--- a/scripts/check-lint-count.sh
+++ b/scripts/check-lint-count.sh
@@ -4,10 +4,6 @@
 # Travis CI builds to fail when the number increases by exploiting the
 # caching mechanism.
 
-# This is to prime the system: when I submitted this change, this is the
-# number of lint warnings that existed.
-DEFAULT_NUMBER=207
-
 if [[ $# != 2 || ! -f $1 ]]; then \
     echo "Usage: $0 <lint.xml file> <historical.xml file>"
     exit 1
@@ -15,7 +11,6 @@ fi
 
 lint_file="$1"
 historical_file="$2"
-success_file="$3"
 
 xmllint="$(which xmllint)"
 

--- a/scripts/check-lint-count.sh
+++ b/scripts/check-lint-count.sh
@@ -28,30 +28,30 @@ fi
 tmp_dir="$(mktemp -d lint.XXXXXXXX)"
 trap "rm -rf $tmp_dir" 1 2 3 6 9 14 15
 
-lint_file="$tmp_dir/lint.txt"
-hist_file="$tmp_dir/hist.txt"
+lint_results="$tmp_dir/lint.txt"
+hist_results="$tmp_dir/hist.txt"
 
 echo "cat //issue/location" | \
     xmllint --shell $historical_file | \
-    grep '<location' >$lint_file
+    grep '<location' >$lint_results
     
 echo "cat //issue/location" | \
     xmllint --shell $lint_file | \
-    grep '<location' >$hist_file
+    grep '<location' >$hist_results
 
-old_count=$(cat $lint_file | wc -l)
-new_count=$(cat $hist_file | wc -l)
+old_count=$(cat $lint_results | wc -l)
+new_count=$(cat $hist_results | wc -l)
 
 echo "Historical count : $old_count, new count : $new_count"
 
 if [[ $new_count > $old_count ]]; then \
     echo "FAILURE: lint issues increased from $old_count to $new_count"
-    diff $lint_file $hist_file
+    diff $lint_results $hist_results
     exit 2
 fi
 
 if [[ $TRAVIS_PULL_REQUEST == false ]]; then \
     # Okay, we either stayed the same or reduced our number.
     # Write it out so we can check it next build!
-    mv $lint_file $historical_file 
+    cp $lint_file $historical_file 
 fi

--- a/scripts/check-lint-count.sh
+++ b/scripts/check-lint-count.sh
@@ -26,7 +26,7 @@ if [[ ! -f $historical_file ]]; then \
 fi
 
 tmp_dir="$(mktemp -d lint.XXXXXXXX)"
-trap "rm -rf $tmp_dir" 1 2 3 6 9 14 15
+trap "rm -rf $tmp_dir" ERR EXIT
 
 lint_results="$tmp_dir/lint.txt"
 hist_results="$tmp_dir/hist.txt"

--- a/scripts/check-lint-count.sh
+++ b/scripts/check-lint-count.sh
@@ -26,7 +26,7 @@ if [[ ! -f $historical_file ]]; then \
 fi
 
 tmp_dir="$(mktemp -d lint.XXXXXXXX)"
-trap "rm -rf $tmp_dir" EXIT ERROR
+trap "rm -rf $tmp_dir" 1 2 3 6 9 14 15
 
 lint_file="$tmp_dir/lint.txt"
 hist_file="$tmp_dir/hist.txt"


### PR DESCRIPTION
I'm always lost with new lint issues... so the idea here is to store the last good lint results and to compare it with the new one, and show the diff if count is higher.
