### PR TITLE
Use 4 spaces per tab instead of 8.

### DIFF
--- a/.idea/codeStyleSettings.xml
+++ b/.idea/codeStyleSettings.xml
@@ -75,40 +75,13 @@
           <option name="XML_WHITE_SPACE_AROUND_CDATA" value="1" />
           <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
         </XML>
-        <codeStyleSettings language="Groovy">
-          <indentOptions>
-            <option name="INDENT_SIZE" value="8" />
-            <option name="CONTINUATION_INDENT_SIZE" value="16" />
-            <option name="TAB_SIZE" value="8" />
-            <option name="USE_TAB_CHARACTER" value="true" />
-          </indentOptions>
-        </codeStyleSettings>
-        <codeStyleSettings language="HTML">
-          <indentOptions>
-            <option name="INDENT_SIZE" value="8" />
-            <option name="CONTINUATION_INDENT_SIZE" value="16" />
-            <option name="TAB_SIZE" value="8" />
-            <option name="USE_TAB_CHARACTER" value="true" />
-          </indentOptions>
-        </codeStyleSettings>
         <codeStyleSettings language="JAVA">
           <option name="INDENT_CASE_FROM_SWITCH" value="false" />
           <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
           <option name="SPACE_BEFORE_ARRAY_INITIALIZER_LBRACE" value="true" />
-          <indentOptions>
-            <option name="INDENT_SIZE" value="8" />
-            <option name="CONTINUATION_INDENT_SIZE" value="16" />
-            <option name="TAB_SIZE" value="8" />
-            <option name="USE_TAB_CHARACTER" value="true" />
-          </indentOptions>
         </codeStyleSettings>
         <codeStyleSettings language="XML">
           <option name="FORCE_REARRANGE_MODE" value="1" />
-          <indentOptions>
-            <option name="INDENT_SIZE" value="8" />
-            <option name="TAB_SIZE" value="8" />
-            <option name="USE_TAB_CHARACTER" value="true" />
-          </indentOptions>
           <arrangement>
             <rules>
               <section>

--- a/.idea/codeStyleSettings.xml
+++ b/.idea/codeStyleSettings.xml
@@ -75,13 +75,39 @@
           <option name="XML_WHITE_SPACE_AROUND_CDATA" value="1" />
           <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
         </XML>
+        <codeStyleSettings language="Groovy">
+          <indentOptions>
+            <option name="USE_TAB_CHARACTER" value="true" />
+          </indentOptions>
+        </codeStyleSettings>
+        <codeStyleSettings language="HTML">
+          <indentOptions>
+            <option name="USE_TAB_CHARACTER" value="true" />
+          </indentOptions>
+        </codeStyleSettings>
         <codeStyleSettings language="JAVA">
           <option name="INDENT_CASE_FROM_SWITCH" value="false" />
           <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
           <option name="SPACE_BEFORE_ARRAY_INITIALIZER_LBRACE" value="true" />
+          <indentOptions>
+            <option name="USE_TAB_CHARACTER" value="true" />
+          </indentOptions>
+        </codeStyleSettings>
+        <codeStyleSettings language="JSON">
+          <indentOptions>
+            <option name="USE_TAB_CHARACTER" value="true" />
+          </indentOptions>
+        </codeStyleSettings>
+        <codeStyleSettings language="ObjectiveC">
+          <indentOptions>
+            <option name="USE_TAB_CHARACTER" value="true" />
+          </indentOptions>
         </codeStyleSettings>
         <codeStyleSettings language="XML">
           <option name="FORCE_REARRANGE_MODE" value="1" />
+          <indentOptions>
+            <option name="USE_TAB_CHARACTER" value="true" />
+          </indentOptions>
           <arrangement>
             <rules>
               <section>


### PR DESCRIPTION
This makes lines shorter and easier to read.