### PR TITLE
Change "continuation indent" tab to only 4 spaces for XML.

### DIFF
--- a/.idea/codeStyleSettings.xml
+++ b/.idea/codeStyleSettings.xml
@@ -106,6 +106,7 @@
         <codeStyleSettings language="XML">
           <option name="FORCE_REARRANGE_MODE" value="1" />
           <indentOptions>
+            <option name="CONTINUATION_INDENT_SIZE" value="4" />
             <option name="USE_TAB_CHARACTER" value="true" />
           </indentOptions>
           <arrangement>


### PR DESCRIPTION
This converts XML such as:

&lt;Foo
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;attribute1="hi"
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;attribute2="bye"&gt;

to:

&lt;Foo
&nbsp;&nbsp;&nbsp;&nbsp;attribute1="hi"
&nbsp;&nbsp;&nbsp;&nbsp;attribute2="bye"&gt;