### PR TITLE
Allow temporary cloned connections

### DIFF
--- a/app/src/main/java/org/connectbot/ConsoleActivity.java
+++ b/app/src/main/java/org/connectbot/ConsoleActivity.java
@@ -182,7 +182,7 @@ public class ConsoleActivity extends AppCompatActivity implements BridgeDisconne
 				}
 			}
 
-			if(requestedBridge != null) {
+			if (requestedBridge != null) {
 				Intent intent = getIntent();
 				if (intent != null) {
 					requestedBridge.setTemp(intent.getBooleanExtra(IS_TEMPORARY, false));

--- a/app/src/main/java/org/connectbot/ConsoleActivity.java
+++ b/app/src/main/java/org/connectbot/ConsoleActivity.java
@@ -105,6 +105,7 @@ public class ConsoleActivity extends AppCompatActivity implements BridgeDisconne
 	private static final int KEYBOARD_REPEAT_INITIAL = 500;
 	private static final int KEYBOARD_REPEAT = 100;
 	private static final String STATE_SELECTED_URI = "selectedUri";
+	public static final String IS_TEMPORARY = "temporary";
 
 	protected ViewPager pager = null;
 	protected TabLayout tabs = null;
@@ -178,6 +179,13 @@ public class ConsoleActivity extends AppCompatActivity implements BridgeDisconne
 					requestedBridge = bound.openConnection(requested);
 				} catch (Exception e) {
 					Log.e(TAG, "Problem while trying to create new requested bridge from URI", e);
+				}
+			}
+
+			if(requestedBridge != null) {
+				Intent intent = getIntent();
+				if (intent != null) {
+					requestedBridge.setTemp(intent.getBooleanExtra(IS_TEMPORARY, false));
 				}
 			}
 
@@ -1190,6 +1198,10 @@ public class ConsoleActivity extends AppCompatActivity implements BridgeDisconne
 					Log.e(TAG, "Problem while trying to create new requested bridge from URI", e);
 					// TODO: We should display an error dialog here.
 					return;
+				}
+
+				if (requestedBridge != null && intent != null) {
+					requestedBridge.setTemp(intent.getBooleanExtra(IS_TEMPORARY, false));
 				}
 
 				adapter.notifyDataSetChanged();

--- a/app/src/main/java/org/connectbot/HostListActivity.java
+++ b/app/src/main/java/org/connectbot/HostListActivity.java
@@ -580,7 +580,7 @@ public class HostListActivity extends ListActivity implements OnHostStatusChange
 			if (this.manager == null)
 				return false;
 			TerminalBridge bridge = manager.getConnectedBridge(host);
-			if(bridge != null)
+			if (bridge != null)
 				return bridge.isTemp();
 			return false;
 		}

--- a/app/src/main/java/org/connectbot/HostListActivity.java
+++ b/app/src/main/java/org/connectbot/HostListActivity.java
@@ -17,6 +17,7 @@
 
 package org.connectbot;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.connectbot.bean.HostBean;
@@ -368,6 +369,21 @@ public class HostListActivity extends ListActivity implements OnHostStatusChange
 			}
 		});
 
+		MenuItem cloneHost = menu.add(R.string.connection_clone);
+		cloneHost.setVisible(bridge != null && !host.getNickname().matches(".* #[0-9]+$"));
+		cloneHost.setOnMenuItemClickListener(new OnMenuItemClickListener() {
+			public boolean onMenuItemClick(MenuItem item) {
+				HostBean clone = host.clone();
+				clone.setNickname(getTempNickname(host.getNickname()));
+				Uri uri = clone.getUri();
+				Intent contents = new Intent(Intent.ACTION_VIEW, uri);
+				contents.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+				contents.setClass(HostListActivity.this, ConsoleActivity.class);
+				HostListActivity.this.startActivity(contents);
+				return true;
+			}
+		});
+
 		MenuItem edit = menu.add(R.string.list_host_edit);
 		edit.setOnMenuItemClickListener(new OnMenuItemClickListener() {
 			public boolean onMenuItemClick(MenuItem item) {
@@ -412,6 +428,21 @@ public class HostListActivity extends ListActivity implements OnHostStatusChange
 			}
 		});
 	}
+
+	private String getTempNickname(String nickName) {
+		List<String> nameList = new ArrayList<>();
+		for (TerminalBridge bridge : bound.getBridges()) {
+			String name = bridge.host.getNickname();
+			if(name.matches(".* #[0-9]+$"))
+				nameList.add(name);
+		}
+		int index = 1;
+		while (nameList.contains(nickName + " #" + index))
+			index++;
+
+		return (nickName + " #" + index);
+	}
+
 	/**
 	 * Disconnects all active connections and closes the activity if appropriate.
 	 */

--- a/app/src/main/java/org/connectbot/HostListActivity.java
+++ b/app/src/main/java/org/connectbot/HostListActivity.java
@@ -433,7 +433,7 @@ public class HostListActivity extends ListActivity implements OnHostStatusChange
 		List<String> nameList = new ArrayList<>();
 		for (TerminalBridge bridge : bound.getBridges()) {
 			String name = bridge.host.getNickname();
-			if(name.matches(".* #[0-9]+$"))
+			if (name.matches(".* #[0-9]+$"))
 				nameList.add(name);
 		}
 		int index = 1;

--- a/app/src/main/java/org/connectbot/bean/HostBean.java
+++ b/app/src/main/java/org/connectbot/bean/HostBean.java
@@ -305,48 +305,33 @@ public class HostBean extends AbstractBean {
 	}
 
 	/**
-	 * @return URI identifying this HostBean
+	 * @return String identifying this HostBean
 	 */
-	public Uri getUri() {
+	public String getUriString() {
 		StringBuilder sb = new StringBuilder();
 		sb.append(protocol)
-			.append("://");
+				.append("://");
 
 		if (username != null)
 			sb.append(Uri.encode(username))
-				.append('@');
+					.append('@');
 
 		sb.append(Uri.encode(hostname))
-			.append(':')
-			.append(port)
-			.append("/#")
-			.append(nickname);
-		return Uri.parse(sb.toString());
+				.append(':')
+				.append(port)
+				.append("/#")
+				.append(nickname);
+		return sb.toString();
 	}
 
-	public HostBean clone() {
-		HostBean clone = new HostBean();
-		clone.nickname = nickname;
-		clone.username = username;
-		clone.hostname = hostname;
-		clone.port = port;
-		clone.protocol = protocol;
-		clone.hostKeyAlgo = hostKeyAlgo;
-		if (hostKey != null)
-			clone.hostKey = hostKey.clone();
-		clone.lastConnect = lastConnect;
-		clone.color = color;
-		clone.useKeys = useKeys;
-		clone.useAuthAgent = useAuthAgent;
-		clone.postLogin = postLogin;
-		clone.pubkeyId = pubkeyId;
-		clone.wantSession = wantSession;
-		clone.delKey = delKey;
-		clone.fontSize = fontSize;
-		clone.compression = compression;
-		clone.encoding = encoding;
-		clone.stayConnected = stayConnected;
-		clone.quickDisconnect = quickDisconnect;
-		return (clone);
+	/**
+	 * @return URI identifying this HostBean
+	 */
+	public Uri getUri() {
+		return Uri.parse(getUriString());
+	}
+
+	public Uri getCloneUri( int index ) {
+		return Uri.parse(String.format("%s #%d", getUriString(), index));
 	}
 }

--- a/app/src/main/java/org/connectbot/bean/HostBean.java
+++ b/app/src/main/java/org/connectbot/bean/HostBean.java
@@ -331,7 +331,7 @@ public class HostBean extends AbstractBean {
 		return Uri.parse(getUriString());
 	}
 
-	public Uri getCloneUri( int index ) {
+	public Uri getCloneUri(int index) {
 		return Uri.parse(String.format("%s #%d", getUriString(), index));
 	}
 }

--- a/app/src/main/java/org/connectbot/bean/HostBean.java
+++ b/app/src/main/java/org/connectbot/bean/HostBean.java
@@ -324,4 +324,29 @@ public class HostBean extends AbstractBean {
 		return Uri.parse(sb.toString());
 	}
 
+	public HostBean clone() {
+		HostBean clone = new HostBean();
+		clone.nickname = nickname;
+		clone.username = username;
+		clone.hostname = hostname;
+		clone.port = port;
+		clone.protocol = protocol;
+		clone.hostKeyAlgo = hostKeyAlgo;
+		if (hostKey != null)
+			clone.hostKey = hostKey.clone();
+		clone.lastConnect = lastConnect;
+		clone.color = color;
+		clone.useKeys = useKeys;
+		clone.useAuthAgent = useAuthAgent;
+		clone.postLogin = postLogin;
+		clone.pubkeyId = pubkeyId;
+		clone.wantSession = wantSession;
+		clone.delKey = delKey;
+		clone.fontSize = fontSize;
+		clone.compression = compression;
+		clone.encoding = encoding;
+		clone.stayConnected = stayConnected;
+		clone.quickDisconnect = quickDisconnect;
+		return (clone);
+	}
 }

--- a/app/src/main/java/org/connectbot/bean/HostBean.java
+++ b/app/src/main/java/org/connectbot/bean/HostBean.java
@@ -22,6 +22,8 @@ import org.connectbot.util.HostDatabase;
 import android.content.ContentValues;
 import android.net.Uri;
 
+import java.util.Locale;
+
 /**
  * @author Kenny Root
  *
@@ -332,6 +334,6 @@ public class HostBean extends AbstractBean {
 	}
 
 	public Uri getCloneUri(int index) {
-		return Uri.parse(String.format("%s #%d", getUriString(), index));
+		return Uri.parse(String.format(Locale.US, "%s #%d", getUriString(), index));
 	}
 }

--- a/app/src/main/java/org/connectbot/service/TerminalBridge.java
+++ b/app/src/main/java/org/connectbot/service/TerminalBridge.java
@@ -125,6 +125,11 @@ public class TerminalBridge implements VDUDisplay {
 	protected BridgeDisconnectedListener disconnectListener = null;
 
 	/**
+	 * Boolean to indicate if this is a temporary connection (clone)
+	 */
+	public boolean temp = false;
+
+	/**
 	 * Create a new terminal bridge suitable for unit testing.
 	 */
 	public TerminalBridge() {
@@ -1043,5 +1048,13 @@ public class TerminalBridge implements VDUDisplay {
 	 */
 	public void decreaseFontSize() {
 		setFontSize(fontSizeDp - FONT_SIZE_STEP);
+	}
+
+	public boolean isTemp() {
+		return temp;
+	}
+
+	public void setTemp(boolean temp) {
+		this.temp = temp;
 	}
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -590,5 +590,8 @@
 	<string name="button_key_f12">F12</string>
 
 	<!-- Host list context menu "Clone connection" -->
-	<string name="connection_clone">Clone connection</string>
+	<string name="clone_connection">Clone connection</string>
+
+	<!-- Host list item "last connection date" for cloned connections -->
+	<string name="cloned_connection">Cloned connection</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -588,4 +588,7 @@
 	<string name="button_key_f11">F11</string>
 	<!-- Text for the "F12" button in virtual keyboard. -->
 	<string name="button_key_f12">F12</string>
+
+	<!-- Host list context menu "Clone connection" -->
+	<string name="connection_clone">Clone connection</string>
 </resources>


### PR DESCRIPTION
I often use more than one connection to a server (sometimes even more than 2). So, in the actual implementation of ConnectBot, we have to create a second host with the same specifications (without any way to clone an existing host).

This patch add a context menu in the hosts list "Clone connection" that will clone the HostBean in memory and change the nickname to "My Server #1",  and connect to it.

~~There~~ ~~is~~ ~~a~~ ~~flaw~~ ~~here,~~ ~~the~~ ~~temporary~~ ~~status~~ ~~is~~ ~~based~~ ~~on~~ ~~the~~ ~~host~~ ~~nickname~~ ~~(regex~~ ~~".*~~ ~~#[0-9]+$"),~~ ~~so~~ ~~if~~ ~~a~~ ~~user~~ ~~has~~ ~~defined~~ ~~manually~~ ~~a~~ ~~nickname~~ ~~ending~~ ~~with~~ ~~this~~ ~~pattern~~ ~~it~~ ~~will~~ ~~be~~ ~~detected~~ ~~as~~ ~~temporary.~~ ~~The~~ ~~only~~ ~~consequence~~ ~~will~~ ~~be~~ ~~that~~ ~~the~~ ~~user~~ ~~won't~~ ~~see~~ ~~the~~ ~~"Clone~~ ~~connection"~~ ~~context~~ ~~menu.

~~I'm~~ ~~not~~ ~~sure~~ ~~this~~ ~~is~~ ~~the~~ ~~proper~~ ~~way~~ ~~to~~ ~~implement~~ ~~this.~~
