### PR TITLE
Only use host if it is not null

### DIFF
--- a/app/src/main/java/org/connectbot/HostListActivity.java
+++ b/app/src/main/java/org/connectbot/HostListActivity.java
@@ -500,14 +500,17 @@ public class HostListActivity extends AppCompatListActivity implements OnHostSta
 		 */
 		private int getConnectedState(HostBean host) {
 			// always disconnected if we don't have backend service
-			if (this.manager == null)
+			if (this.manager == null || host == null) {
 				return STATE_UNKNOWN;
+			}
 
-			if (manager.getConnectedBridge(host) != null)
+			if (manager.getConnectedBridge(host) != null) {
 				return STATE_CONNECTED;
+			}
 
-			if (manager.disconnected.contains(host))
+			if (manager.disconnected.contains(host)) {
 				return STATE_DISCONNECTED;
+			}
 
 			return STATE_UNKNOWN;
 		}
@@ -525,16 +528,14 @@ public class HostListActivity extends AppCompatListActivity implements OnHostSta
 			HostViewHolder hostHolder = (HostViewHolder) holder;
 
 			HostBean host = hosts.get(position);
+			hostHolder.host = host;
 			if (host == null) {
 				// Well, something bad happened. We can't continue.
 				Log.e("HostAdapter", "Host bean is null!");
-
 				hostHolder.nickname.setText("Error during lookup");
-				hostHolder.caption.setText("see 'adb logcat' for more");
+			} else {
+				hostHolder.nickname.setText(host.getNickname());
 			}
-			hostHolder.host = host;
-
-			hostHolder.nickname.setText(host.getNickname());
 
 			switch (this.getConnectedState(host)) {
 			case STATE_UNKNOWN:

--- a/app/src/main/java/org/connectbot/PubkeyListActivity.java
+++ b/app/src/main/java/org/connectbot/PubkeyListActivity.java
@@ -629,16 +629,15 @@ public class PubkeyListActivity extends AppCompatListActivity implements EventLi
 			PubkeyViewHolder pubkeyHolder = (PubkeyViewHolder) holder;
 
 			PubkeyBean pubkey = pubkeys.get(position);
+			pubkeyHolder.pubkey = pubkey;
 			if (pubkey == null) {
 				// Well, something bad happened. We can't continue.
 				Log.e("PubkeyAdapter", "Pubkey bean is null!");
 
 				pubkeyHolder.nickname.setText("Error during lookup");
-				pubkeyHolder.caption.setText("see 'adb logcat' for more");
+			} else {
+				pubkeyHolder.nickname.setText(pubkey.getNickname());
 			}
-			pubkeyHolder.pubkey = pubkey;
-
-			pubkeyHolder.nickname.setText(pubkey.getNickname());
 
 			boolean imported = PubkeyDatabase.KEY_TYPE_IMPORTED.equals(pubkey.getType());
 


### PR DESCRIPTION
Since we null check the host, we should make sure not to dereference it
later on.