### PR TITLE
Database refactor

### DIFF
--- a/app/src/androidTest/java/org/connectbot/StartupTest.java
+++ b/app/src/androidTest/java/org/connectbot/StartupTest.java
@@ -1,29 +1,20 @@
 package org.connectbot;
 
-import org.connectbot.bean.HostBean;
 import org.connectbot.util.HostDatabase;
-import org.hamcrest.Description;
-import org.hamcrest.Matcher;
-import org.hamcrest.TypeSafeMatcher;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import android.content.Context;
 import android.content.Intent;
 import android.content.res.Resources;
-import android.support.annotation.ColorInt;
 import android.support.annotation.ColorRes;
-import android.support.annotation.NonNull;
 import android.support.annotation.StringRes;
 import android.support.test.InstrumentationRegistry;
 import android.support.test.espresso.intent.Intents;
-import android.support.test.espresso.matcher.BoundedMatcher;
 import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
-import android.view.View;
-import android.widget.ImageView;
-import android.widget.TextView;
 
 import static android.support.test.espresso.Espresso.onData;
 import static android.support.test.espresso.Espresso.onView;
@@ -34,7 +25,6 @@ import static android.support.test.espresso.action.ViewActions.pressBack;
 import static android.support.test.espresso.action.ViewActions.pressImeActionButton;
 import static android.support.test.espresso.action.ViewActions.pressMenuKey;
 import static android.support.test.espresso.action.ViewActions.typeText;
-import static android.support.test.espresso.assertion.ViewAssertions.doesNotExist;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
 import static android.support.test.espresso.intent.Intents.intended;
 import static android.support.test.espresso.intent.matcher.IntentMatchers.hasComponent;
@@ -58,7 +48,8 @@ public class StartupTest {
 
 	@Before
 	public void makeDatabasePristine() {
-		HostDatabase.resetInMemoryInstance(InstrumentationRegistry.getTargetContext());
+		Context testContext = InstrumentationRegistry.getTargetContext();
+		HostDatabase.resetInMemoryInstance(testContext);
 
 		mActivityRule.launchActivity(new Intent());
 	}

--- a/app/src/androidTest/java/org/connectbot/StartupTest.java
+++ b/app/src/androidTest/java/org/connectbot/StartupTest.java
@@ -58,7 +58,7 @@ public class StartupTest {
 
 	@Before
 	public void makeDatabasePristine() {
-		HostDatabase db = new HostDatabase(InstrumentationRegistry.getTargetContext());
+		HostDatabase db = HostDatabase.get(InstrumentationRegistry.getTargetContext());
 		db.resetDatabase();
 
 		mActivityRule.launchActivity(new Intent());

--- a/app/src/androidTest/java/org/connectbot/StartupTest.java
+++ b/app/src/androidTest/java/org/connectbot/StartupTest.java
@@ -101,9 +101,9 @@ public class StartupTest {
 	}
 
 	@Test
-	public void localConnectionCanChangeToRed() throws Exception {
-		startNewLocalConnectionAndGoBack("Local1");
-		changeColor("Local1", R.color.red, R.string.color_red);
+	public void localConnectionCanChangeToRed() {
+		startNewLocalConnectionAndGoBack("RedLocal");
+		changeColor("RedLocal", R.color.red, R.string.color_red);
 	}
 
 	/**

--- a/app/src/androidTest/java/org/connectbot/StartupTest.java
+++ b/app/src/androidTest/java/org/connectbot/StartupTest.java
@@ -58,8 +58,7 @@ public class StartupTest {
 
 	@Before
 	public void makeDatabasePristine() {
-		HostDatabase db = HostDatabase.get(InstrumentationRegistry.getTargetContext());
-		db.resetDatabase();
+		HostDatabase.resetInMemoryInstance(InstrumentationRegistry.getTargetContext());
 
 		mActivityRule.launchActivity(new Intent());
 	}

--- a/app/src/androidTest/java/org/connectbot/StartupTest.java
+++ b/app/src/androidTest/java/org/connectbot/StartupTest.java
@@ -1,6 +1,7 @@
 package org.connectbot;
 
 import org.connectbot.util.HostDatabase;
+import org.hamcrest.Matcher;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -12,14 +13,17 @@ import android.content.res.Resources;
 import android.support.annotation.ColorRes;
 import android.support.annotation.StringRes;
 import android.support.test.InstrumentationRegistry;
+import android.support.test.espresso.UiController;
+import android.support.test.espresso.ViewAction;
+import android.support.test.espresso.action.CloseKeyboardAction;
 import android.support.test.espresso.intent.Intents;
 import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
+import android.view.View;
 
 import static android.support.test.espresso.Espresso.onData;
 import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.action.ViewActions.click;
-import static android.support.test.espresso.action.ViewActions.closeSoftKeyboard;
 import static android.support.test.espresso.action.ViewActions.longClick;
 import static android.support.test.espresso.action.ViewActions.pressBack;
 import static android.support.test.espresso.action.ViewActions.pressImeActionButton;
@@ -152,5 +156,41 @@ public class StartupTest {
 
 		onView(withId(R.id.console_flip)).check(matches(
 				hasDescendant(allOf(isDisplayed(), withId(R.id.terminal_view)))));
+	}
+
+	/*
+	 * This is to work around a race condition where the software keyboard does not dismiss in time
+	 * and you get a Security Exception.
+	 *
+	 * From: https://code.google.com/p/android-test-kit/issues/detail?id=79#c7
+	 */
+	public static ViewAction closeSoftKeyboard() {
+		return new ViewAction() {
+			/**
+			 * The delay time to allow the soft keyboard to dismiss.
+			 */
+			private static final long KEYBOARD_DISMISSAL_DELAY_MILLIS = 1000L;
+
+			/**
+			 * The real {@link CloseKeyboardAction} instance.
+			 */
+			private final ViewAction mCloseSoftKeyboard = new CloseKeyboardAction();
+
+			@Override
+			public Matcher<View> getConstraints() {
+				return mCloseSoftKeyboard.getConstraints();
+			}
+
+			@Override
+			public String getDescription() {
+				return mCloseSoftKeyboard.getDescription();
+			}
+
+			@Override
+			public void perform(final UiController uiController, final View view) {
+				mCloseSoftKeyboard.perform(uiController, view);
+				uiController.loopMainThreadForAtLeast(KEYBOARD_DISMISSAL_DELAY_MILLIS);
+			}
+		};
 	}
 }

--- a/app/src/main/java/org/connectbot/ColorsActivity.java
+++ b/app/src/main/java/org/connectbot/ColorsActivity.java
@@ -56,6 +56,7 @@ public class ColorsActivity extends Activity implements OnItemClickListener, OnC
 	private int mColorScheme;
 
 	private List<Integer> mColorList;
+	private HostDatabase mHostDb;
 
 	private int mCurrentColor = 0;
 
@@ -73,10 +74,10 @@ public class ColorsActivity extends Activity implements OnItemClickListener, OnC
 
 		mColorScheme = HostDatabase.DEFAULT_COLOR_SCHEME;
 
-		HostDatabase hostDb = HostDatabase.get(this);
+		mHostDb = HostDatabase.get(this);
 
-		mColorList = Arrays.asList(hostDb.getColorsForScheme(mColorScheme));
-		mDefaultColors = hostDb.getDefaultColorsForScheme(mColorScheme);
+		mColorList = Arrays.asList(mHostDb.getColorsForScheme(mColorScheme));
+		mDefaultColors = mHostDb.getDefaultColorsForScheme(mColorScheme);
 
 		mColorGrid = (GridView) findViewById(R.id.color_grid);
 		mColorGrid.setAdapter(new ColorsAdapter(true));
@@ -92,6 +93,24 @@ public class ColorsActivity extends Activity implements OnItemClickListener, OnC
 		mBgSpinner.setAdapter(new ColorsAdapter(false, R.string.color_bg_label));
 		mBgSpinner.setSelection(mDefaultColors[1]);
 		mBgSpinner.setOnItemSelectedListener(this);
+	}
+
+	@Override
+	protected void onDestroy() {
+		super.onDestroy();
+
+		if (mHostDb != null) {
+			mHostDb = null;
+		}
+	}
+
+	@Override
+	protected void onResume() {
+		super.onResume();
+
+		if (mHostDb == null) {
+			mHostDb = HostDatabase.get(this);
+		}
 	}
 
 	private class ColorsAdapter extends BaseAdapter {
@@ -285,8 +304,7 @@ public class ColorsActivity extends Activity implements OnItemClickListener, OnC
 	public void onNothingSelected(AdapterView<?> arg0) { }
 
 	public void colorChanged(int value) {
-		HostDatabase hostDb = HostDatabase.get(this);
-		hostDb.setGlobalColor(mCurrentColor, value);
+		mHostDb.setGlobalColor(mCurrentColor, value);
 		mColorList.set(mCurrentColor, value);
 		mColorGrid.invalidateViews();
 	}
@@ -307,8 +325,7 @@ public class ColorsActivity extends Activity implements OnItemClickListener, OnC
 		}
 
 		if (needUpdate) {
-			HostDatabase hostDb = HostDatabase.get(this);
-			hostDb.setDefaultColorsForScheme(mColorScheme, mDefaultColors[0], mDefaultColors[1]);
+			mHostDb.setDefaultColorsForScheme(mColorScheme, mDefaultColors[0], mDefaultColors[1]);
 		}
 	}
 
@@ -322,12 +339,10 @@ public class ColorsActivity extends Activity implements OnItemClickListener, OnC
 		reset.setIcon(android.R.drawable.ic_menu_revert);
 		reset.setOnMenuItemClickListener(new OnMenuItemClickListener() {
 			public boolean onMenuItemClick(MenuItem arg0) {
-				HostDatabase hostDb = HostDatabase.get(ColorsActivity.this);
-
 				// Reset each individual color to defaults.
 				for (int i = 0; i < Colors.defaults.length; i++) {
 					if (!mColorList.get(i).equals(Colors.defaults[i])) {
-						hostDb.setGlobalColor(i, Colors.defaults[i]);
+						mHostDb.setGlobalColor(i, Colors.defaults[i]);
 						mColorList.set(i, Colors.defaults[i]);
 					}
 				}
@@ -336,7 +351,7 @@ public class ColorsActivity extends Activity implements OnItemClickListener, OnC
 				// Reset the default FG/BG colors as well.
 				mFgSpinner.setSelection(HostDatabase.DEFAULT_FG_COLOR);
 				mBgSpinner.setSelection(HostDatabase.DEFAULT_BG_COLOR);
-				hostDb.setDefaultColorsForScheme(HostDatabase.DEFAULT_COLOR_SCHEME,
+				mHostDb.setDefaultColorsForScheme(HostDatabase.DEFAULT_COLOR_SCHEME,
 						HostDatabase.DEFAULT_FG_COLOR, HostDatabase.DEFAULT_BG_COLOR);
 
 				return true;

--- a/app/src/main/java/org/connectbot/ColorsActivity.java
+++ b/app/src/main/java/org/connectbot/ColorsActivity.java
@@ -18,8 +18,6 @@
 package org.connectbot;
 
 import java.text.NumberFormat;
-import java.util.Arrays;
-import java.util.List;
 
 import org.connectbot.data.ColorStorage;
 import org.connectbot.util.Colors;

--- a/app/src/main/java/org/connectbot/ColorsActivity.java
+++ b/app/src/main/java/org/connectbot/ColorsActivity.java
@@ -74,7 +74,7 @@ public class ColorsActivity extends Activity implements OnItemClickListener, OnC
 
 		mColorScheme = HostDatabase.DEFAULT_COLOR_SCHEME;
 
-		mHostDb = new HostDatabase(this);
+		mHostDb = HostDatabase.get(this);
 
 		mColorList = Arrays.asList(mHostDb.getColorsForScheme(mColorScheme));
 		mDefaultColors = mHostDb.getDefaultColorsForScheme(mColorScheme);
@@ -110,7 +110,7 @@ public class ColorsActivity extends Activity implements OnItemClickListener, OnC
 		super.onResume();
 
 		if (mHostDb == null)
-			mHostDb = new HostDatabase(this);
+			mHostDb = HostDatabase.get(this);
 	}
 
 	private class ColorsAdapter extends BaseAdapter {

--- a/app/src/main/java/org/connectbot/ColorsActivity.java
+++ b/app/src/main/java/org/connectbot/ColorsActivity.java
@@ -21,6 +21,7 @@ import java.text.NumberFormat;
 import java.util.Arrays;
 import java.util.List;
 
+import org.connectbot.data.ColorStorage;
 import org.connectbot.util.Colors;
 import org.connectbot.util.HostDatabase;
 import org.connectbot.util.UberColorPickerDialog;
@@ -56,7 +57,7 @@ public class ColorsActivity extends Activity implements OnItemClickListener, OnC
 	private int mColorScheme;
 
 	private int[] mColorList;
-	private HostDatabase mHostDb;
+	private ColorStorage mHostDb;
 
 	private int mCurrentColor = 0;
 

--- a/app/src/main/java/org/connectbot/ColorsActivity.java
+++ b/app/src/main/java/org/connectbot/ColorsActivity.java
@@ -55,7 +55,7 @@ public class ColorsActivity extends Activity implements OnItemClickListener, OnC
 
 	private int mColorScheme;
 
-	private List<Integer> mColorList;
+	private int[] mColorList;
 	private HostDatabase mHostDb;
 
 	private int mCurrentColor = 0;
@@ -76,7 +76,7 @@ public class ColorsActivity extends Activity implements OnItemClickListener, OnC
 
 		mHostDb = HostDatabase.get(this);
 
-		mColorList = Arrays.asList(mHostDb.getColorsForScheme(mColorScheme));
+		mColorList = mHostDb.getColorsForScheme(mColorScheme);
 		mDefaultColors = mHostDb.getDefaultColorsForScheme(mColorScheme);
 
 		mColorGrid = (GridView) findViewById(R.id.color_grid);
@@ -135,18 +135,18 @@ public class ColorsActivity extends Activity implements OnItemClickListener, OnC
 				c = (ColorView) convertView;
 			}
 
-			c.setColor(mColorList.get(position));
+			c.setColor(mColorList[position]);
 			c.setNumber(position + 1);
 
 			return c;
 		}
 
 		public int getCount() {
-			return mColorList.size();
+			return mColorList.length;
 		}
 
 		public Object getItem(int position) {
-			return mColorList.get(position);
+			return mColorList[position];
 		}
 
 		public long getItemId(int position) {
@@ -294,7 +294,7 @@ public class ColorsActivity extends Activity implements OnItemClickListener, OnC
 
 	private void editColor(int colorNumber) {
 		mCurrentColor = colorNumber;
-		new UberColorPickerDialog(this, this, mColorList.get(colorNumber)).show();
+		new UberColorPickerDialog(this, this, mColorList[colorNumber]).show();
 	}
 
 	public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
@@ -305,7 +305,7 @@ public class ColorsActivity extends Activity implements OnItemClickListener, OnC
 
 	public void colorChanged(int value) {
 		mHostDb.setGlobalColor(mCurrentColor, value);
-		mColorList.set(mCurrentColor, value);
+		mColorList[mCurrentColor] = value;
 		mColorGrid.invalidateViews();
 	}
 
@@ -341,9 +341,9 @@ public class ColorsActivity extends Activity implements OnItemClickListener, OnC
 			public boolean onMenuItemClick(MenuItem arg0) {
 				// Reset each individual color to defaults.
 				for (int i = 0; i < Colors.defaults.length; i++) {
-					if (!mColorList.get(i).equals(Colors.defaults[i])) {
+					if (mColorList[i] != Colors.defaults[i]) {
 						mHostDb.setGlobalColor(i, Colors.defaults[i]);
-						mColorList.set(i, Colors.defaults[i]);
+						mColorList[i] = Colors.defaults[i];
 					}
 				}
 				mColorGrid.invalidateViews();

--- a/app/src/main/java/org/connectbot/ConsoleActivity.java
+++ b/app/src/main/java/org/connectbot/ConsoleActivity.java
@@ -167,8 +167,6 @@ public class ConsoleActivity extends AppCompatActivity implements BridgeDisconne
 			bound.setResizeAllowed(true);
 
 			final String requestedNickname = (requested != null) ? requested.getFragment() : null;
-			int requestedIndex = 0;
-
 			TerminalBridge requestedBridge = bound.getConnectedBridge(requestedNickname);
 
 			// If we didn't find the requested connection, try opening it
@@ -183,9 +181,11 @@ public class ConsoleActivity extends AppCompatActivity implements BridgeDisconne
 
 			// create views for all bridges on this service
 			adapter.notifyDataSetChanged();
-			requestedIndex = bound.getBridges().indexOf(requestedBridge);
+			int requestedIndex = bound.getBridges().indexOf(requestedBridge);
 
-			setDisplayedTerminal(requestedIndex == -1 ? 0 : requestedIndex);
+			if (requestedIndex != -1) {
+				setDisplayedTerminal(requestedIndex);
+			}
 		}
 
 		public void onServiceDisconnected(ComponentName className) {

--- a/app/src/main/java/org/connectbot/GeneratePubkeyActivity.java
+++ b/app/src/main/java/org/connectbot/GeneratePubkeyActivity.java
@@ -300,7 +300,6 @@ public class GeneratePubkeyActivity extends Activity implements OnEntropyGathere
 
 				PubkeyDatabase pubkeydb = PubkeyDatabase.get(GeneratePubkeyActivity.this);
 				pubkeydb.savePubkey(pubkey);
-				pubkeydb.close();
 			} catch (Exception e) {
 				Log.e(TAG, "Could not generate key pair");
 

--- a/app/src/main/java/org/connectbot/GeneratePubkeyActivity.java
+++ b/app/src/main/java/org/connectbot/GeneratePubkeyActivity.java
@@ -298,7 +298,7 @@ public class GeneratePubkeyActivity extends Activity implements OnEntropyGathere
 				pubkey.setStartup(unlockAtStartup.isChecked());
 				pubkey.setConfirmUse(confirmUse.isChecked());
 
-				PubkeyDatabase pubkeydb = new PubkeyDatabase(GeneratePubkeyActivity.this);
+				PubkeyDatabase pubkeydb = PubkeyDatabase.get(GeneratePubkeyActivity.this);
 				pubkeydb.savePubkey(pubkey);
 				pubkeydb.close();
 			} catch (Exception e) {

--- a/app/src/main/java/org/connectbot/HostEditorActivity.java
+++ b/app/src/main/java/org/connectbot/HostEditorActivity.java
@@ -244,8 +244,8 @@ public class HostEditorActivity extends PreferenceActivity implements OnSharedPr
 		// TODO: we could pass through a specific ContentProvider uri here
 		//this.getPreferenceManager().setSharedPreferencesName(uri);
 
-		this.hostdb = new HostDatabase(this);
-		this.pubkeydb = new PubkeyDatabase(this);
+		this.hostdb = HostDatabase.get(this);
+		this.pubkeydb = PubkeyDatabase.get(this);
 
 		host = hostdb.findHostById(hostId);
 
@@ -307,10 +307,10 @@ public class HostEditorActivity extends PreferenceActivity implements OnSharedPr
 		bindService(new Intent(this, TerminalManager.class), connection, Context.BIND_AUTO_CREATE);
 
 		if (this.hostdb == null)
-			this.hostdb = new HostDatabase(this);
+			this.hostdb = HostDatabase.get(this);
 
 		if (this.pubkeydb == null)
-			this.pubkeydb = new PubkeyDatabase(this);
+			this.pubkeydb = PubkeyDatabase.get(this);
 	}
 
 	@Override

--- a/app/src/main/java/org/connectbot/HostEditorActivity.java
+++ b/app/src/main/java/org/connectbot/HostEditorActivity.java
@@ -68,6 +68,7 @@ public class HostEditorActivity extends PreferenceActivity implements OnSharedPr
 			// fill a cursor and cache the values locally
 			// this makes sure we don't have any floating cursor to dispose later
 
+			HostDatabase hostdb = HostDatabase.get(HostEditorActivity.this);
 			SQLiteDatabase db = hostdb.getWritableDatabase();
 			Cursor cursor = db.query(table, null, "_id = ?",
 					new String[] { String.valueOf(id) }, null, null, null);
@@ -98,7 +99,7 @@ public class HostEditorActivity extends PreferenceActivity implements OnSharedPr
 			}
 
 			public boolean commit() {
-				//Log.d(this.getClass().toString(), "commit() changes back to database");
+				HostDatabase hostdb = HostDatabase.get(HostEditorActivity.this);
 				SQLiteDatabase db = hostdb.getWritableDatabase();
 				db.beginTransaction();
 				try {
@@ -214,9 +215,6 @@ public class HostEditorActivity extends PreferenceActivity implements OnSharedPr
 
 	protected static final String TAG = "CB.HostEditorActivity";
 
-	protected HostDatabase hostdb = null;
-	private PubkeyDatabase pubkeydb = null;
-
 	private CursorPreferenceHack pref;
 	private ServiceConnection connection;
 
@@ -232,8 +230,7 @@ public class HostEditorActivity extends PreferenceActivity implements OnSharedPr
 		// TODO: we could pass through a specific ContentProvider uri here
 		//this.getPreferenceManager().setSharedPreferencesName(uri);
 
-		this.hostdb = HostDatabase.get(this);
-		this.pubkeydb = PubkeyDatabase.get(this);
+		HostDatabase hostdb = HostDatabase.get(this);
 
 		host = hostdb.findHostById(hostId);
 
@@ -259,6 +256,7 @@ public class HostEditorActivity extends PreferenceActivity implements OnSharedPr
 		// TODO: should consider moving into onStart, but we dont have a good way of resetting the listpref after filling once
 		ListPreference pubkeyPref = (ListPreference) findPreference(HostDatabase.FIELD_HOST_PUBKEYID);
 
+		PubkeyDatabase pubkeydb = PubkeyDatabase.get(this);
 		List<CharSequence> pubkeyNicks = new LinkedList<CharSequence>(Arrays.asList(pubkeyPref.getEntries()));
 		pubkeyNicks.addAll(pubkeydb.allValues(PubkeyDatabase.FIELD_PUBKEY_NICKNAME));
 		pubkeyPref.setEntries(pubkeyNicks.toArray(new CharSequence[pubkeyNicks.size()]));
@@ -293,9 +291,6 @@ public class HostEditorActivity extends PreferenceActivity implements OnSharedPr
 		super.onStart();
 
 		bindService(new Intent(this, TerminalManager.class), connection, Context.BIND_AUTO_CREATE);
-
-		hostdb = HostDatabase.get(this);
-		pubkeydb = PubkeyDatabase.get(this);
 	}
 
 	@Override
@@ -303,12 +298,11 @@ public class HostEditorActivity extends PreferenceActivity implements OnSharedPr
 		super.onStop();
 
 		unbindService(connection);
-
-		hostdb = null;
-		pubkeydb = null;
 	}
 
 	private void updateSummaries() {
+		PubkeyDatabase pubkeydb = PubkeyDatabase.get(this);
+
 		// for all text preferences, set hint as current database value
 		for (String key : this.pref.values.keySet()) {
 			if (key.equals(HostDatabase.FIELD_HOST_POSTLOGIN)) continue;

--- a/app/src/main/java/org/connectbot/HostEditorActivity.java
+++ b/app/src/main/java/org/connectbot/HostEditorActivity.java
@@ -66,9 +66,9 @@ public class HostEditorActivity extends PreferenceActivity implements OnSharedPr
 
 		protected final void cacheValues() {
 			// fill a cursor and cache the values locally
-			// this makes sure we dont have any floating cursor to dispose later
+			// this makes sure we don't have any floating cursor to dispose later
 
-			SQLiteDatabase db = hostdb.getReadableDatabase();
+			SQLiteDatabase db = hostdb.getWritableDatabase();
 			Cursor cursor = db.query(table, null, "_id = ?",
 					new String[] { String.valueOf(id) }, null, null, null);
 
@@ -81,23 +81,6 @@ public class HostEditorActivity extends PreferenceActivity implements OnSharedPr
 				}
 			}
 			cursor.close();
-			db.close();
-
-//			db = pubkeydb.getReadableDatabase();
-//			cursor = db.query(PubkeyDatabase.TABLE_PUBKEYS,
-//					new String[] { "_id", PubkeyDatabase.FIELD_PUBKEY_NICKNAME },
-//					null, null, null, null, null);
-//
-//			if (cursor.moveToFirst()) {
-//				do {
-//					String pubkeyid = String.valueOf(cursor.getLong(0));
-//					String value = cursor.getString(1);
-//					pubkeys.put(pubkeyid, value);
-//				} while (cursor.moveToNext());
-//			}
-//
-//			cursor.close();
-//			db.close();
 		}
 
 		public boolean contains(String key) {
@@ -118,7 +101,6 @@ public class HostEditorActivity extends PreferenceActivity implements OnSharedPr
 				//Log.d(this.getClass().toString(), "commit() changes back to database");
 				SQLiteDatabase db = hostdb.getWritableDatabase();
 				db.update(table, update, "_id = ?", new String[] { String.valueOf(id) });
-				db.close();
 
 				// make sure we refresh the parent cached values
 				cacheValues();
@@ -306,11 +288,8 @@ public class HostEditorActivity extends PreferenceActivity implements OnSharedPr
 
 		bindService(new Intent(this, TerminalManager.class), connection, Context.BIND_AUTO_CREATE);
 
-		if (this.hostdb == null)
-			this.hostdb = HostDatabase.get(this);
-
-		if (this.pubkeydb == null)
-			this.pubkeydb = PubkeyDatabase.get(this);
+		hostdb = HostDatabase.get(this);
+		pubkeydb = PubkeyDatabase.get(this);
 	}
 
 	@Override
@@ -319,15 +298,8 @@ public class HostEditorActivity extends PreferenceActivity implements OnSharedPr
 
 		unbindService(connection);
 
-		if (this.hostdb != null) {
-			this.hostdb.close();
-			this.hostdb = null;
-		}
-
-		if (this.pubkeydb != null) {
-			this.pubkeydb.close();
-			this.pubkeydb = null;
-		}
+		hostdb = null;
+		pubkeydb = null;
 	}
 
 	private void updateSummaries() {

--- a/app/src/main/java/org/connectbot/HostEditorActivity.java
+++ b/app/src/main/java/org/connectbot/HostEditorActivity.java
@@ -100,7 +100,13 @@ public class HostEditorActivity extends PreferenceActivity implements OnSharedPr
 			public boolean commit() {
 				//Log.d(this.getClass().toString(), "commit() changes back to database");
 				SQLiteDatabase db = hostdb.getWritableDatabase();
-				db.update(table, update, "_id = ?", new String[] { String.valueOf(id) });
+				db.beginTransaction();
+				try {
+					db.update(table, update, "_id = ?", new String[] {String.valueOf(id)});
+					db.setTransactionSuccessful();
+				} finally {
+					db.endTransaction();
+				}
 
 				// make sure we refresh the parent cached values
 				cacheValues();

--- a/app/src/main/java/org/connectbot/HostListActivity.java
+++ b/app/src/main/java/org/connectbot/HostListActivity.java
@@ -20,6 +20,7 @@ package org.connectbot;
 import java.util.List;
 
 import org.connectbot.bean.HostBean;
+import org.connectbot.data.HostStorage;
 import org.connectbot.service.OnHostStatusChangedListener;
 import org.connectbot.service.TerminalBridge;
 import org.connectbot.service.TerminalManager;
@@ -71,7 +72,7 @@ public class HostListActivity extends ListActivity implements OnHostStatusChange
 
 	protected TerminalManager bound = null;
 
-	protected HostDatabase hostdb;
+	private HostStorage hostdb;
 	private List<HostBean> hosts;
 	protected LayoutInflater inflater = null;
 

--- a/app/src/main/java/org/connectbot/HostListActivity.java
+++ b/app/src/main/java/org/connectbot/HostListActivity.java
@@ -127,7 +127,7 @@ public class HostListActivity extends ListActivity implements OnHostStatusChange
 		this.bindService(new Intent(this, TerminalManager.class), connection, Context.BIND_AUTO_CREATE);
 
 		if (this.hostdb == null)
-			this.hostdb = new HostDatabase(this);
+			this.hostdb = HostDatabase.get(this);
 	}
 
 	@Override
@@ -210,7 +210,7 @@ public class HostListActivity extends ListActivity implements OnHostStatusChange
 								|| Intent.ACTION_PICK.equals(getIntent().getAction());
 
 		// connect with hosts database and populate list
-		this.hostdb = new HostDatabase(this);
+		this.hostdb = HostDatabase.get(this);
 		ListView list = this.getListView();
 
 		this.sortedByColor = prefs.getBoolean(PreferenceConstants.SORT_BY_COLOR, false);
@@ -490,7 +490,7 @@ public class HostListActivity extends ListActivity implements OnHostStatusChange
 		}
 
 		if (hostdb == null)
-			hostdb = new HostDatabase(this);
+			hostdb = HostDatabase.get(this);
 
 		hosts = hostdb.getHosts(sortedByColor);
 

--- a/app/src/main/java/org/connectbot/HostListActivity.java
+++ b/app/src/main/java/org/connectbot/HostListActivity.java
@@ -72,7 +72,6 @@ public class HostListActivity extends ListActivity implements OnHostStatusChange
 
 	protected TerminalManager bound = null;
 
-	protected HostDatabase hostdb;
 	private List<HostBean> hosts;
 	protected LayoutInflater inflater = null;
 
@@ -125,16 +124,12 @@ public class HostListActivity extends ListActivity implements OnHostStatusChange
 
 		// start the terminal manager service
 		this.bindService(new Intent(this, TerminalManager.class), connection, Context.BIND_AUTO_CREATE);
-
-		hostdb = HostDatabase.get(this);
 	}
 
 	@Override
 	public void onStop() {
 		super.onStop();
 		this.unbindService(connection);
-
-		hostdb = null;
 
 		closeOnDisconnectAll = true;
 	}
@@ -206,7 +201,6 @@ public class HostListActivity extends ListActivity implements OnHostStatusChange
 								|| Intent.ACTION_PICK.equals(getIntent().getAction());
 
 		// connect with hosts database and populate list
-		this.hostdb = HostDatabase.get(this);
 		ListView list = this.getListView();
 
 		this.sortedByColor = prefs.getBoolean(PreferenceConstants.SORT_BY_COLOR, false);
@@ -399,7 +393,7 @@ public class HostListActivity extends ListActivity implements OnHostStatusChange
 								if (bridge != null)
 									bridge.dispatchDisconnect(true);
 
-								hostdb.deleteHost(host);
+								HostDatabase.get(HostListActivity.this).deleteHost(host);
 								updateList();
 							}
 						})
@@ -460,6 +454,7 @@ public class HostListActivity extends ListActivity implements OnHostStatusChange
 			return false;
 		}
 
+		HostDatabase hostdb = HostDatabase.get(this);
 		HostBean host = TransportFactory.findHost(hostdb, uri);
 		if (host == null) {
 			host = TransportFactory.getTransport(uri.getScheme()).createHost(uri);
@@ -485,9 +480,7 @@ public class HostListActivity extends ListActivity implements OnHostStatusChange
 			edit.commit();
 		}
 
-		if (hostdb == null)
-			hostdb = HostDatabase.get(this);
-
+		HostDatabase hostdb = HostDatabase.get(this);
 		hosts = hostdb.getHosts(sortedByColor);
 
 		// Don't lose hosts that are connected via shortcuts but not in the database.

--- a/app/src/main/java/org/connectbot/HostListActivity.java
+++ b/app/src/main/java/org/connectbot/HostListActivity.java
@@ -126,8 +126,7 @@ public class HostListActivity extends ListActivity implements OnHostStatusChange
 		// start the terminal manager service
 		this.bindService(new Intent(this, TerminalManager.class), connection, Context.BIND_AUTO_CREATE);
 
-		if (this.hostdb == null)
-			this.hostdb = HostDatabase.get(this);
+		hostdb = HostDatabase.get(this);
 	}
 
 	@Override
@@ -135,10 +134,7 @@ public class HostListActivity extends ListActivity implements OnHostStatusChange
 		super.onStop();
 		this.unbindService(connection);
 
-		if (this.hostdb != null) {
-			this.hostdb.close();
-			this.hostdb = null;
-		}
+		hostdb = null;
 
 		closeOnDisconnectAll = true;
 	}

--- a/app/src/main/java/org/connectbot/PortForwardListActivity.java
+++ b/app/src/main/java/org/connectbot/PortForwardListActivity.java
@@ -210,9 +210,12 @@ public class PortForwardListActivity extends ListActivity {
 									hostBridge.enablePortForward(pfb);
 								}
 
-								if (host != null && !hostdb.savePortForward(pfb))
-									throw new SQLException("Could not save port forward");
-
+								if (host != null) {
+									HostDatabase hostdb = HostDatabase.get(PortForwardListActivity.this);
+									if (!hostdb.savePortForward(pfb)) {
+										throw new SQLException("Could not save port forward");
+									}
+								}
 								updateHandler.sendEmptyMessage(-1);
 							} catch (Exception e) {
 								Log.e(TAG, "Could not update port forward", e);
@@ -307,8 +310,10 @@ public class PortForwardListActivity extends ListActivity {
 									}, LISTENER_CYCLE_TIME);
 
 
-								if (!hostdb.savePortForward(pfb))
+								HostDatabase hostdb = HostDatabase.get(PortForwardListActivity.this);
+								if (!hostdb.savePortForward(pfb)) {
 									throw new SQLException("Could not save port forward");
+								}
 
 								updateHandler.sendEmptyMessage(-1);
 							} catch (Exception e) {

--- a/app/src/main/java/org/connectbot/PortForwardListActivity.java
+++ b/app/src/main/java/org/connectbot/PortForwardListActivity.java
@@ -68,8 +68,6 @@ public class PortForwardListActivity extends ListActivity {
 
 	private static final int LISTENER_CYCLE_TIME = 500;
 
-	protected HostDatabase hostdb;
-
 	private List<PortForwardBean> portForwards;
 
 	private ServiceConnection connection = null;
@@ -83,8 +81,6 @@ public class PortForwardListActivity extends ListActivity {
 		super.onStart();
 
 		this.bindService(new Intent(this, TerminalManager.class), connection, Context.BIND_AUTO_CREATE);
-
-		hostdb = HostDatabase.get(this);
 	}
 
 	@Override
@@ -92,8 +88,6 @@ public class PortForwardListActivity extends ListActivity {
 		super.onStop();
 
 		this.unbindService(connection);
-
-		hostdb = null;
 	}
 
 	@Override
@@ -105,7 +99,7 @@ public class PortForwardListActivity extends ListActivity {
 		setContentView(R.layout.act_portforwardlist);
 
 		// connect with hosts database and populate list
-		this.hostdb = HostDatabase.get(this);
+		HostDatabase hostdb = HostDatabase.get(this);
 		host = hostdb.findHostById(hostId);
 
 		{
@@ -342,6 +336,7 @@ public class PortForwardListActivity extends ListActivity {
 								if (hostBridge != null)
 									hostBridge.removePortForward(pfb);
 
+								HostDatabase hostdb = HostDatabase.get(PortForwardListActivity.this);
 								hostdb.deletePortForward(pfb);
 							} catch (Exception e) {
 								Log.e(TAG, "Could not delete port forward", e);
@@ -368,8 +363,8 @@ public class PortForwardListActivity extends ListActivity {
 		if (hostBridge != null) {
 			this.portForwards = hostBridge.getPortForwards();
 		} else {
-			if (this.hostdb == null) return;
-			this.portForwards = this.hostdb.getPortForwardsForHost(host);
+			HostDatabase hostdb = HostDatabase.get(this);
+			this.portForwards = hostdb.getPortForwardsForHost(host);
 		}
 
 		PortForwardAdapter adapter = new PortForwardAdapter(this, portForwards);

--- a/app/src/main/java/org/connectbot/PortForwardListActivity.java
+++ b/app/src/main/java/org/connectbot/PortForwardListActivity.java
@@ -84,8 +84,7 @@ public class PortForwardListActivity extends ListActivity {
 
 		this.bindService(new Intent(this, TerminalManager.class), connection, Context.BIND_AUTO_CREATE);
 
-		if (this.hostdb == null)
-			this.hostdb = HostDatabase.get(this);
+		hostdb = HostDatabase.get(this);
 	}
 
 	@Override
@@ -94,10 +93,7 @@ public class PortForwardListActivity extends ListActivity {
 
 		this.unbindService(connection);
 
-		if (this.hostdb != null) {
-			this.hostdb.close();
-			this.hostdb = null;
-		}
+		hostdb = null;
 	}
 
 	@Override

--- a/app/src/main/java/org/connectbot/PortForwardListActivity.java
+++ b/app/src/main/java/org/connectbot/PortForwardListActivity.java
@@ -210,12 +210,10 @@ public class PortForwardListActivity extends ListActivity {
 									hostBridge.enablePortForward(pfb);
 								}
 
-								if (host != null) {
-									HostDatabase hostdb = HostDatabase.get(PortForwardListActivity.this);
-									if (!hostdb.savePortForward(pfb)) {
-										throw new SQLException("Could not save port forward");
-									}
+								if (host != null && !hostdb.savePortForward(pfb)) {
+									throw new SQLException("Could not save port forward");
 								}
+
 								updateHandler.sendEmptyMessage(-1);
 							} catch (Exception e) {
 								Log.e(TAG, "Could not update port forward", e);
@@ -310,7 +308,6 @@ public class PortForwardListActivity extends ListActivity {
 									}, LISTENER_CYCLE_TIME);
 
 
-								HostDatabase hostdb = HostDatabase.get(PortForwardListActivity.this);
 								if (!hostdb.savePortForward(pfb)) {
 									throw new SQLException("Could not save port forward");
 								}

--- a/app/src/main/java/org/connectbot/PortForwardListActivity.java
+++ b/app/src/main/java/org/connectbot/PortForwardListActivity.java
@@ -68,6 +68,8 @@ public class PortForwardListActivity extends ListActivity {
 
 	private static final int LISTENER_CYCLE_TIME = 500;
 
+	protected HostDatabase hostdb;
+
 	private List<PortForwardBean> portForwards;
 
 	private ServiceConnection connection = null;
@@ -81,6 +83,8 @@ public class PortForwardListActivity extends ListActivity {
 		super.onStart();
 
 		this.bindService(new Intent(this, TerminalManager.class), connection, Context.BIND_AUTO_CREATE);
+
+		hostdb = HostDatabase.get(this);
 	}
 
 	@Override
@@ -88,6 +92,8 @@ public class PortForwardListActivity extends ListActivity {
 		super.onStop();
 
 		this.unbindService(connection);
+
+		hostdb = null;
 	}
 
 	@Override
@@ -99,7 +105,7 @@ public class PortForwardListActivity extends ListActivity {
 		setContentView(R.layout.act_portforwardlist);
 
 		// connect with hosts database and populate list
-		HostDatabase hostdb = HostDatabase.get(this);
+		this.hostdb = HostDatabase.get(this);
 		host = hostdb.findHostById(hostId);
 
 		{
@@ -338,7 +344,6 @@ public class PortForwardListActivity extends ListActivity {
 								if (hostBridge != null)
 									hostBridge.removePortForward(pfb);
 
-								HostDatabase hostdb = HostDatabase.get(PortForwardListActivity.this);
 								hostdb.deletePortForward(pfb);
 							} catch (Exception e) {
 								Log.e(TAG, "Could not delete port forward", e);
@@ -365,8 +370,8 @@ public class PortForwardListActivity extends ListActivity {
 		if (hostBridge != null) {
 			this.portForwards = hostBridge.getPortForwards();
 		} else {
-			HostDatabase hostdb = HostDatabase.get(this);
-			this.portForwards = hostdb.getPortForwardsForHost(host);
+			if (this.hostdb == null) return;
+			this.portForwards = this.hostdb.getPortForwardsForHost(host);
 		}
 
 		PortForwardAdapter adapter = new PortForwardAdapter(this, portForwards);

--- a/app/src/main/java/org/connectbot/PortForwardListActivity.java
+++ b/app/src/main/java/org/connectbot/PortForwardListActivity.java
@@ -85,7 +85,7 @@ public class PortForwardListActivity extends ListActivity {
 		this.bindService(new Intent(this, TerminalManager.class), connection, Context.BIND_AUTO_CREATE);
 
 		if (this.hostdb == null)
-			this.hostdb = new HostDatabase(this);
+			this.hostdb = HostDatabase.get(this);
 	}
 
 	@Override
@@ -109,7 +109,7 @@ public class PortForwardListActivity extends ListActivity {
 		setContentView(R.layout.act_portforwardlist);
 
 		// connect with hosts database and populate list
-		this.hostdb = new HostDatabase(this);
+		this.hostdb = HostDatabase.get(this);
 		host = hostdb.findHostById(hostId);
 
 		{

--- a/app/src/main/java/org/connectbot/PubkeyListActivity.java
+++ b/app/src/main/java/org/connectbot/PubkeyListActivity.java
@@ -130,10 +130,7 @@ public class PubkeyListActivity extends ListActivity implements EventListener {
 
 		unbindService(connection);
 
-		if (pubkeydb != null) {
-			pubkeydb.close();
-			pubkeydb = null;
-		}
+		pubkeydb = null;
 	}
 
 	@Override

--- a/app/src/main/java/org/connectbot/PubkeyListActivity.java
+++ b/app/src/main/java/org/connectbot/PubkeyListActivity.java
@@ -121,7 +121,7 @@ public class PubkeyListActivity extends ListActivity implements EventListener {
 		bindService(new Intent(this, TerminalManager.class), connection, Context.BIND_AUTO_CREATE);
 
 		if (pubkeydb == null)
-			pubkeydb = new PubkeyDatabase(this);
+			pubkeydb = PubkeyDatabase.get(this);
 	}
 
 	@Override
@@ -146,7 +146,7 @@ public class PubkeyListActivity extends ListActivity implements EventListener {
 				getResources().getText(R.string.title_pubkey_list)));
 
 		// connect with hosts database and populate list
-		pubkeydb = new PubkeyDatabase(this);
+		pubkeydb = PubkeyDatabase.get(this);
 
 		updateList();
 
@@ -546,7 +546,7 @@ public class PubkeyListActivity extends ListActivity implements EventListener {
 
 			// write new value into database
 			if (pubkeydb == null)
-				pubkeydb = new PubkeyDatabase(this);
+				pubkeydb = PubkeyDatabase.get(this);
 			pubkeydb.savePubkey(pubkey);
 
 			updateList();

--- a/app/src/main/java/org/connectbot/PubkeyListActivity.java
+++ b/app/src/main/java/org/connectbot/PubkeyListActivity.java
@@ -88,7 +88,6 @@ public class PubkeyListActivity extends ListActivity implements EventListener {
 	private static final String ANDEXPLORER_TITLE = "explorer_title";
 	private static final String MIME_TYPE_ANDEXPLORER_FILE = "vnd.android.cursor.dir/lysesoft.andexplorer.file";
 
-	protected PubkeyDatabase pubkeydb;
 	private List<PubkeyBean> pubkeys;
 
 	protected ClipboardManager clipboard;
@@ -120,7 +119,6 @@ public class PubkeyListActivity extends ListActivity implements EventListener {
 
 		bindService(new Intent(this, TerminalManager.class), connection, Context.BIND_AUTO_CREATE);
 
-		pubkeydb = PubkeyDatabase.get(this);
 		updateList();
 	}
 
@@ -129,8 +127,6 @@ public class PubkeyListActivity extends ListActivity implements EventListener {
 		super.onStop();
 
 		unbindService(connection);
-
-		pubkeydb = null;
 	}
 
 	@Override
@@ -323,7 +319,8 @@ public class PubkeyListActivity extends ListActivity implements EventListener {
 			public boolean onMenuItemClick(MenuItem item) {
 				// toggle onstart status
 				pubkey.setStartup(!pubkey.isStartup());
-				pubkeydb.savePubkey(pubkey);
+				PubkeyDatabase pubkeyDb = PubkeyDatabase.get(PubkeyListActivity.this);
+				pubkeyDb.savePubkey(pubkey);
 				updateList();
 				return true;
 			}
@@ -397,7 +394,8 @@ public class PubkeyListActivity extends ListActivity implements EventListener {
 										.setPositiveButton(android.R.string.ok, null)
 										.create().show();
 								else {
-									pubkeydb.savePubkey(pubkey);
+									PubkeyDatabase pubkeyDb = PubkeyDatabase.get(PubkeyListActivity.this);
+									pubkeyDb.savePubkey(pubkey);
 									updateList();
 								}
 							} catch (Exception e) {
@@ -422,7 +420,8 @@ public class PubkeyListActivity extends ListActivity implements EventListener {
 			public boolean onMenuItemClick(MenuItem item) {
 				// toggle confirm use
 				pubkey.setConfirmUse(!pubkey.isConfirmUse());
-				pubkeydb.savePubkey(pubkey);
+				PubkeyDatabase pubkeyDb = PubkeyDatabase.get(PubkeyListActivity.this);
+				pubkeyDb.savePubkey(pubkey);
 				updateList();
 				return true;
 			}
@@ -438,11 +437,13 @@ public class PubkeyListActivity extends ListActivity implements EventListener {
 						public void onClick(DialogInterface dialog, int which) {
 
 							// dont forget to remove from in-memory
-							if (loaded)
+							if (loaded) {
 								bound.removeKey(pubkey.getNickname());
+							}
 
 							// delete from backend database and update gui
-							pubkeydb.deletePubkey(pubkey);
+							PubkeyDatabase pubkeyDb = PubkeyDatabase.get(PubkeyListActivity.this);
+							pubkeyDb.deletePubkey(pubkey);
 							updateList();
 						}
 					})
@@ -455,9 +456,8 @@ public class PubkeyListActivity extends ListActivity implements EventListener {
 	}
 
 	protected void updateList() {
-		if (pubkeydb == null) return;
-
-		pubkeys = pubkeydb.allPubkeys();
+		PubkeyDatabase pubkeyDb = PubkeyDatabase.get(PubkeyListActivity.this);
+		pubkeys = pubkeyDb.allPubkeys();
 		PubkeyAdapter adapter = new PubkeyAdapter(this, pubkeys);
 
 		this.setListAdapter(adapter);
@@ -488,7 +488,7 @@ public class PubkeyListActivity extends ListActivity implements EventListener {
 	}
 
 	/**
-	 * @param name
+	 * @param file
 	 */
 	private void readKeyFromFile(File file) {
 		PubkeyBean pubkey = new PubkeyBean();
@@ -537,8 +537,8 @@ public class PubkeyListActivity extends ListActivity implements EventListener {
 			}
 
 			// write new value into database
-			pubkeydb = PubkeyDatabase.get(this);
-			pubkeydb.savePubkey(pubkey);
+			PubkeyDatabase pubkeyDb = PubkeyDatabase.get(this);
+			pubkeyDb.savePubkey(pubkey);
 
 			updateList();
 		} catch (Exception e) {

--- a/app/src/main/java/org/connectbot/PubkeyListActivity.java
+++ b/app/src/main/java/org/connectbot/PubkeyListActivity.java
@@ -120,8 +120,8 @@ public class PubkeyListActivity extends ListActivity implements EventListener {
 
 		bindService(new Intent(this, TerminalManager.class), connection, Context.BIND_AUTO_CREATE);
 
-		if (pubkeydb == null)
-			pubkeydb = PubkeyDatabase.get(this);
+		pubkeydb = PubkeyDatabase.get(this);
+		updateList();
 	}
 
 	@Override
@@ -141,11 +141,6 @@ public class PubkeyListActivity extends ListActivity implements EventListener {
 		this.setTitle(String.format("%s: %s",
 				getResources().getText(R.string.app_name),
 				getResources().getText(R.string.title_pubkey_list)));
-
-		// connect with hosts database and populate list
-		pubkeydb = PubkeyDatabase.get(this);
-
-		updateList();
 
 		registerForContextMenu(getListView());
 
@@ -542,8 +537,7 @@ public class PubkeyListActivity extends ListActivity implements EventListener {
 			}
 
 			// write new value into database
-			if (pubkeydb == null)
-				pubkeydb = PubkeyDatabase.get(this);
+			pubkeydb = PubkeyDatabase.get(this);
 			pubkeydb.savePubkey(pubkey);
 
 			updateList();

--- a/app/src/main/java/org/connectbot/PubkeyListActivity.java
+++ b/app/src/main/java/org/connectbot/PubkeyListActivity.java
@@ -134,11 +134,6 @@ public class PubkeyListActivity extends ListActivity implements EventListener {
 		super.onCreate(icicle);
 		setContentView(R.layout.act_pubkeylist);
 
-		// connect with hosts database and populate list
-		pubkeydb = new PubkeyDatabase(this);
-
-		updateList();
-
 		registerForContextMenu(getListView());
 
 		getListView().setOnItemClickListener(new OnItemClickListener() {

--- a/app/src/main/java/org/connectbot/data/ColorStorage.java
+++ b/app/src/main/java/org/connectbot/data/ColorStorage.java
@@ -1,0 +1,31 @@
+/*
+ * ConnectBot: simple, powerful, open-source SSH client for Android
+ * Copyright 2015 Kenny Root, Jeffrey Sharkey
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.connectbot.data;
+
+/**
+ * Created by kroot on 9/11/15.
+ */
+public interface ColorStorage {
+	public int[] getColorsForScheme(int colorScheme);
+
+	public void setGlobalColor(int mCurrentColor, int value);
+
+	public int[] getDefaultColorsForScheme(int colorScheme);
+
+	public void setDefaultColorsForScheme(int mColorScheme, int mDefaultColor, int mDefaultColor1);
+}

--- a/app/src/main/java/org/connectbot/data/HostStorage.java
+++ b/app/src/main/java/org/connectbot/data/HostStorage.java
@@ -1,0 +1,89 @@
+/*
+ * ConnectBot: simple, powerful, open-source SSH client for Android
+ * Copyright 2015 Kenny Root, Jeffrey Sharkey
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.connectbot.data;
+
+import java.util.List;
+import java.util.Map;
+
+import org.connectbot.bean.HostBean;
+import org.connectbot.bean.PortForwardBean;
+
+import com.trilead.ssh2.KnownHosts;
+
+import android.support.annotation.VisibleForTesting;
+
+/**
+ * Interface that defines the operation used to interact with the storage layer.
+ */
+public interface HostStorage {
+	/**
+	 * Resets the database during testing.
+	 */
+	@VisibleForTesting
+	void resetDatabase();
+
+	/**
+	 * Finds the host that is represented by the given selection.
+	 * @param selection all fields to be considered
+	 * @return the matching host
+	 */
+	HostBean findHost(Map<String, String> selection);
+
+	/**
+	 * Deletes the given {@code host} from the storage layer.
+	 */
+	void deleteHost(HostBean host);
+
+	/**
+	 * Saves the given {@code host} to the storage layer.
+	 */
+	HostBean saveHost(HostBean host);
+
+	/**
+	 * Returns a list of all the hosts as a list of {@link HostBean}.
+	 * @param sortedByColor if hosts should be grouped by color.
+	 */
+	List<HostBean> getHosts(boolean sortedByColor);
+
+	/**
+	 * Updates the last connected time for {@code host}.
+	 */
+	void touchHost(HostBean host);
+
+	/**
+	 * Finds a {@link HostBean} based on the given {@code hostId}.
+	 */
+	HostBean findHostById(long hostId);
+
+	/**
+	 * Returns the list of known hosts.
+	 *
+	 * @see #saveKnownHost(String, int, String, byte[])
+	 */
+	KnownHosts getKnownHosts();
+
+	/**
+	 * Adds a known host to the database for later retrieval using {@link #getKnownHosts()}.
+	 */
+	void saveKnownHost(String hostname, int port, String serverHostKeyAlgorithm, byte[] serverHostKey);
+
+	/**
+	 * Return all port forwards for the given {@code host}.
+	 */
+	PortForwardBean[] getPortForwardsForHost(HostBean host);
+}

--- a/app/src/main/java/org/connectbot/data/HostStorage.java
+++ b/app/src/main/java/org/connectbot/data/HostStorage.java
@@ -85,5 +85,5 @@ public interface HostStorage {
 	/**
 	 * Return all port forwards for the given {@code host}.
 	 */
-	PortForwardBean[] getPortForwardsForHost(HostBean host);
+	List<PortForwardBean> getPortForwardsForHost(HostBean host);
 }

--- a/app/src/main/java/org/connectbot/service/BackupAgent.java
+++ b/app/src/main/java/org/connectbot/service/BackupAgent.java
@@ -17,19 +17,14 @@
 
 package org.connectbot.service;
 
-import java.io.IOException;
-
 import org.connectbot.util.HostDatabase;
 import org.connectbot.util.PreferenceConstants;
 import org.connectbot.util.PubkeyDatabase;
 
 import android.annotation.TargetApi;
 import android.app.backup.BackupAgentHelper;
-import android.app.backup.BackupDataInput;
-import android.app.backup.BackupDataOutput;
 import android.app.backup.FileBackupHelper;
 import android.app.backup.SharedPreferencesBackupHelper;
-import android.os.ParcelFileDescriptor;
 import android.util.Log;
 
 /**

--- a/app/src/main/java/org/connectbot/service/BackupAgent.java
+++ b/app/src/main/java/org/connectbot/service/BackupAgent.java
@@ -53,24 +53,4 @@ public class BackupAgent extends BackupAgentHelper {
 		addHelper(PubkeyDatabase.DB_NAME, pubkeys);
 
 	}
-
-	@Override
-	public void onBackup(ParcelFileDescriptor oldState, BackupDataOutput data,
-			ParcelFileDescriptor newState) throws IOException {
-		synchronized (HostDatabase.dbLock) {
-			super.onBackup(oldState, data, newState);
-		}
-	}
-
-	@Override
-	public void onRestore(BackupDataInput data, int appVersionCode,
-			ParcelFileDescriptor newState) throws IOException {
-		Log.d("ConnectBot.BackupAgent", "onRestore called");
-
-		synchronized (HostDatabase.dbLock) {
-			Log.d("ConnectBot.BackupAgent", "onRestore in-lock");
-
-			super.onRestore(data, appVersionCode, newState);
-		}
-	}
 }

--- a/app/src/main/java/org/connectbot/service/TerminalBridge.java
+++ b/app/src/main/java/org/connectbot/service/TerminalBridge.java
@@ -273,7 +273,8 @@ public class TerminalBridge implements VDUDisplay {
 		transport.setEmulation(emulation);
 
 		if (transport.canForwardPorts()) {
-			for (PortForwardBean portForward : manager.hostdb.getPortForwardsForHost(host))
+			HostDatabase hostDb = HostDatabase.get(manager);
+			for (PortForwardBean portForward : hostDb.getPortForwardsForHost(host))
 				transport.addPortForward(portForward);
 		}
 
@@ -533,7 +534,8 @@ public class TerminalBridge implements VDUDisplay {
 		}
 
 		host.setFontSize((int) sizeDp);
-		manager.hostdb.updateFontSize(host);
+		HostDatabase hostDb = HostDatabase.get(manager);
+		hostDb.updateFontSize(host);
 
 		forcedSize = false;
 	}
@@ -950,11 +952,12 @@ public class TerminalBridge implements VDUDisplay {
 	}
 
 	public final void resetColors() {
-		int[] defaults = manager.hostdb.getDefaultColorsForScheme(HostDatabase.DEFAULT_COLOR_SCHEME);
+		HostDatabase hostDb = HostDatabase.get(manager);
+		int[] defaults = hostDb.getDefaultColorsForScheme(HostDatabase.DEFAULT_COLOR_SCHEME);
 		defaultFg = defaults[0];
 		defaultBg = defaults[1];
 
-		color = manager.hostdb.getColorsForScheme(HostDatabase.DEFAULT_COLOR_SCHEME);
+		color = hostDb.getColorsForScheme(HostDatabase.DEFAULT_COLOR_SCHEME);
 	}
 
 	private static Pattern urlPattern = null;

--- a/app/src/main/java/org/connectbot/service/TerminalBridge.java
+++ b/app/src/main/java/org/connectbot/service/TerminalBridge.java
@@ -273,8 +273,7 @@ public class TerminalBridge implements VDUDisplay {
 		transport.setEmulation(emulation);
 
 		if (transport.canForwardPorts()) {
-			HostDatabase hostDb = HostDatabase.get(manager);
-			for (PortForwardBean portForward : hostDb.getPortForwardsForHost(host))
+			for (PortForwardBean portForward : manager.hostdb.getPortForwardsForHost(host))
 				transport.addPortForward(portForward);
 		}
 
@@ -534,8 +533,7 @@ public class TerminalBridge implements VDUDisplay {
 		}
 
 		host.setFontSize((int) sizeDp);
-		HostDatabase hostDb = HostDatabase.get(manager);
-		hostDb.updateFontSize(host);
+		manager.hostdb.updateFontSize(host);
 
 		forcedSize = false;
 	}
@@ -952,12 +950,11 @@ public class TerminalBridge implements VDUDisplay {
 	}
 
 	public final void resetColors() {
-		HostDatabase hostDb = HostDatabase.get(manager);
-		int[] defaults = hostDb.getDefaultColorsForScheme(HostDatabase.DEFAULT_COLOR_SCHEME);
+		int[] defaults = manager.hostdb.getDefaultColorsForScheme(HostDatabase.DEFAULT_COLOR_SCHEME);
 		defaultFg = defaults[0];
 		defaultBg = defaults[1];
 
-		color = hostDb.getColorsForScheme(HostDatabase.DEFAULT_COLOR_SCHEME);
+		color = manager.hostdb.getColorsForScheme(HostDatabase.DEFAULT_COLOR_SCHEME);
 	}
 
 	private static Pattern urlPattern = null;

--- a/app/src/main/java/org/connectbot/service/TerminalBridge.java
+++ b/app/src/main/java/org/connectbot/service/TerminalBridge.java
@@ -65,7 +65,7 @@ public class TerminalBridge implements VDUDisplay {
 	private final static int FONT_SIZE_STEP = 2;
 	private final float displayDensity;
 
-	public Integer[] color;
+	public int[] color;
 
 	public int defaultFg = HostDatabase.DEFAULT_FG_COLOR;
 	public int defaultBg = HostDatabase.DEFAULT_BG_COLOR;
@@ -950,11 +950,11 @@ public class TerminalBridge implements VDUDisplay {
 	}
 
 	public final void resetColors() {
-		int[] defaults = manager.hostdb.getDefaultColorsForScheme(HostDatabase.DEFAULT_COLOR_SCHEME);
+		int[] defaults = manager.colordb.getDefaultColorsForScheme(HostDatabase.DEFAULT_COLOR_SCHEME);
 		defaultFg = defaults[0];
 		defaultBg = defaults[1];
 
-		color = manager.hostdb.getColorsForScheme(HostDatabase.DEFAULT_COLOR_SCHEME);
+		color = manager.colordb.getColorsForScheme(HostDatabase.DEFAULT_COLOR_SCHEME);
 	}
 
 	private static Pattern urlPattern = null;

--- a/app/src/main/java/org/connectbot/service/TerminalBridge.java
+++ b/app/src/main/java/org/connectbot/service/TerminalBridge.java
@@ -533,7 +533,7 @@ public class TerminalBridge implements VDUDisplay {
 		}
 
 		host.setFontSize((int) sizeDp);
-		manager.hostdb.updateFontSize(host);
+		manager.hostdb.saveHost(host);
 
 		forcedSize = false;
 	}

--- a/app/src/main/java/org/connectbot/service/TerminalManager.java
+++ b/app/src/main/java/org/connectbot/service/TerminalManager.java
@@ -87,6 +87,9 @@ public class TerminalManager extends Service implements BridgeDisconnectedListen
 
 	public Resources res;
 
+	public HostDatabase hostdb;
+	public PubkeyDatabase pubkeydb;
+
 	protected SharedPreferences prefs;
 
 	final private IBinder binder = new TerminalBinder();
@@ -126,9 +129,11 @@ public class TerminalManager extends Service implements BridgeDisconnectedListen
 
 		pubkeyTimer = new Timer("pubkeyTimer", true);
 
+		hostdb = HostDatabase.get(this);
+		pubkeydb = PubkeyDatabase.get(this);
+
 		// load all marked pubkeys into memory
 		updateSavingKeys();
-		PubkeyDatabase pubkeydb = PubkeyDatabase.get(this);
 		List<PubkeyBean> pubkeys = pubkeydb.getAllStartPubkeys();
 
 		for (PubkeyBean pubkey : pubkeys) {
@@ -167,6 +172,9 @@ public class TerminalManager extends Service implements BridgeDisconnectedListen
 		Log.i(TAG, "Destroying service");
 
 		disconnectAll(true, false);
+
+		hostdb = null;
+		pubkeydb = null;
 
 		synchronized (this) {
 			if (idleTimer != null)
@@ -262,12 +270,10 @@ public class TerminalManager extends Service implements BridgeDisconnectedListen
 	 * format specified by an individual transport.
 	 */
 	public TerminalBridge openConnection(Uri uri) throws Exception {
-		HostDatabase hostdb = HostDatabase.get(this);
 		HostBean host = TransportFactory.findHost(hostdb, uri);
 
-		if (host == null) {
+		if (host == null)
 			host = TransportFactory.getTransport(uri.getScheme()).createHost(uri);
-		}
 
 		return openConnection(host);
 	}
@@ -277,7 +283,6 @@ public class TerminalManager extends Service implements BridgeDisconnectedListen
 	 * to {@link HostDatabase}.
 	 */
 	private void touchHost(HostBean host) {
-		HostDatabase hostdb = HostDatabase.get(this);
 		hostdb.touchHost(host);
 	}
 

--- a/app/src/main/java/org/connectbot/service/TerminalManager.java
+++ b/app/src/main/java/org/connectbot/service/TerminalManager.java
@@ -173,15 +173,8 @@ public class TerminalManager extends Service implements BridgeDisconnectedListen
 
 		disconnectAll(true, false);
 
-		if (hostdb != null) {
-			hostdb.close();
-			hostdb = null;
-		}
-
-		if (pubkeydb != null) {
-			pubkeydb.close();
-			pubkeydb = null;
-		}
+		hostdb = null;
+		pubkeydb = null;
 
 		synchronized (this) {
 			if (idleTimer != null)

--- a/app/src/main/java/org/connectbot/service/TerminalManager.java
+++ b/app/src/main/java/org/connectbot/service/TerminalManager.java
@@ -87,9 +87,6 @@ public class TerminalManager extends Service implements BridgeDisconnectedListen
 
 	public Resources res;
 
-	public HostDatabase hostdb;
-	public PubkeyDatabase pubkeydb;
-
 	protected SharedPreferences prefs;
 
 	final private IBinder binder = new TerminalBinder();
@@ -129,11 +126,9 @@ public class TerminalManager extends Service implements BridgeDisconnectedListen
 
 		pubkeyTimer = new Timer("pubkeyTimer", true);
 
-		hostdb = HostDatabase.get(this);
-		pubkeydb = PubkeyDatabase.get(this);
-
 		// load all marked pubkeys into memory
 		updateSavingKeys();
+		PubkeyDatabase pubkeydb = PubkeyDatabase.get(this);
 		List<PubkeyBean> pubkeys = pubkeydb.getAllStartPubkeys();
 
 		for (PubkeyBean pubkey : pubkeys) {
@@ -172,9 +167,6 @@ public class TerminalManager extends Service implements BridgeDisconnectedListen
 		Log.i(TAG, "Destroying service");
 
 		disconnectAll(true, false);
-
-		hostdb = null;
-		pubkeydb = null;
 
 		synchronized (this) {
 			if (idleTimer != null)
@@ -270,10 +262,12 @@ public class TerminalManager extends Service implements BridgeDisconnectedListen
 	 * format specified by an individual transport.
 	 */
 	public TerminalBridge openConnection(Uri uri) throws Exception {
+		HostDatabase hostdb = HostDatabase.get(this);
 		HostBean host = TransportFactory.findHost(hostdb, uri);
 
-		if (host == null)
+		if (host == null) {
 			host = TransportFactory.getTransport(uri.getScheme()).createHost(uri);
+		}
 
 		return openConnection(host);
 	}
@@ -283,6 +277,7 @@ public class TerminalManager extends Service implements BridgeDisconnectedListen
 	 * to {@link HostDatabase}.
 	 */
 	private void touchHost(HostBean host) {
+		HostDatabase hostdb = HostDatabase.get(this);
 		hostdb.touchHost(host);
 	}
 

--- a/app/src/main/java/org/connectbot/service/TerminalManager.java
+++ b/app/src/main/java/org/connectbot/service/TerminalManager.java
@@ -35,6 +35,8 @@ import java.util.TimerTask;
 import org.connectbot.R;
 import org.connectbot.bean.HostBean;
 import org.connectbot.bean.PubkeyBean;
+import org.connectbot.data.ColorStorage;
+import org.connectbot.data.HostStorage;
 import org.connectbot.transport.TransportFactory;
 import org.connectbot.util.HostDatabase;
 import org.connectbot.util.PreferenceConstants;
@@ -87,7 +89,8 @@ public class TerminalManager extends Service implements BridgeDisconnectedListen
 
 	public Resources res;
 
-	public HostDatabase hostdb;
+	public HostStorage hostdb;
+	public ColorStorage colordb;
 	public PubkeyDatabase pubkeydb;
 
 	protected SharedPreferences prefs;
@@ -130,6 +133,7 @@ public class TerminalManager extends Service implements BridgeDisconnectedListen
 		pubkeyTimer = new Timer("pubkeyTimer", true);
 
 		hostdb = HostDatabase.get(this);
+		colordb = HostDatabase.get(this);
 		pubkeydb = PubkeyDatabase.get(this);
 
 		// load all marked pubkeys into memory

--- a/app/src/main/java/org/connectbot/service/TerminalManager.java
+++ b/app/src/main/java/org/connectbot/service/TerminalManager.java
@@ -129,8 +129,8 @@ public class TerminalManager extends Service implements BridgeDisconnectedListen
 
 		pubkeyTimer = new Timer("pubkeyTimer", true);
 
-		hostdb = new HostDatabase(this);
-		pubkeydb = new PubkeyDatabase(this);
+		hostdb = HostDatabase.get(this);
+		pubkeydb = PubkeyDatabase.get(this);
 
 		// load all marked pubkeys into memory
 		updateSavingKeys();

--- a/app/src/main/java/org/connectbot/transport/SSH.java
+++ b/app/src/main/java/org/connectbot/transport/SSH.java
@@ -141,8 +141,7 @@ public class SSH extends AbsTransport implements ConnectionMonitor, InteractiveC
 				String serverHostKeyAlgorithm, byte[] serverHostKey) throws IOException {
 
 			// read in all known hosts from hostdb
-			HostDatabase hostDb = HostDatabase.get(manager);
-			KnownHosts hosts = hostDb.getKnownHosts();
+			KnownHosts hosts = manager.hostdb.getKnownHosts();
 			Boolean result;
 
 			String matchName = String.format(Locale.US, "%s:%d", hostname, port);
@@ -173,7 +172,7 @@ public class SSH extends AbsTransport implements ConnectionMonitor, InteractiveC
 				if (result == null) return false;
 				if (result.booleanValue()) {
 					// save this key in known database
-					hostDb.saveKnownHost(hostname, port, serverHostKeyAlgorithm, serverHostKey);
+					manager.hostdb.saveKnownHost(hostname, port, serverHostKeyAlgorithm, serverHostKey);
 				}
 				return result.booleanValue();
 
@@ -196,7 +195,7 @@ public class SSH extends AbsTransport implements ConnectionMonitor, InteractiveC
 				result = bridge.promptHelper.requestBooleanPrompt(null, manager.res.getString(R.string.prompt_continue_connecting));
 				if (result != null && result.booleanValue()) {
 					// save this key in known database
-					hostDb.saveKnownHost(hostname, port, serverHostKeyAlgorithm, serverHostKey);
+					manager.hostdb.saveKnownHost(hostname, port, serverHostKeyAlgorithm, serverHostKey);
 					return true;
 				} else {
 					return false;
@@ -250,16 +249,13 @@ public class SSH extends AbsTransport implements ConnectionMonitor, InteractiveC
 				} else {
 					bridge.outputLine(manager.res.getString(R.string.terminal_auth_pubkey_specific));
 					// use a specific key for this host, as requested
-					PubkeyDatabase pubkeyDb = PubkeyDatabase.get(manager);
-					PubkeyBean pubkey = pubkeyDb.findPubkeyById(pubkeyId);
+					PubkeyBean pubkey = manager.pubkeydb.findPubkeyById(pubkeyId);
 
-					if (pubkey == null) {
+					if (pubkey == null)
 						bridge.outputLine(manager.res.getString(R.string.terminal_auth_pubkey_invalid));
-					} else {
-						if (tryPublicKey(pubkey)) {
+					else
+						if (tryPublicKey(pubkey))
 							finishConnection();
-						}
-					}
 				}
 
 				pubkeysExhausted = true;
@@ -297,7 +293,7 @@ public class SSH extends AbsTransport implements ConnectionMonitor, InteractiveC
 
 	/**
 	 * Attempt connection with database row pointed to by cursor.
-	 * @param pubkey
+	 * @param cursor
 	 * @return true for successful authentication
 	 * @throws NoSuchAlgorithmException
 	 * @throws InvalidKeySpecException

--- a/app/src/main/java/org/connectbot/transport/SSH.java
+++ b/app/src/main/java/org/connectbot/transport/SSH.java
@@ -292,9 +292,8 @@ public class SSH extends AbsTransport implements ConnectionMonitor, InteractiveC
 	}
 
 	/**
-	 * Attempt connection with database row pointed to by cursor.
-	 * @param cursor
-	 * @return true for successful authentication
+	 * Attempt connection with given {@code pubkey}.
+	 * @return {@code true} for successful authentication
 	 * @throws NoSuchAlgorithmException
 	 * @throws InvalidKeySpecException
 	 * @throws IOException

--- a/app/src/main/java/org/connectbot/transport/SSH.java
+++ b/app/src/main/java/org/connectbot/transport/SSH.java
@@ -141,7 +141,8 @@ public class SSH extends AbsTransport implements ConnectionMonitor, InteractiveC
 				String serverHostKeyAlgorithm, byte[] serverHostKey) throws IOException {
 
 			// read in all known hosts from hostdb
-			KnownHosts hosts = manager.hostdb.getKnownHosts();
+			HostDatabase hostDb = HostDatabase.get(manager);
+			KnownHosts hosts = hostDb.getKnownHosts();
 			Boolean result;
 
 			String matchName = String.format(Locale.US, "%s:%d", hostname, port);
@@ -172,7 +173,7 @@ public class SSH extends AbsTransport implements ConnectionMonitor, InteractiveC
 				if (result == null) return false;
 				if (result.booleanValue()) {
 					// save this key in known database
-					manager.hostdb.saveKnownHost(hostname, port, serverHostKeyAlgorithm, serverHostKey);
+					hostDb.saveKnownHost(hostname, port, serverHostKeyAlgorithm, serverHostKey);
 				}
 				return result.booleanValue();
 
@@ -195,7 +196,7 @@ public class SSH extends AbsTransport implements ConnectionMonitor, InteractiveC
 				result = bridge.promptHelper.requestBooleanPrompt(null, manager.res.getString(R.string.prompt_continue_connecting));
 				if (result != null && result.booleanValue()) {
 					// save this key in known database
-					manager.hostdb.saveKnownHost(hostname, port, serverHostKeyAlgorithm, serverHostKey);
+					hostDb.saveKnownHost(hostname, port, serverHostKeyAlgorithm, serverHostKey);
 					return true;
 				} else {
 					return false;
@@ -249,13 +250,16 @@ public class SSH extends AbsTransport implements ConnectionMonitor, InteractiveC
 				} else {
 					bridge.outputLine(manager.res.getString(R.string.terminal_auth_pubkey_specific));
 					// use a specific key for this host, as requested
-					PubkeyBean pubkey = manager.pubkeydb.findPubkeyById(pubkeyId);
+					PubkeyDatabase pubkeyDb = PubkeyDatabase.get(manager);
+					PubkeyBean pubkey = pubkeyDb.findPubkeyById(pubkeyId);
 
-					if (pubkey == null)
+					if (pubkey == null) {
 						bridge.outputLine(manager.res.getString(R.string.terminal_auth_pubkey_invalid));
-					else
-						if (tryPublicKey(pubkey))
+					} else {
+						if (tryPublicKey(pubkey)) {
 							finishConnection();
+						}
+					}
 				}
 
 				pubkeysExhausted = true;
@@ -293,7 +297,7 @@ public class SSH extends AbsTransport implements ConnectionMonitor, InteractiveC
 
 	/**
 	 * Attempt connection with database row pointed to by cursor.
-	 * @param cursor
+	 * @param pubkey
 	 * @return true for successful authentication
 	 * @throws NoSuchAlgorithmException
 	 * @throws InvalidKeySpecException

--- a/app/src/main/java/org/connectbot/transport/TransportFactory.java
+++ b/app/src/main/java/org/connectbot/transport/TransportFactory.java
@@ -22,7 +22,6 @@ import java.util.Map;
 
 import org.connectbot.bean.HostBean;
 import org.connectbot.data.HostStorage;
-import org.connectbot.util.HostDatabase;
 
 import android.content.Context;
 import android.net.Uri;

--- a/app/src/main/java/org/connectbot/transport/TransportFactory.java
+++ b/app/src/main/java/org/connectbot/transport/TransportFactory.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.connectbot.bean.HostBean;
+import org.connectbot.data.HostStorage;
 import org.connectbot.util.HostDatabase;
 
 import android.content.Context;
@@ -112,10 +113,9 @@ public class TransportFactory {
 	/**
 	 * @param hostdb Handle to HostDatabase
 	 * @param uri URI to target server
-	 * @param host HostBean in which to put the results
 	 * @return true when host was found
 	 */
-	public static HostBean findHost(HostDatabase hostdb, Uri uri) {
+	public static HostBean findHost(HostStorage hostdb, Uri uri) {
 		AbsTransport transport = getTransport(uri.getScheme());
 
 		Map<String, String> selection = new HashMap<String, String>();

--- a/app/src/main/java/org/connectbot/util/Colors.java
+++ b/app/src/main/java/org/connectbot/util/Colors.java
@@ -22,7 +22,7 @@ package org.connectbot.util;
  *
  */
 public class Colors {
-	public final static Integer[] defaults = new Integer[] {
+	public final static int[] defaults = new int[] {
 			0xff000000, // black
 			0xffcc0000, // red
 			0xff00cc00, // green

--- a/app/src/main/java/org/connectbot/util/HostDatabase.java
+++ b/app/src/main/java/org/connectbot/util/HostDatabase.java
@@ -343,14 +343,18 @@ public class HostDatabase extends RobustSQLiteOpenHelper implements HostStorage,
 	}
 
 	/**
-	 * Create a new host using the given parameters.
+	 * Create a new or update an existing {@code host}.
 	 */
 	public HostBean saveHost(HostBean host) {
-		long id;
+		long id = host.getId();
 
 		mDb.beginTransaction();
 		try {
-			id = mDb.insert(TABLE_HOSTS, null, host.getValues());
+			if (id == -1) {
+				id = mDb.insert(TABLE_HOSTS, null, host.getValues());
+			} else {
+				mDb.update(TABLE_HOSTS, host.getValues(), "_id = ?", new String[] {String.valueOf(id)});
+			}
 			mDb.setTransactionSuccessful();
 		} finally {
 			mDb.endTransaction();
@@ -359,29 +363,6 @@ public class HostDatabase extends RobustSQLiteOpenHelper implements HostStorage,
 		host.setId(id);
 
 		return host;
-	}
-
-	/**
-	 * Update a field in a host record.
-	 */
-	public boolean updateFontSize(HostBean host) {
-		long id = host.getId();
-		if (id < 0)
-			return false;
-
-		ContentValues updates = new ContentValues();
-		updates.put(FIELD_HOST_FONTSIZE, host.getFontSize());
-
-		mDb.beginTransaction();
-		try {
-			mDb.update(TABLE_HOSTS, updates, "_id = ?",
-					new String[] {String.valueOf(id)});
-			mDb.setTransactionSuccessful();
-		} finally {
-			mDb.endTransaction();
-		}
-
-		return true;
 	}
 
 	/**

--- a/app/src/main/java/org/connectbot/util/HostDatabase.java
+++ b/app/src/main/java/org/connectbot/util/HostDatabase.java
@@ -159,7 +159,7 @@ public class HostDatabase extends RobustSQLiteOpenHelper {
 		}
 	}
 
-	public HostDatabase(Context context) {
+	private HostDatabase(Context context) {
 		super(context, DB_NAME, null, DB_VERSION);
 
 		this.displayDensity = context.getResources().getDisplayMetrics().density;

--- a/app/src/main/java/org/connectbot/util/HostDatabase.java
+++ b/app/src/main/java/org/connectbot/util/HostDatabase.java
@@ -148,6 +148,8 @@ public class HostDatabase extends RobustSQLiteOpenHelper {
 
 	private static HostDatabase sInstance;
 
+	private final SQLiteDatabase mDb;
+
 	public static HostDatabase get(Context context) {
 		synchronized (sInstanceLock) {
 			if (sInstance != null) {
@@ -167,6 +169,7 @@ public class HostDatabase extends RobustSQLiteOpenHelper {
 		super(context, dbName, null, DB_VERSION);
 
 		this.displayDensity = context.getResources().getDisplayMetrics().density;
+		mDb = getWritableDatabase();
 	}
 
 	@Override
@@ -315,13 +318,12 @@ public class HostDatabase extends RobustSQLiteOpenHelper {
 		values.put(FIELD_HOST_LASTCONNECT, now);
 
 		synchronized (dbLock) {
-			SQLiteDatabase db = this.getWritableDatabase();
-			db.beginTransaction();
+			mDb.beginTransaction();
 			try {
-				db.update(TABLE_HOSTS, values, "_id = ?", new String[] {String.valueOf(host.getId())});
-				db.setTransactionSuccessful();
+				mDb.update(TABLE_HOSTS, values, "_id = ?", new String[] {String.valueOf(host.getId())});
+				mDb.setTransactionSuccessful();
 			} finally {
-				db.endTransaction();
+				mDb.endTransaction();
 			}
 		}
 	}
@@ -333,13 +335,12 @@ public class HostDatabase extends RobustSQLiteOpenHelper {
 		long id;
 
 		synchronized (dbLock) {
-			SQLiteDatabase db = this.getWritableDatabase();
-			db.beginTransaction();
+			mDb.beginTransaction();
 			try {
-				id = db.insert(TABLE_HOSTS, null, host.getValues());
-				db.setTransactionSuccessful();
+				id = mDb.insert(TABLE_HOSTS, null, host.getValues());
+				mDb.setTransactionSuccessful();
 			} finally {
-				db.endTransaction();
+				mDb.endTransaction();
 			}
 		}
 
@@ -360,14 +361,13 @@ public class HostDatabase extends RobustSQLiteOpenHelper {
 		updates.put(FIELD_HOST_FONTSIZE, host.getFontSize());
 
 		synchronized (dbLock) {
-			SQLiteDatabase db = getWritableDatabase();
-			db.beginTransaction();
+			mDb.beginTransaction();
 			try {
-				db.update(TABLE_HOSTS, updates, "_id = ?",
+				mDb.update(TABLE_HOSTS, updates, "_id = ?",
 						new String[] {String.valueOf(id)});
-				db.setTransactionSuccessful();
+				mDb.setTransactionSuccessful();
 			} finally {
-				db.endTransaction();
+				mDb.endTransaction();
 			}
 
 		}
@@ -383,13 +383,12 @@ public class HostDatabase extends RobustSQLiteOpenHelper {
 			return;
 
 		synchronized (dbLock) {
-			SQLiteDatabase db = this.getWritableDatabase();
-			db.beginTransaction();
+			mDb.beginTransaction();
 			try {
-				db.delete(TABLE_HOSTS, "_id = ?", new String[] {String.valueOf(host.getId())});
-				db.setTransactionSuccessful();
+				mDb.delete(TABLE_HOSTS, "_id = ?", new String[] {String.valueOf(host.getId())});
+				mDb.setTransactionSuccessful();
 			} finally {
-				db.endTransaction();
+				mDb.endTransaction();
 			}
 		}
 	}
@@ -403,9 +402,7 @@ public class HostDatabase extends RobustSQLiteOpenHelper {
 		List<HostBean> hosts;
 
 		synchronized (dbLock) {
-			SQLiteDatabase db = this.getReadableDatabase();
-
-			Cursor c = db.query(TABLE_HOSTS, null, null, null, null, null, sortField + " ASC");
+			Cursor c = mDb.query(TABLE_HOSTS, null, null, null, null, null, sortField + " ASC");
 
 			hosts = createHostBeans(c);
 
@@ -518,9 +515,7 @@ public class HostDatabase extends RobustSQLiteOpenHelper {
 		HostBean host;
 
 		synchronized (dbLock) {
-			SQLiteDatabase db = getReadableDatabase();
-
-			Cursor c = db.query(TABLE_HOSTS, null,
+			Cursor c = mDb.query(TABLE_HOSTS, null,
 					selectionBuilder.toString(),
 					selectionValues,
 					null, null, null);
@@ -539,9 +534,7 @@ public class HostDatabase extends RobustSQLiteOpenHelper {
 		HostBean host;
 
 		synchronized (dbLock) {
-			SQLiteDatabase db = getReadableDatabase();
-
-			Cursor c = db.query(TABLE_HOSTS, null,
+			Cursor c = mDb.query(TABLE_HOSTS, null,
 					"_id = ?", new String[] { String.valueOf(hostId) },
 					null, null, null);
 
@@ -564,9 +557,7 @@ public class HostDatabase extends RobustSQLiteOpenHelper {
 		values.put(FIELD_HOST_HOSTKEY, hostkey);
 
 		synchronized (dbLock) {
-			SQLiteDatabase db = getReadableDatabase();
-
-			db.update(TABLE_HOSTS, values,
+			mDb.update(TABLE_HOSTS, values,
 					FIELD_HOST_HOSTNAME + " = ? AND " + FIELD_HOST_PORT + " = ?",
 					new String[] { hostname, String.valueOf(port) });
 			Log.d(TAG, String.format("Finished saving hostkey information for '%s'", hostname));
@@ -581,8 +572,7 @@ public class HostDatabase extends RobustSQLiteOpenHelper {
 		KnownHosts known = new KnownHosts();
 
 		synchronized (dbLock) {
-			SQLiteDatabase db = this.getReadableDatabase();
-			Cursor c = db.query(TABLE_HOSTS, new String[] { FIELD_HOST_HOSTNAME,
+			Cursor c = mDb.query(TABLE_HOSTS, new String[] { FIELD_HOST_HOSTNAME,
 					FIELD_HOST_PORT, FIELD_HOST_HOSTKEYALGO, FIELD_HOST_HOSTKEY },
 					null, null, null, null, null);
 
@@ -626,13 +616,12 @@ public class HostDatabase extends RobustSQLiteOpenHelper {
 		values.put(FIELD_HOST_PUBKEYID, PUBKEYID_ANY);
 
 		synchronized (dbLock) {
-			SQLiteDatabase db = this.getWritableDatabase();
-			db.beginTransaction();
+			mDb.beginTransaction();
 			try {
-				db.update(TABLE_HOSTS, values, FIELD_HOST_PUBKEYID + " = ?", new String[] {String.valueOf(pubkeyId)});
-				db.setTransactionSuccessful();
+				mDb.update(TABLE_HOSTS, values, FIELD_HOST_PUBKEYID + " = ?", new String[] {String.valueOf(pubkeyId)});
+				mDb.setTransactionSuccessful();
 			} finally {
-				db.endTransaction();
+				mDb.endTransaction();
 			}
 		}
 
@@ -655,9 +644,7 @@ public class HostDatabase extends RobustSQLiteOpenHelper {
 		}
 
 		synchronized (dbLock) {
-			SQLiteDatabase db = this.getReadableDatabase();
-
-			Cursor c = db.query(TABLE_PORTFORWARDS, new String[] {
+			Cursor c = mDb.query(TABLE_PORTFORWARDS, new String[] {
 					"_id", FIELD_PORTFORWARD_NICKNAME, FIELD_PORTFORWARD_TYPE, FIELD_PORTFORWARD_SOURCEPORT,
 					FIELD_PORTFORWARD_DESTADDR, FIELD_PORTFORWARD_DESTPORT },
 					FIELD_PORTFORWARD_HOSTID + " = ?", new String[] { String.valueOf(host.getId()) },
@@ -688,25 +675,24 @@ public class HostDatabase extends RobustSQLiteOpenHelper {
 	 */
 	public boolean savePortForward(PortForwardBean pfb) {
 		synchronized (dbLock) {
-			SQLiteDatabase db = getWritableDatabase();
-			db.beginTransaction();
+			mDb.beginTransaction();
 			try {
 				if (pfb.getId() < 0) {
-					long addedId = db.insert(TABLE_PORTFORWARDS, null, pfb.getValues());
+					long addedId = mDb.insert(TABLE_PORTFORWARDS, null, pfb.getValues());
 					if (addedId == -1) {
 						return false;
 					}
 					pfb.setId(addedId);
 				} else {
-					if (db.update(TABLE_PORTFORWARDS, pfb.getValues(), "_id = ?", new String[] {String.valueOf(pfb.getId())}) <= 0) {
+					if (mDb.update(TABLE_PORTFORWARDS, pfb.getValues(), "_id = ?", new String[] {String.valueOf(pfb.getId())}) <= 0) {
 						return false;
 					}
 				}
 
-				db.setTransactionSuccessful();
+				mDb.setTransactionSuccessful();
 				return true;
 			} finally {
-				db.endTransaction();
+				mDb.endTransaction();
 			}
 		}
 	}
@@ -720,13 +706,12 @@ public class HostDatabase extends RobustSQLiteOpenHelper {
 			return;
 
 		synchronized (dbLock) {
-			SQLiteDatabase db = this.getWritableDatabase();
-			db.beginTransaction();
+			mDb.beginTransaction();
 			try {
-				db.delete(TABLE_PORTFORWARDS, "_id = ?", new String[] {String.valueOf(pfb.getId())});
-				db.setTransactionSuccessful();
+				mDb.delete(TABLE_PORTFORWARDS, "_id = ?", new String[] {String.valueOf(pfb.getId())});
+				mDb.setTransactionSuccessful();
 			} finally {
-				db.endTransaction();
+				mDb.endTransaction();
 			}
 		}
 	}
@@ -735,9 +720,7 @@ public class HostDatabase extends RobustSQLiteOpenHelper {
 		Integer[] colors = Colors.defaults.clone();
 
 		synchronized (dbLock) {
-			SQLiteDatabase db = getReadableDatabase();
-
-			Cursor c = db.query(TABLE_COLORS, new String[] {
+			Cursor c = mDb.query(TABLE_COLORS, new String[] {
 					FIELD_COLOR_NUMBER, FIELD_COLOR_VALUE },
 					FIELD_COLOR_SCHEME + " = ?",
 					new String[] { String.valueOf(scheme) },
@@ -760,14 +743,13 @@ public class HostDatabase extends RobustSQLiteOpenHelper {
 
 		if (value == Colors.defaults[number]) {
 			synchronized (dbLock) {
-				db = getWritableDatabase();
-				db.beginTransaction();
+				mDb.beginTransaction();
 				try {
-					db.delete(TABLE_COLORS,
+					mDb.delete(TABLE_COLORS,
 							WHERE_SCHEME_AND_COLOR, whereArgs);
-					db.setTransactionSuccessful();
+					mDb.setTransactionSuccessful();
 				} finally {
-					db.endTransaction();
+					mDb.endTransaction();
 				}
 			}
 		} else {
@@ -775,20 +757,19 @@ public class HostDatabase extends RobustSQLiteOpenHelper {
 			values.put(FIELD_COLOR_VALUE, value);
 
 			synchronized (dbLock) {
-				db = getWritableDatabase();
-				db.beginTransaction();
+				mDb.beginTransaction();
 				try {
-					final int rowsAffected = db.update(TABLE_COLORS, values,
+					final int rowsAffected = mDb.update(TABLE_COLORS, values,
 							WHERE_SCHEME_AND_COLOR, whereArgs);
 
 					if (rowsAffected == 0) {
 						values.put(FIELD_COLOR_SCHEME, scheme);
 						values.put(FIELD_COLOR_NUMBER, number);
-						db.insert(TABLE_COLORS, null, values);
+						mDb.insert(TABLE_COLORS, null, values);
 					}
-					db.setTransactionSuccessful();
+					mDb.setTransactionSuccessful();
 				} finally {
-					db.endTransaction();
+					mDb.endTransaction();
 				}
 			}
 		}
@@ -802,9 +783,7 @@ public class HostDatabase extends RobustSQLiteOpenHelper {
 		int[] colors = new int[] { DEFAULT_FG_COLOR, DEFAULT_BG_COLOR };
 
 		synchronized (dbLock) {
-			SQLiteDatabase db = getReadableDatabase();
-
-			Cursor c = db.query(TABLE_COLOR_DEFAULTS,
+			Cursor c = mDb.query(TABLE_COLOR_DEFAULTS,
 					new String[] { FIELD_COLOR_FG, FIELD_COLOR_BG },
 					FIELD_COLOR_SCHEME + " = ?",
 					new String[] { String.valueOf(scheme) },
@@ -839,19 +818,18 @@ public class HostDatabase extends RobustSQLiteOpenHelper {
 		values.put(FIELD_COLOR_BG, bg);
 
 		synchronized (dbLock) {
-			db = getWritableDatabase();
-			db.beginTransaction();
+			mDb.beginTransaction();
 			try {
-				int rowsAffected = db.update(TABLE_COLOR_DEFAULTS, values,
+				int rowsAffected = mDb.update(TABLE_COLOR_DEFAULTS, values,
 						schemeWhere, whereArgs);
 
 				if (rowsAffected == 0) {
 					values.put(FIELD_COLOR_SCHEME, scheme);
-					db.insert(TABLE_COLOR_DEFAULTS, null, values);
+					mDb.insert(TABLE_COLOR_DEFAULTS, null, values);
 				}
-				db.setTransactionSuccessful();
+				mDb.setTransactionSuccessful();
 			} finally {
-				db.endTransaction();
+				mDb.endTransaction();
 			}
 		}
 	}

--- a/app/src/main/java/org/connectbot/util/HostDatabase.java
+++ b/app/src/main/java/org/connectbot/util/HostDatabase.java
@@ -160,7 +160,11 @@ public class HostDatabase extends RobustSQLiteOpenHelper {
 	}
 
 	private HostDatabase(Context context) {
-		super(context, DB_NAME, null, DB_VERSION);
+		this(context, DB_NAME);
+	}
+
+	private HostDatabase(Context context, String dbName) {
+		super(context, dbName, null, DB_VERSION);
 
 		this.displayDensity = context.getResources().getDisplayMetrics().density;
 	}
@@ -222,13 +226,10 @@ public class HostDatabase extends RobustSQLiteOpenHelper {
 	}
 
 	@VisibleForTesting
-	public void resetDatabase() {
-		SQLiteDatabase db = getWritableDatabase();
-		db.execSQL("DROP TABLE IF EXISTS " + TABLE_HOSTS);
-		db.execSQL("DROP TABLE IF EXISTS " + TABLE_PORTFORWARDS);
-		db.execSQL("DROP TABLE IF EXISTS " + TABLE_COLORS);
-		db.execSQL("DROP TABLE IF EXISTS " + TABLE_COLOR_DEFAULTS);
-		createTables(db);
+	public static void resetInMemoryInstance(Context context) {
+		synchronized (sInstanceLock) {
+			sInstance = new HostDatabase(context, null);
+		}
 	}
 
 	@Override

--- a/app/src/main/java/org/connectbot/util/HostDatabase.java
+++ b/app/src/main/java/org/connectbot/util/HostDatabase.java
@@ -227,10 +227,26 @@ public class HostDatabase extends RobustSQLiteOpenHelper {
 	}
 
 	@VisibleForTesting
-	public static void resetInMemoryInstance(Context context) {
-		synchronized (sInstanceLock) {
-			sInstance = new HostDatabase(context, null);
+	public void resetDatabase() {
+		try {
+			mDb.beginTransaction();
+
+			mDb.execSQL("DROP TABLE IF EXISTS " + TABLE_HOSTS);
+			mDb.execSQL("DROP TABLE IF EXISTS " + TABLE_PORTFORWARDS);
+			mDb.execSQL("DROP TABLE IF EXISTS " + TABLE_COLORS);
+			mDb.execSQL("DROP TABLE IF EXISTS " + TABLE_COLOR_DEFAULTS);
+
+			createTables(mDb);
+
+			mDb.setTransactionSuccessful();
+		} finally {
+			mDb.endTransaction();
 		}
+	}
+
+	@VisibleForTesting
+	public static void resetInMemoryInstance(Context context) {
+		get(context).resetDatabase();
 	}
 
 	@Override

--- a/app/src/main/java/org/connectbot/util/HostDatabase.java
+++ b/app/src/main/java/org/connectbot/util/HostDatabase.java
@@ -148,8 +148,6 @@ public class HostDatabase extends RobustSQLiteOpenHelper {
 		super(context, DB_NAME, null, DB_VERSION);
 
 		this.displayDensity = context.getResources().getDisplayMetrics().density;
-
-		getWritableDatabase().close();
 	}
 
 	@Override
@@ -216,7 +214,6 @@ public class HostDatabase extends RobustSQLiteOpenHelper {
 		db.execSQL("DROP TABLE IF EXISTS " + TABLE_COLORS);
 		db.execSQL("DROP TABLE IF EXISTS " + TABLE_COLOR_DEFAULTS);
 		createTables(db);
-		db.close();
 	}
 
 	@Override

--- a/app/src/main/java/org/connectbot/util/HostDatabase.java
+++ b/app/src/main/java/org/connectbot/util/HostDatabase.java
@@ -26,6 +26,8 @@ import java.util.Map.Entry;
 
 import org.connectbot.bean.HostBean;
 import org.connectbot.bean.PortForwardBean;
+import org.connectbot.data.ColorStorage;
+import org.connectbot.data.HostStorage;
 
 import android.content.ContentValues;
 import android.content.Context;
@@ -43,7 +45,7 @@ import com.trilead.ssh2.KnownHosts;
  *
  * @author jsharkey
  */
-public class HostDatabase extends RobustSQLiteOpenHelper {
+public class HostDatabase extends RobustSQLiteOpenHelper implements HostStorage, ColorStorage {
 
 	public final static String TAG = "CB.HostDatabase";
 

--- a/app/src/main/java/org/connectbot/util/HostDatabase.java
+++ b/app/src/main/java/org/connectbot/util/HostDatabase.java
@@ -144,6 +144,21 @@ public class HostDatabase extends RobustSQLiteOpenHelper {
 	/** Used during upgrades from DB version 23 to 24. */
 	private final float displayDensity;
 
+	private static final Object sInstanceLock = new Object();
+
+	private static HostDatabase sInstance;
+
+	public static HostDatabase get(Context context) {
+		synchronized (sInstanceLock) {
+			if (sInstance != null) {
+				return sInstance;
+			}
+
+			sInstance = new HostDatabase(context.getApplicationContext());
+			return sInstance;
+		}
+	}
+
 	public HostDatabase(Context context) {
 		super(context, DB_NAME, null, DB_VERSION);
 

--- a/app/src/main/java/org/connectbot/util/HostDatabase.java
+++ b/app/src/main/java/org/connectbot/util/HostDatabase.java
@@ -699,8 +699,8 @@ public class HostDatabase extends RobustSQLiteOpenHelper {
 		}
 	}
 
-	public Integer[] getColorsForScheme(int scheme) {
-		Integer[] colors = Colors.defaults.clone();
+	public int[] getColorsForScheme(int scheme) {
+		int[] colors = Colors.defaults.clone();
 
 		Cursor c = mDb.query(TABLE_COLORS, new String[] {
 						FIELD_COLOR_NUMBER, FIELD_COLOR_VALUE},

--- a/app/src/main/java/org/connectbot/util/HostDatabase.java
+++ b/app/src/main/java/org/connectbot/util/HostDatabase.java
@@ -501,7 +501,6 @@ public class HostDatabase extends RobustSQLiteOpenHelper {
 
 		String selectionValues[] = new String[selectionValuesList.size()];
 		selectionValuesList.toArray(selectionValues);
-		selectionValuesList = null;
 
 		HostBean host;
 

--- a/app/src/main/java/org/connectbot/util/HostDatabase.java
+++ b/app/src/main/java/org/connectbot/util/HostDatabase.java
@@ -718,6 +718,8 @@ public class HostDatabase extends RobustSQLiteOpenHelper {
 	}
 
 	public void setColorForScheme(int scheme, int number, int value) {
+		final SQLiteDatabase db;
+
 		final String[] whereArgs = new String[] { String.valueOf(scheme), String.valueOf(number) };
 
 		if (value == Colors.defaults[number]) {

--- a/app/src/main/java/org/connectbot/util/HostDatabase.java
+++ b/app/src/main/java/org/connectbot/util/HostDatabase.java
@@ -702,8 +702,6 @@ public class HostDatabase extends RobustSQLiteOpenHelper {
 	}
 
 	public void setColorForScheme(int scheme, int number, int value) {
-		final SQLiteDatabase db;
-
 		final String[] whereArgs = new String[] { String.valueOf(scheme), String.valueOf(number) };
 
 		if (value == Colors.defaults[number]) {

--- a/app/src/main/java/org/connectbot/util/PubkeyDatabase.java
+++ b/app/src/main/java/org/connectbot/util/PubkeyDatabase.java
@@ -111,18 +111,6 @@ public class PubkeyDatabase extends RobustSQLiteOpenHelper {
 		}
 	}
 
-	/**
-	 * Return a cursor that contains information about all known hosts.
-	 */
-	/*
-	public Cursor allPubkeys() {
-		SQLiteDatabase db = this.getReadableDatabase();
-		return db.query(TABLE_PUBKEYS, new String[] { "_id",
-				FIELD_PUBKEY_NICKNAME, FIELD_PUBKEY_TYPE, FIELD_PUBKEY_PRIVATE,
-				FIELD_PUBKEY_PUBLIC, FIELD_PUBKEY_ENCRYPTED, FIELD_PUBKEY_STARTUP },
-				null, null, null, null, null);
-	}*/
-
 	public List<PubkeyBean> allPubkeys() {
 		return getPubkeys(null, null);
 	}
@@ -250,53 +238,6 @@ public class PubkeyDatabase extends RobustSQLiteOpenHelper {
 
 		return nickname;
 	}
-
-/*
-	public void setOnStart(long id, boolean onStart) {
-
-		SQLiteDatabase db = this.getWritableDatabase();
-
-		ContentValues values = new ContentValues();
-		values.put(FIELD_PUBKEY_STARTUP, onStart ? 1 : 0);
-
-		db.update(TABLE_PUBKEYS, values, "_id = ?", new String[] { Long.toString(id) });
-
-	}
-
-	public boolean changePassword(long id, String oldPassword, String newPassword) throws NoSuchAlgorithmException, NoSuchPaddingException, IllegalBlockSizeException, InvalidKeyException, BadPaddingException {
-		SQLiteDatabase db = this.getWritableDatabase();
-
-		Cursor c = db.query(TABLE_PUBKEYS, new String[] { FIELD_PUBKEY_TYPE,
-				FIELD_PUBKEY_PRIVATE, FIELD_PUBKEY_ENCRYPTED },
-				"_id = ?", new String[] { String.valueOf(id) },
-				null, null, null);
-
-		if (!c.moveToFirst())
-			return false;
-
-		String keyType = c.getString(0);
-		byte[] encPriv = c.getBlob(1);
-		c.close();
-
-		PrivateKey priv;
-		try {
-			priv = PubkeyUtils.decodePrivate(encPriv, keyType, oldPassword);
-		} catch (InvalidKeyException e) {
-			return false;
-		} catch (BadPaddingException e) {
-			return false;
-		} catch (InvalidKeySpecException e) {
-			return false;
-		}
-
-		ContentValues values = new ContentValues();
-		values.put(FIELD_PUBKEY_PRIVATE, PubkeyUtils.getEncodedPrivate(priv, newPassword));
-		values.put(FIELD_PUBKEY_ENCRYPTED, newPassword.length() > 0 ? 1 : 0);
-		db.update(TABLE_PUBKEYS, values, "_id = ?", new String[] { String.valueOf(id) });
-
-		return true;
-	}
-	*/
 
 	/**
 	 * @param pubkey

--- a/app/src/main/java/org/connectbot/util/PubkeyDatabase.java
+++ b/app/src/main/java/org/connectbot/util/PubkeyDatabase.java
@@ -61,6 +61,22 @@ public class PubkeyDatabase extends RobustSQLiteOpenHelper {
 		addTableName(TABLE_PUBKEYS);
 	}
 
+	private static final Object sInstanceLock = new Object();
+
+	private static PubkeyDatabase sInstance;
+
+	public static PubkeyDatabase get(Context context) {
+		synchronized (sInstanceLock) {
+			if (sInstance != null) {
+				return sInstance;
+			}
+
+			Context appContext = context.getApplicationContext();
+			sInstance = new PubkeyDatabase(appContext);
+			return sInstance;
+		}
+	}
+
 	public PubkeyDatabase(Context context) {
 		super(context, DB_NAME, null, DB_VERSION);
 

--- a/app/src/main/java/org/connectbot/util/PubkeyDatabase.java
+++ b/app/src/main/java/org/connectbot/util/PubkeyDatabase.java
@@ -172,8 +172,8 @@ public class PubkeyDatabase extends RobustSQLiteOpenHelper {
 	}
 
 	/**
-	 * @param hostId
-	 * @return
+	 * @param pubkeyId database ID for a desired pubkey
+	 * @return object representing the pubkey
 	 */
 	public PubkeyBean findPubkeyById(long pubkeyId) {
 		SQLiteDatabase db = getReadableDatabase();

--- a/app/src/main/java/org/connectbot/util/PubkeyDatabase.java
+++ b/app/src/main/java/org/connectbot/util/PubkeyDatabase.java
@@ -77,7 +77,7 @@ public class PubkeyDatabase extends RobustSQLiteOpenHelper {
 		}
 	}
 
-	public PubkeyDatabase(Context context) {
+	private PubkeyDatabase(Context context) {
 		super(context, DB_NAME, null, DB_VERSION);
 
 		this.context = context;

--- a/app/src/main/java/org/connectbot/util/PubkeyDatabase.java
+++ b/app/src/main/java/org/connectbot/util/PubkeyDatabase.java
@@ -114,7 +114,7 @@ public class PubkeyDatabase extends RobustSQLiteOpenHelper {
 	 * Delete a specific host by its <code>_id</code> value.
 	 */
 	public void deletePubkey(PubkeyBean pubkey) {
-		HostDatabase hostdb = new HostDatabase(context);
+		HostDatabase hostdb = HostDatabase.get(context);
 		hostdb.stopUsingPubkey(pubkey.getId());
 
 		SQLiteDatabase db = getWritableDatabase();

--- a/app/src/main/java/org/connectbot/util/PubkeyDatabase.java
+++ b/app/src/main/java/org/connectbot/util/PubkeyDatabase.java
@@ -100,11 +100,9 @@ public class PubkeyDatabase extends RobustSQLiteOpenHelper {
 	public void deletePubkey(PubkeyBean pubkey) {
 		HostDatabase hostdb = new HostDatabase(context);
 		hostdb.stopUsingPubkey(pubkey.getId());
-		hostdb.close();
 
 		SQLiteDatabase db = getWritableDatabase();
 		db.delete(TABLE_PUBKEYS, "_id = ?", new String[] { Long.toString(pubkey.getId()) });
-		db.close();
 	}
 
 	/**
@@ -164,8 +162,6 @@ public class PubkeyDatabase extends RobustSQLiteOpenHelper {
 			c.close();
 		}
 
-		db.close();
-
 		return pubkeys;
 	}
 
@@ -188,8 +184,6 @@ public class PubkeyDatabase extends RobustSQLiteOpenHelper {
 
 			c.close();
 		}
-
-		db.close();
 
 		return pubkey;
 	}
@@ -230,8 +224,6 @@ public class PubkeyDatabase extends RobustSQLiteOpenHelper {
 			c.close();
 		}
 
-		db.close();
-
 		return list;
 	}
 
@@ -249,8 +241,6 @@ public class PubkeyDatabase extends RobustSQLiteOpenHelper {
 
 			c.close();
 		}
-
-		db.close();
 
 		return nickname;
 	}
@@ -321,8 +311,6 @@ public class PubkeyDatabase extends RobustSQLiteOpenHelper {
 			long id = db.insert(TABLE_PUBKEYS, null, pubkey.getValues());
 			pubkey.setId(id);
 		}
-
-		db.close();
 
 		return pubkey;
 	}


### PR DESCRIPTION
Totally refactor the way databases work. The current advice is to never close the database when using a `SQLiteOpenHelper` and to use transactions when writing to the database. The old system of using locks around use of database kind of worked, but there were places that were violating this principle.

This is the first step toward using something like SQLBrite which will allow us to use a more reactive style for updating the host list, et al.