### PR TITLE
Activity title not sync correctly with ViewPager

### DIFF
--- a/app/src/main/java/org/connectbot/ConsoleActivity.java
+++ b/app/src/main/java/org/connectbot/ConsoleActivity.java
@@ -47,7 +47,6 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.IBinder;
 import android.os.Message;
-import android.os.Trace;
 import android.preference.PreferenceManager;
 import android.support.annotation.Nullable;
 import android.support.v4.app.ActivityCompat;

--- a/app/src/main/java/org/connectbot/ConsoleActivity.java
+++ b/app/src/main/java/org/connectbot/ConsoleActivity.java
@@ -47,6 +47,7 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.IBinder;
 import android.os.Message;
+import android.os.Trace;
 import android.preference.PreferenceManager;
 import android.support.annotation.Nullable;
 import android.support.v4.app.ActivityCompat;
@@ -500,6 +501,7 @@ public class ConsoleActivity extends AppCompatActivity implements BridgeDisconne
 				new ViewPager.SimpleOnPageChangeListener() {
 					@Override
 					public void onPageSelected(int position) {
+						setTitle(adapter.getPageTitle(position));
 						onTerminalChanged();
 					}
 				});
@@ -1250,7 +1252,6 @@ public class ConsoleActivity extends AppCompatActivity implements BridgeDisconne
 			return;
 		}
 		bound.defaultBridge = view.bridge;
-		setTitle(view.bridge.host.getNickname());
 	}
 
 	protected void updateEmptyVisible() {
@@ -1368,6 +1369,8 @@ public class ConsoleActivity extends AppCompatActivity implements BridgeDisconne
 	 */
 	private void setDisplayedTerminal(int requestedIndex) {
 		pager.setCurrentItem(requestedIndex);
+		// set activity title
+		setTitle(adapter.getPageTitle(requestedIndex));
 		onTerminalChanged();
 	}
 


### PR DESCRIPTION
It seems in ConsoleActivity.onTerminalChanged() is sometime called before the view has actually changed so adapter.getCurrentTerminalView() does not always return the actual TerminalView but sometimes returns the one selected just before, so setTitle() was setting the wrong title. Also it returns null in some cases so the title was not set at all.