### PR TITLE
Fix host list for API 10 and before

### DIFF
--- a/app/src/main/res/values-v11/styles.xml
+++ b/app/src/main/res/values-v11/styles.xml
@@ -17,26 +17,6 @@
  */
 -->
 <resources>
-
-	<style name="KeyboardKey">
-		<item name="android:layout_width">45dip</item>
-		<item name="android:layout_height">30dip</item>
-		<item name="android:layout_margin">0dp</item>
-		<item name="android:padding">0dp</item>
-		<item name="android:textSize">10sp</item>
-	</style>
-
-	<style name="KeyboardButton" parent="KeyboardKey">
-		<item name="android:background">@drawable/keyboard_button_selector</item>
-	</style>
-
-	<style name="ListItemFirstLineText">
-		<item name="android:textColor">?android:textColorPrimary</item>
-		<item name="android:textSize">16sp</item>
-	</style>
-
-	<style name="ListItemSecondLineText">
-		<item name="android:textColor">?android:textColorSecondary</item>
-		<item name="android:textSize">14sp</item>
-	</style>
+	<style name="ListItemFirstLineText" parent="TextAppearance.AppCompat" />
+	<style name="ListItemSecondLineText" parent="TextAppearance.AppCompat" />
 </resources>


### PR DESCRIPTION
There is some kind of problem with inheriting TextAppearance.AppCompat
on API 10 and before that causes a crash. Instead only inherit it on API
11 (Honeycomb) and later. This doesn't make any visual difference with
Gingerbread and before.