### PR TITLE
Add padding to bottom of HostList to prevent FAB covering list.

### DIFF
--- a/app/src/main/res/layout/act_hostlist.xml
+++ b/app/src/main/res/layout/act_hostlist.xml
@@ -26,10 +26,14 @@
 	android:orientation="vertical"
 	>
 
+	<!-- paddingBottom is calculated with FloatingActionButton's height (56dp) and
+	     margins (16dp): 56dp + (2 x 16dp) = 88dp. -->
 	<android.support.v7.widget.RecyclerView
 		android:id="@+id/list"
 		android:layout_width="fill_parent"
 		android:layout_height="fill_parent"
+		android:paddingBottom="88dp"
+		android:clipToPadding="false"
 		/>
 
 	<TextView


### PR DESCRIPTION
Fixes #241 

Before: 
![fab before](https://cloud.githubusercontent.com/assets/1788374/10059200/9081a290-61fe-11e5-83fb-6135e518362a.png)

After:
![fab after](https://cloud.githubusercontent.com/assets/1788374/10059207/96a1c268-61fe-11e5-807b-11c76d379093.png)

