### PR TITLE
Forward mouseevents to the terminal when appropriate.

### DIFF
--- a/app/src/main/java/de/mud/terminal/VDUInput.java
+++ b/app/src/main/java/de/mud/terminal/VDUInput.java
@@ -61,9 +61,8 @@ public interface VDUInput {
    * of the release.
    * @param x
    * @param y
-   * @param modifiers
    */
-  void mouseReleased(int x, int y, int modifiers);
+  void mouseReleased(int x, int y);
 
   /**
    * Override the standard key codes used by the terminal emulation.

--- a/app/src/main/java/de/mud/terminal/VDUInput.java
+++ b/app/src/main/java/de/mud/terminal/VDUInput.java
@@ -57,6 +57,17 @@ public interface VDUInput {
   void mousePressed(int x, int y, int modifiers);
 
   /**
+   * Passes mouse wheel events to the terminal.
+   * @param down True if scrolling down the page. False if scrolling up.
+   * @param x
+   * @param y
+   * @param ctrl
+   * @param shift
+   * @param meta
+   */
+  public void mouseWheel(boolean down, int x, int y, boolean ctrl, boolean shift, boolean meta);
+
+  /**
    * Terminal is mouse-aware and requires the coordinates and button
    * of the release.
    * @param x

--- a/app/src/main/java/de/mud/terminal/vt320.java
+++ b/app/src/main/java/de/mud/terminal/vt320.java
@@ -336,6 +336,10 @@ public void setScreenSize(int c, int r, boolean broadcast) {
     this(80, 24);
   }
 
+  public boolean isMouseReportEnabled() {
+    return mouserpt != 0;
+  }
+
   /**
    * Terminal is mouse-aware and requires (x,y) coordinates of
    * on the terminal (character coordinates) and the button clicked.

--- a/app/src/main/java/de/mud/terminal/vt320.java
+++ b/app/src/main/java/de/mud/terminal/vt320.java
@@ -385,26 +385,63 @@ public void setScreenSize(int c, int r, boolean broadcast) {
    * @param meta
    */
   public void mouseWheel(boolean down, int x, int y, boolean ctrl, boolean shift, boolean meta) {
-   if (mouserpt == 0 || mouserpt == 9)
-    return;
+    if (mouserpt == 0 || mouserpt == 9)
+      return;
 
-   int mods = 0;
-   if (ctrl) mods |= 2;
-   if (shift) mods |= 1;
-   if (meta) mods |= 4;
+    int mods = 0;
+    if (ctrl) mods |= 16;
+    if (shift) mods |= 4;
+    if (meta) mods |= 8;
 
-   int mousecode = ((down ? 0 : 1) + 96) | 0x20 | ((mods & 7) << 2);
+    int mousecode = ((down ? 0 : 1) + 96) | 0x20 | mods;
 
-   byte b[] = new byte[6];
+    byte b[] = new byte[6];
 
-   b[0] = 27;
-   b[1] = (byte) '[';
-   b[2] = (byte) 'M';
-   b[3] = (byte) mousecode;
-   b[4] = (byte) (0x20 + x + 1);
-   b[5] = (byte) (0x20 + y + 1);
+    b[0] = 27;
+    b[1] = (byte) '[';
+    b[2] = (byte) 'M';
+    b[3] = (byte) mousecode;
+    b[4] = (byte) (0x20 + x + 1);
+    b[5] = (byte) (0x20 + y + 1);
 
-   write(b); // FIXME: writeSpecial here
+    write(b); // FIXME: writeSpecial here
+  }
+
+  /**
+   * Passes mouse move events to the terminal.
+   * @param button The mouse button pressed. 3 indicates no button is pressed.
+   * @param x
+   * @param y
+   * @param ctrl
+   * @param shift
+   * @param meta
+   */
+  public void mouseMoved(int button, int x, int y, boolean ctrl, boolean shift, boolean meta) {
+    if (mouserpt != 1002 && mouserpt != 1003)
+      return;
+
+    // 1002 only reports drags. 1003 reports any movement.
+    if (mouserpt == 1002 && button == 3)
+      return;
+
+    int mods = 0;
+    if (ctrl) mods |= 16;
+    if (shift) mods |= 4;
+    if (meta) mods |= 8;
+
+    // Normal mouse code plus additional 32 to indicate movement.
+    int mousecode = (button + 0x40) | mods;
+
+    byte b[] = new byte[6];
+
+    b[0] = 27;
+    b[1] = (byte) '[';
+    b[2] = (byte) 'M';
+    b[3] = (byte) mousecode;
+    b[4] = (byte) (0x20 + x + 1);
+    b[5] = (byte) (0x20 + y + 1);
+
+    write(b); // FIXME: writeSpecial here
   }
 
   /**

--- a/app/src/main/java/de/mud/terminal/vt320.java
+++ b/app/src/main/java/de/mud/terminal/vt320.java
@@ -376,9 +376,8 @@ public void setScreenSize(int c, int r, boolean broadcast) {
    * of the release.
    * @param x
    * @param y
-   * @param modifiers
    */
-  public void mouseReleased(int x, int y, int modifiers) {
+  public void mouseReleased(int x, int y) {
     if (mouserpt == 0)
       return;
 

--- a/app/src/main/java/de/mud/terminal/vt320.java
+++ b/app/src/main/java/de/mud/terminal/vt320.java
@@ -376,6 +376,38 @@ public void setScreenSize(int c, int r, boolean broadcast) {
   }
 
   /**
+   * Passes mouse wheel events to the terminal.
+   * @param down True if scrolling down the page. False if scrolling up.
+   * @param x
+   * @param y
+   * @param ctrl
+   * @param shift
+   * @param meta
+   */
+  public void mouseWheel(boolean down, int x, int y, boolean ctrl, boolean shift, boolean meta) {
+   if (mouserpt == 0 || mouserpt == 9)
+    return;
+
+   int mods = 0;
+   if (ctrl) mods |= 2;
+   if (shift) mods |= 1;
+   if (meta) mods |= 4;
+
+   int mousecode = ((down ? 0 : 1) + 96) | 0x20 | ((mods & 7) << 2);
+
+   byte b[] = new byte[6];
+
+   b[0] = 27;
+   b[1] = (byte) '[';
+   b[2] = (byte) 'M';
+   b[3] = (byte) mousecode;
+   b[4] = (byte) (0x20 + x + 1);
+   b[5] = (byte) (0x20 + y + 1);
+
+   write(b); // FIXME: writeSpecial here
+  }
+
+  /**
    * Terminal is mouse-aware and requires the coordinates and button
    * of the release.
    * @param x

--- a/app/src/main/java/org/connectbot/ConsoleActivity.java
+++ b/app/src/main/java/org/connectbot/ConsoleActivity.java
@@ -753,7 +753,10 @@ public class ConsoleActivity extends AppCompatActivity implements BridgeDisconne
 						MotionEventCompat.getSource(event) == InputDevice.SOURCE_MOUSE) {
 					int meta = event.getMetaState();
 					boolean shiftOn = (event.getMetaState() & KeyEvent.META_SHIFT_ON) != 0;
-					if (shiftOn && event.getAction() == MotionEvent.ACTION_DOWN){
+					boolean mouseReport = ((vt320) bridge.buffer).isMouseReportEnabled();
+
+					// MouseReport can be "defeated" using the shift key.
+					if ((!mouseReport || shiftOn) && event.getAction() == MotionEvent.ACTION_DOWN){
 						switch (event.getButtonState()) {
 						case MotionEvent.BUTTON_PRIMARY:
 							// Automatically start copy mode if using a mouse.
@@ -851,9 +854,11 @@ public class ConsoleActivity extends AppCompatActivity implements BridgeDisconne
 	}
 
 	/**
-	 *
-	 * @param mouseEvent
-	 * @return
+	 * Takes an android mouse event and produces a Java InputEvent modifiers int which can be
+	 * passed to vt320.
+	 * @param mouseEvent The {@link MotionEvent} which should be a mouse click or release.
+	 * @return A Java InputEvent modifier int. See
+	 * http://docs.oracle.com/javase/7/docs/api/java/awt/event/InputEvent.html
 	 */
 	@TargetApi(14)
 	private static int mouseEventToJavaModifiers(MotionEvent mouseEvent) {

--- a/app/src/main/java/org/connectbot/ConsoleActivity.java
+++ b/app/src/main/java/org/connectbot/ConsoleActivity.java
@@ -756,25 +756,39 @@ public class ConsoleActivity extends AppCompatActivity implements BridgeDisconne
 					boolean mouseReport = ((vt320) bridge.buffer).isMouseReportEnabled();
 
 					// MouseReport can be "defeated" using the shift key.
-					if ((!mouseReport || shiftOn) && event.getAction() == MotionEvent.ACTION_DOWN) {
-						switch (event.getButtonState()) {
-						case MotionEvent.BUTTON_PRIMARY:
-							// Automatically start copy mode if using a mouse.
-							startCopyMode();
-							break;
-						case MotionEvent.BUTTON_SECONDARY:
-							openContextMenu(pager);
-							return true;
-						case MotionEvent.BUTTON_TERTIARY:
-							// Middle click pastes.
-							pasteIntoTerminal();
-							return true;
+					if ((!mouseReport || shiftOn)) {
+						if (event.getAction() == MotionEvent.ACTION_DOWN) {
+							switch (event.getButtonState()) {
+							case MotionEvent.BUTTON_PRIMARY:
+								// Automatically start copy mode if using a mouse.
+								startCopyMode();
+								break;
+							case MotionEvent.BUTTON_SECONDARY:
+								openContextMenu(pager);
+								return true;
+							case MotionEvent.BUTTON_TERTIARY:
+								// Middle click pastes.
+								pasteIntoTerminal();
+								return true;
+							}
 						}
 					} else if (event.getAction() == MotionEvent.ACTION_DOWN) {
 						((vt320) bridge.buffer).mousePressed(
 								col, row, mouseEventToJavaModifiers(event));
 					} else if (event.getAction() == MotionEvent.ACTION_UP) {
 						((vt320) bridge.buffer).mouseReleased(col, row);
+					} else if (event.getAction() == MotionEvent.ACTION_MOVE) {
+						int buttonState = event.getButtonState();
+						int button = (buttonState & MotionEvent.BUTTON_PRIMARY) != 0 ? 0 :
+								(buttonState & MotionEvent.BUTTON_SECONDARY) != 0 ? 1 :
+								(buttonState & MotionEvent.BUTTON_TERTIARY) != 0 ? 2 : 3;
+						((vt320) bridge.buffer).mouseMoved(
+								button,
+								col,
+								row,
+								(event.getMetaState() & KeyEvent.META_CTRL_ON) != 0,
+								(event.getMetaState() & KeyEvent.META_SHIFT_ON) != 0,
+								(event.getMetaState() & KeyEvent.META_META_ON) != 0);
 					}
 				}
 

--- a/app/src/main/java/org/connectbot/ConsoleActivity.java
+++ b/app/src/main/java/org/connectbot/ConsoleActivity.java
@@ -756,7 +756,7 @@ public class ConsoleActivity extends AppCompatActivity implements BridgeDisconne
 					boolean mouseReport = ((vt320) bridge.buffer).isMouseReportEnabled();
 
 					// MouseReport can be "defeated" using the shift key.
-					if ((!mouseReport || shiftOn) && event.getAction() == MotionEvent.ACTION_DOWN){
+					if ((!mouseReport || shiftOn) && event.getAction() == MotionEvent.ACTION_DOWN) {
 						switch (event.getButtonState()) {
 						case MotionEvent.BUTTON_PRIMARY:
 							// Automatically start copy mode if using a mouse.
@@ -770,10 +770,10 @@ public class ConsoleActivity extends AppCompatActivity implements BridgeDisconne
 							pasteIntoTerminal();
 							return true;
 						}
-					} else if (event.getAction() == MotionEvent.ACTION_DOWN){
+					} else if (event.getAction() == MotionEvent.ACTION_DOWN) {
 						((vt320) bridge.buffer).mousePressed(
 								col, row, mouseEventToJavaModifiers(event));
-					} else if (event.getAction() == MotionEvent.ACTION_UP){
+					} else if (event.getAction() == MotionEvent.ACTION_UP) {
 						((vt320) bridge.buffer).mouseReleased(col, row);
 					}
 				}

--- a/app/src/main/java/org/connectbot/TerminalView.java
+++ b/app/src/main/java/org/connectbot/TerminalView.java
@@ -40,7 +40,6 @@ import android.graphics.PixelXorXfermode;
 import android.graphics.RectF;
 import android.net.Uri;
 import android.os.AsyncTask;
-import android.os.Build;
 import android.support.v4.view.MotionEventCompat;
 import android.view.InputDevice;
 import android.view.KeyEvent;
@@ -328,8 +327,6 @@ public class TerminalView extends View implements FontSizeChangedListener {
 	@Override
 	@TargetApi(12)
 	public boolean onGenericMotionEvent(MotionEvent event) {
-		if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.HONEYCOMB) return false;
-
 		if ((MotionEventCompat.getSource(event) & InputDevice.SOURCE_CLASS_POINTER) != 0) {
 			switch (event.getAction()) {
 			case MotionEvent.ACTION_SCROLL:

--- a/app/src/main/java/org/connectbot/TerminalView.java
+++ b/app/src/main/java/org/connectbot/TerminalView.java
@@ -26,6 +26,7 @@ import org.connectbot.service.FontSizeChangedListener;
 import org.connectbot.service.TerminalBridge;
 import org.connectbot.service.TerminalKeyListener;
 
+import android.annotation.TargetApi;
 import android.content.ContentResolver;
 import android.content.Context;
 import android.content.Intent;
@@ -39,6 +40,7 @@ import android.graphics.PixelXorXfermode;
 import android.graphics.RectF;
 import android.net.Uri;
 import android.os.AsyncTask;
+import android.os.Build;
 import android.support.v4.view.MotionEventCompat;
 import android.view.InputDevice;
 import android.view.KeyEvent;
@@ -324,7 +326,10 @@ public class TerminalView extends View implements FontSizeChangedListener {
 	}
 
 	@Override
+	@TargetApi(12)
 	public boolean onGenericMotionEvent(MotionEvent event) {
+		if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.HONEYCOMB) return false;
+
 		if ((MotionEventCompat.getSource(event) & InputDevice.SOURCE_CLASS_POINTER) != 0) {
 			switch (event.getAction()) {
 			case MotionEvent.ACTION_SCROLL:

--- a/app/src/main/java/org/connectbot/TerminalView.java
+++ b/app/src/main/java/org/connectbot/TerminalView.java
@@ -52,6 +52,7 @@ import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputConnection;
 import android.widget.Toast;
 import de.mud.terminal.VDUBuffer;
+import de.mud.terminal.vt320;
 
 /**
  * User interface {@link View} for showing a TerminalBridge in an
@@ -329,7 +330,20 @@ public class TerminalView extends View implements FontSizeChangedListener {
 			case MotionEvent.ACTION_SCROLL:
 				// Process scroll wheel movement:
 				float yDistance = MotionEventCompat.getAxisValue(event, MotionEvent.AXIS_VSCROLL);
-				if (yDistance != 0) {
+				boolean mouseReport = ((vt320) bridge.buffer).isMouseReportEnabled();
+				if (mouseReport) {
+					int row = (int) Math.floor(event.getY() / bridge.charHeight);
+					int col = (int) Math.floor(event.getX() / bridge.charWidth);
+
+					((vt320) bridge.buffer).mouseWheel(
+							yDistance > 0,
+							col,
+							row,
+							(event.getMetaState() & KeyEvent.META_CTRL_ON) != 0,
+							(event.getMetaState() & KeyEvent.META_SHIFT_ON) != 0,
+							(event.getMetaState() & KeyEvent.META_META_ON) != 0);
+					return true;
+				} else if (yDistance != 0) {
 					int base = bridge.buffer.getWindowBase();
 					bridge.buffer.setWindowBase(base - Math.round(yDistance));
 					return true;


### PR DESCRIPTION
Only handle mouse events locally if shift is held.
Partially fixes #225. Still need to figure out mouse wheel forwarding
and proper copy support when the terminal is handling selection itself
(ie in an editor).