### PR TITLE
Add/edit host view: add fields for the connection-related preferences.

### DIFF
--- a/app/src/main/java/org/connectbot/HostEditorFragment.java
+++ b/app/src/main/java/org/connectbot/HostEditorFragment.java
@@ -156,6 +156,7 @@ public class HostEditorFragment extends Fragment {
 		for (int i = 0; i < transportNames.length; i++) {
 			if (transportNames.equals(mHost.getProtocol())) {
 				mTransportSpinner.setSelection(i);
+				break;
 			}
 		}
 		mTransportSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {

--- a/app/src/main/java/org/connectbot/HostEditorFragment.java
+++ b/app/src/main/java/org/connectbot/HostEditorFragment.java
@@ -39,7 +39,6 @@ import android.widget.EditText;
 import android.widget.ImageButton;
 import android.widget.SeekBar;
 import android.widget.Spinner;
-import android.widget.Switch;
 import android.widget.TextView;
 
 import org.connectbot.bean.HostBean;

--- a/app/src/main/java/org/connectbot/HostEditorFragment.java
+++ b/app/src/main/java/org/connectbot/HostEditorFragment.java
@@ -25,6 +25,8 @@ import android.os.Bundle;
 import android.os.Parcelable;
 import android.support.design.widget.TextInputLayout;
 import android.support.v4.app.Fragment;
+import android.support.v7.widget.AppCompatCheckBox;
+import android.support.v7.widget.SwitchCompat;
 import android.text.Editable;
 import android.text.TextWatcher;
 import android.view.LayoutInflater;
@@ -32,10 +34,12 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
+import android.widget.CompoundButton;
 import android.widget.EditText;
 import android.widget.ImageButton;
 import android.widget.SeekBar;
 import android.widget.Spinner;
+import android.widget.Switch;
 import android.widget.TextView;
 
 import org.connectbot.bean.HostBean;
@@ -76,6 +80,12 @@ public class HostEditorFragment extends Fragment {
 	// the text in the Spinner because the text is localized while these values are not.
 	private TypedArray mColorValues;
 
+	// Likewise, but for SSH auth agent values.
+	private TypedArray mSshAuthValues;
+
+	// Likewise, but for DEL key values.
+	private TypedArray mDelKeyValues;
+
 	private Spinner mTransportSpinner;
 	private TextInputLayout mQuickConnectContainer;
 	private EditText mQuickConnectField;
@@ -91,6 +101,17 @@ public class HostEditorFragment extends Fragment {
 	private Spinner mColorSelector;
 	private TextView mFontSizeText;
 	private SeekBar mFontSizeSeekBar;
+	private Spinner mPubkeySpinner;
+	private View mUseSshConfirmationContainer;
+	private SwitchCompat mUseSshAuthSwitch;
+	private AppCompatCheckBox mSshAuthConfirmationCheckbox;
+	private SwitchCompat mCompressionSwitch;
+	private SwitchCompat mStartShellSwitch;
+	private SwitchCompat mStayConnectedSwitch;
+	private SwitchCompat mCloseOnDisconnectSwitch;
+	private EditText mPostLoginAutomationField;
+	private Spinner mDelKeySpinner;
+	private Spinner mEncodingSpinner;
 
 	public static HostEditorFragment newInstance(HostBean existingHost) {
 		HostEditorFragment fragment = new HostEditorFragment();
@@ -128,12 +149,16 @@ public class HostEditorFragment extends Fragment {
 		View view = inflater.inflate(R.layout.fragment_host_editor, container, false);
 
 		mTransportSpinner = (Spinner) view.findViewById(R.id.transport_selector);
+		String[] transportNames = TransportFactory.getTransportNames();
 		ArrayAdapter<String> transportSelection = new ArrayAdapter<>(
-				getActivity(),
-				android.R.layout.simple_spinner_item,
-				TransportFactory.getTransportNames());
+				getActivity(), android.R.layout.simple_spinner_item, transportNames);
 		transportSelection.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
 		mTransportSpinner.setAdapter(transportSelection);
+		for (int i = 0; i < transportNames.length; i++) {
+			if (transportNames.equals(mHost.getProtocol())) {
+				mTransportSpinner.setSelection(i);
+			}
+		}
 		mTransportSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
 			@Override
 			public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
@@ -240,14 +265,10 @@ public class HostEditorFragment extends Fragment {
 				new HostTextFieldWatcher(HostDatabase.FIELD_HOST_NICKNAME));
 
 		mColorSelector = (Spinner) view.findViewById(R.id.color_selector);
-		if (mHost.getColor() != null) {
-			// Unfortunately, TypedArray doesn't have an indexOf(String) function, so search through
-			// the array for the saved color.
-			for (int i = 0; i < mColorValues.getIndexCount(); i++) {
-				if (mHost.getColor().equals(mColorValues.getString(i))) {
-					mColorSelector.setSelection(i);
-					break;
-				}
+		for (int i = 0; i < mColorValues.getIndexCount(); i++) {
+			if (mHost.getColor().equals(mColorValues.getString(i))) {
+				mColorSelector.setSelection(i);
+				break;
 			}
 		}
 		mColorSelector.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
@@ -281,6 +302,88 @@ public class HostEditorFragment extends Fragment {
 		});
 		mFontSizeSeekBar.setProgress(mHost.getFontSize() - MINIMUM_FONT_SIZE);
 
+		mPubkeySpinner = (Spinner) view.findViewById(R.id.pubkey_spinner);
+		// TODO: Set up spinner. This requires passing pubkey data into the fragment from the
+		// activity and will be part of an upcoming PR.
+
+		mUseSshConfirmationContainer = view.findViewById(R.id.ssh_confirmation_container);
+		mUseSshAuthSwitch = (SwitchCompat) view.findViewById(R.id.use_ssh_auth_switch);
+		mSshAuthConfirmationCheckbox =
+				(AppCompatCheckBox) view.findViewById(R.id.ssh_auth_confirmation_checkbox);
+		CompoundButton.OnCheckedChangeListener authSwitchListener = new CompoundButton.OnCheckedChangeListener() {
+			@Override
+			public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+				mUseSshConfirmationContainer.setVisibility(
+						mUseSshAuthSwitch.isChecked() ? View.VISIBLE : View.GONE);
+				if (mUseSshAuthSwitch.isChecked()) {
+					mHost.setUseAuthAgent(
+							mSshAuthConfirmationCheckbox.isChecked() ?
+									/* require confirmation */ mSshAuthValues.getString(1) :
+									/* don't require confirmation */ mSshAuthValues.getString(2));
+				} else {
+					mHost.setUseAuthAgent(/* don't use */ mSshAuthValues.getString(0));
+				}
+			}
+		};
+		mUseSshAuthSwitch.setOnCheckedChangeListener(authSwitchListener);
+		mSshAuthConfirmationCheckbox.setOnCheckedChangeListener(authSwitchListener);
+		if (mHost.getUseAuthAgent() == null ||
+				mHost.getUseAuthAgent().equals(mSshAuthValues.getString(0))) {
+			mUseSshAuthSwitch.setChecked(false);
+			mSshAuthConfirmationCheckbox.setChecked(false);
+		} else {
+			mUseSshAuthSwitch.setChecked(true);
+			mSshAuthConfirmationCheckbox.setChecked(
+					mHost.getUseAuthAgent().equals(mSshAuthValues.getString(1)));
+		}
+
+		mCompressionSwitch = (SwitchCompat) view.findViewById(R.id.compression_switch);
+		mCompressionSwitch.setChecked(mHost.getCompression());
+		mCompressionSwitch.setOnCheckedChangeListener(
+				new HostSwitchWatcher(HostDatabase.FIELD_HOST_COMPRESSION));
+
+		mStartShellSwitch = (SwitchCompat) view.findViewById(R.id.start_shell_switch);
+		mStartShellSwitch.setChecked(mHost.getWantSession());
+		mStartShellSwitch.setOnCheckedChangeListener(
+				new HostSwitchWatcher(HostDatabase.FIELD_HOST_WANTSESSION));
+
+		mStayConnectedSwitch = (SwitchCompat) view.findViewById(R.id.stay_connected_switch);
+		mStayConnectedSwitch.setChecked(mHost.getStayConnected());
+		mStayConnectedSwitch.setOnCheckedChangeListener(
+				new HostSwitchWatcher(HostDatabase.FIELD_HOST_STAYCONNECTED));
+
+		mCloseOnDisconnectSwitch = (SwitchCompat) view.findViewById(R.id.close_on_disconnect_switch);
+		mCloseOnDisconnectSwitch.setChecked(mHost.getQuickDisconnect());
+		mCloseOnDisconnectSwitch.setOnCheckedChangeListener(
+				new HostSwitchWatcher(HostDatabase.FIELD_HOST_QUICKDISCONNECT));
+
+		mPostLoginAutomationField = (EditText) view.findViewById(R.id.post_login_automation_field);
+		mPostLoginAutomationField.setText(mHost.getPostLogin());
+		mPostLoginAutomationField.addTextChangedListener(
+				new HostTextFieldWatcher(HostDatabase.FIELD_HOST_POSTLOGIN));
+
+		mDelKeySpinner = (Spinner) view.findViewById(R.id.del_key_spinner);
+		for (int i = 0; i < mDelKeyValues.getIndexCount(); i++) {
+			if (mHost.getDelKey().equals(mDelKeyValues.getString(i))) {
+				mDelKeySpinner.setSelection(i);
+				break;
+			}
+		}
+		mDelKeySpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
+			@Override
+			public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
+				mHost.setDelKey(mDelKeyValues.getString(position));
+			}
+
+			@Override
+			public void onNothingSelected(AdapterView<?> parent) {
+			}
+		});
+
+		mEncodingSpinner = (Spinner) view.findViewById(R.id.encoding_spinner);
+		// TODO: Set up spinner. This requires passing pubkey data into the fragment from the
+		// activity and will be part of an upcoming PR.
+
 		setUriPartsContainerExpanded(mIsUriEditorExpanded);
 
 		return view;
@@ -295,9 +398,11 @@ public class HostEditorFragment extends Fragment {
 			throw new ClassCastException(context.toString() + " must implement Listener");
 		}
 
-		// Now that the fragment is attached to an Activity, fetch the array from the attached
+		// Now that the fragment is attached to an Activity, fetch the arrays from the attached
 		// Activity's resources.
 		mColorValues = getResources().obtainTypedArray(R.array.list_color_values);
+		mSshAuthValues = getResources().obtainTypedArray(R.array.list_authagent_values);
+		mDelKeyValues = getResources().obtainTypedArray(R.array.list_delkey_values);
 	}
 
 	@Override
@@ -305,6 +410,8 @@ public class HostEditorFragment extends Fragment {
 		super.onDetach();
 		mListener = null;
 		mColorValues.recycle();
+		mSshAuthValues.recycle();
+		mDelKeyValues.recycle();
 	}
 
 	@Override
@@ -392,6 +499,8 @@ public class HostEditorFragment extends Fragment {
 				}
 			} else if (HostDatabase.FIELD_HOST_NICKNAME.equals(mFieldType)) {
 				mHost.setNickname(text);
+			} else if (HostDatabase.FIELD_HOST_POSTLOGIN.equals(mFieldType)) {
+				mHost.setPostLogin(text);
 			} else {
 				throw new RuntimeException("Invalid field type.");
 			}
@@ -412,6 +521,30 @@ public class HostEditorFragment extends Fragment {
 			return HostDatabase.FIELD_HOST_USERNAME.equals(fieldType) ||
 					HostDatabase.FIELD_HOST_HOSTNAME.equals(fieldType) ||
 					HostDatabase.FIELD_HOST_PORT.equals(fieldType);
+		}
+	}
+
+	private class HostSwitchWatcher implements CompoundButton.OnCheckedChangeListener {
+
+		private final String mFieldType;
+
+		public HostSwitchWatcher(String fieldType) {
+			mFieldType = fieldType;
+		}
+
+		@Override
+		public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+			if (HostDatabase.FIELD_HOST_COMPRESSION.equals(mFieldType)) {
+				mHost.setCompression(isChecked);
+			} else if (HostDatabase.FIELD_HOST_WANTSESSION.equals(mFieldType)) {
+				mHost.setWantSession(isChecked);
+			} else if (HostDatabase.FIELD_HOST_STAYCONNECTED.equals(mFieldType)) {
+				mHost.setStayConnected(isChecked);
+			} else if (HostDatabase.FIELD_HOST_QUICKDISCONNECT.equals(mFieldType)) {
+				mHost.setQuickDisconnect(isChecked);
+			} else {
+				throw new RuntimeException("Invalid field type.");
+			}
 		}
 	}
 }

--- a/app/src/main/res/layout/fragment_host_editor.xml
+++ b/app/src/main/res/layout/fragment_host_editor.xml
@@ -19,13 +19,13 @@
 	xmlns:android="http://schemas.android.com/apk/res/android"
 	xmlns:tools="http://schemas.android.com/tools"
 	android:layout_width="match_parent"
-	android:layout_height="match_parent"
+	android:layout_height="wrap_content"
 	tools:context="org.connectbot.HostEditorFragment"
 	>
 
 	<LinearLayout
 		android:layout_width="match_parent"
-		android:layout_height="match_parent"
+		android:layout_height="wrap_content"
 		android:orientation="vertical"
 		>
 
@@ -291,6 +291,7 @@
 					android:layout_width="wrap_content"
 					android:layout_height="wrap_content"
 					android:layout_alignParentRight="true"
+					android:layout_alignParentEnd="true"
 					/>
 
 			</RelativeLayout>
@@ -313,6 +314,7 @@
 					android:layout_width="wrap_content"
 					android:layout_height="wrap_content"
 					android:layout_alignParentRight="true"
+					android:layout_alignParentEnd="true"
 					/>
 
 			</RelativeLayout>
@@ -335,6 +337,7 @@
 				android:layout_width="wrap_content"
 				android:layout_height="wrap_content"
 				android:layout_alignParentRight="true"
+				android:layout_alignParentEnd="true"
 				/>
 
 		</RelativeLayout>
@@ -355,6 +358,7 @@
 				android:layout_width="wrap_content"
 				android:layout_height="wrap_content"
 				android:layout_alignParentRight="true"
+				android:layout_alignParentEnd="true"
 				/>
 
 		</RelativeLayout>
@@ -375,6 +379,7 @@
 				android:layout_width="wrap_content"
 				android:layout_height="wrap_content"
 				android:layout_alignParentRight="true"
+				android:layout_alignParentEnd="true"
 				/>
 
 		</RelativeLayout>
@@ -395,6 +400,7 @@
 				android:layout_width="wrap_content"
 				android:layout_height="wrap_content"
 				android:layout_alignParentRight="true"
+				android:layout_alignParentEnd="true"
 				/>
 
 		</RelativeLayout>

--- a/app/src/main/res/layout/fragment_host_editor.xml
+++ b/app/src/main/res/layout/fragment_host_editor.xml
@@ -15,226 +15,462 @@
   ~ limitations under the License.
   -->
 
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView
+	xmlns:android="http://schemas.android.com/apk/res/android"
 	xmlns:tools="http://schemas.android.com/tools"
 	android:layout_width="match_parent"
 	android:layout_height="match_parent"
-	android:orientation="vertical"
 	tools:context="org.connectbot.HostEditorFragment"
-    >
+	>
 
 	<LinearLayout
-		android:layout_width="wrap_content"
-		android:layout_height="wrap_content"
+		android:layout_width="match_parent"
+		android:layout_height="match_parent"
 		android:orientation="vertical"
-		android:layout_marginStart="4dp"
-		android:layout_marginLeft="4dp"
-		android:layout_marginBottom="4dp"
-		>
-
-		<TextView
-			android:layout_width="wrap_content"
-			android:layout_height="wrap_content"
-			android:text="@string/protocol_spinner_label"
-			android:textSize="12sp"
-			/>
-
-		<Spinner
-			android:id="@+id/transport_selector"
-			android:layout_width="wrap_content"
-			android:layout_height="wrap_content"
-			/>
-
-	</LinearLayout>
-
-	<LinearLayout
-		android:layout_width="match_parent"
-		android:layout_height="wrap_content"
-		android:animateLayoutChanges="true"
-		tools:ignore="UnusedAttribute"
-		>
-
-	<android.support.design.widget.TextInputLayout
-		android:id="@+id/quickconnect_field_container"
-		android:layout_width="0dp"
-		android:layout_weight ="1"
-		android:layout_height="wrap_content"
-		>
-
-		<EditText
-			android:id="@+id/quickconnect_field"
-			android:layout_width="match_parent"
-			android:layout_weight="1"
-			android:layout_height="wrap_content"
-			android:maxLines="1"
-			android:inputType="textNoSuggestions"
-			/>
-
-	</android.support.design.widget.TextInputLayout>
-
-	<ImageButton
-		android:id="@+id/expand_collapse_button"
-		android:layout_width="16dp"
-		android:layout_height="16dp"
-		android:layout_gravity="center"
-		android:layout_margin="16dp"
-		android:src="@drawable/ic_expand_more"
-		android:contentDescription="@string/expand"
-		android:background="#00000000"
-		/>
-
-	</LinearLayout>
-
-	<LinearLayout
-		android:id="@+id/uri_parts_container"
-		android:layout_width="match_parent"
-		android:layout_height="wrap_content"
-		android:orientation="vertical"
-		android:layout_marginLeft="56dp"
-		android:layout_marginStart="56dp"
-		android:visibility="gone"
-		android:animateLayoutChanges="true"
-		tools:ignore="UnusedAttribute"
-		>
-
-		<android.support.design.widget.TextInputLayout
-			android:id="@+id/username_field_container"
-			android:layout_width="match_parent"
-			android:layout_height="wrap_content"
-			>
-
-		<EditText
-			android:id="@+id/username_edit_text"
-			android:layout_width="match_parent"
-			android:layout_height="wrap_content"
-			android:hint="@string/hostpref_username_title"
-			android:maxLines="1"
-			android:inputType="textNoSuggestions"
-			/>
-
-		</android.support.design.widget.TextInputLayout>
-
-		<android.support.design.widget.TextInputLayout
-			android:id="@+id/hostname_field_container"
-			android:layout_width="match_parent"
-			android:layout_height="wrap_content"
-			>
-
-		<EditText
-			android:id="@+id/hostname_edit_text"
-			android:layout_width="match_parent"
-			android:layout_height="wrap_content"
-			android:hint="@string/hostpref_hostname_title"
-			android:maxLines="1"
-			android:inputType="textNoSuggestions"
-			/>
-
-		</android.support.design.widget.TextInputLayout>
-
-		<android.support.design.widget.TextInputLayout
-			android:id="@+id/port_field_container"
-			android:layout_width="match_parent"
-			android:layout_height="wrap_content"
-			>
-
-		<EditText
-			android:id="@+id/port_edit_text"
-			android:layout_width="match_parent"
-			android:layout_height="wrap_content"
-			android:inputType="number"
-			android:hint="@string/hostpref_port_title"
-			android:maxLines="1"
-			/>
-
-		</android.support.design.widget.TextInputLayout>
-
-	</LinearLayout>
-
-	<View style="@style/Divider"
-		/>
-
-	<android.support.design.widget.TextInputLayout
-		android:layout_width="match_parent"
-		android:layout_height="wrap_content"
-		>
-
-		<EditText
-			android:id="@+id/nickname_field"
-			android:layout_width="match_parent"
-			android:layout_height="wrap_content"
-			android:maxLines="1"
-			android:inputType="text"
-			android:hint="@string/hostpref_nickname_title"
-			/>
-
-	</android.support.design.widget.TextInputLayout>
-
-	<LinearLayout
-		android:layout_width="match_parent"
-		android:layout_height="wrap_content"
-		android:orientation="vertical"
-		android:layout_marginStart="4dp"
-		android:layout_marginLeft="4dp"
-		android:layout_marginBottom="4dp"
-		>
-
-		<TextView
-			android:layout_width="wrap_content"
-			android:layout_height="wrap_content"
-			android:text="@string/hostpref_color_title"
-			android:textSize="12sp"
-			/>
-
-		<Spinner
-			android:id="@+id/color_selector"
-			android:layout_width="wrap_content"
-			android:layout_height="wrap_content"
-			android:entries="@array/list_colors"
-			android:entryValues="@array/list_color_values"
-			/>
-
-	</LinearLayout>
-
-	<LinearLayout
-		android:layout_width="match_parent"
-		android:layout_height="wrap_content"
-		android:orientation="vertical"
-		android:layout_marginStart="4dp"
-		android:layout_marginLeft="4dp"
-		android:layout_marginBottom="4dp"
 		>
 
 		<LinearLayout
-			android:layout_width="match_parent"
+			android:layout_width="wrap_content"
 			android:layout_height="wrap_content"
+			android:orientation="vertical"
+			android:layout_marginStart="4dp"
+			android:layout_marginLeft="4dp"
+			android:layout_marginBottom="4dp"
 			>
 
 			<TextView
 				android:layout_width="wrap_content"
 				android:layout_height="wrap_content"
-				android:text="@string/hostpref_fontsize_title"
+				android:text="@string/protocol_spinner_label"
 				android:textSize="12sp"
 				/>
 
-			<TextView
-				android:id="@+id/font_size_text"
+			<Spinner
+				android:id="@+id/transport_selector"
 				android:layout_width="wrap_content"
 				android:layout_height="wrap_content"
-				android:textSize="12sp"
 				/>
 
 		</LinearLayout>
 
-		<SeekBar
-			android:id="@+id/font_size_bar"
+		<LinearLayout
 			android:layout_width="match_parent"
 			android:layout_height="wrap_content"
-			android:max="32"
+			android:animateLayoutChanges="true"
+			tools:ignore="UnusedAttribute"
+			>
+
+			<android.support.design.widget.TextInputLayout
+				android:id="@+id/quickconnect_field_container"
+				android:layout_width="0dp"
+				android:layout_weight ="1"
+				android:layout_height="wrap_content"
+				>
+
+				<EditText
+					android:id="@+id/quickconnect_field"
+					android:layout_width="match_parent"
+					android:layout_weight="1"
+					android:layout_height="wrap_content"
+					android:maxLines="1"
+					android:inputType="textNoSuggestions"
+					/>
+
+			</android.support.design.widget.TextInputLayout>
+
+			<ImageButton
+				android:id="@+id/expand_collapse_button"
+				android:layout_width="16dp"
+				android:layout_height="16dp"
+				android:layout_gravity="center"
+				android:layout_margin="16dp"
+				android:src="@drawable/ic_expand_more"
+				android:contentDescription="@string/expand"
+				android:background="#00000000"
+				/>
+
+		</LinearLayout>
+
+		<LinearLayout
+			android:id="@+id/uri_parts_container"
+			android:layout_width="match_parent"
+			android:layout_height="wrap_content"
+			android:orientation="vertical"
+			android:layout_marginLeft="56dp"
+			android:layout_marginStart="56dp"
+			android:visibility="gone"
+			android:animateLayoutChanges="true"
+			tools:ignore="UnusedAttribute"
+			>
+
+			<android.support.design.widget.TextInputLayout
+				android:id="@+id/username_field_container"
+				android:layout_width="match_parent"
+				android:layout_height="wrap_content"
+				>
+
+				<EditText
+					android:id="@+id/username_edit_text"
+					android:layout_width="match_parent"
+					android:layout_height="wrap_content"
+					android:hint="@string/hostpref_username_title"
+					android:maxLines="1"
+					android:inputType="textNoSuggestions"
+					/>
+
+			</android.support.design.widget.TextInputLayout>
+
+			<android.support.design.widget.TextInputLayout
+				android:id="@+id/hostname_field_container"
+				android:layout_width="match_parent"
+				android:layout_height="wrap_content"
+				>
+
+				<EditText
+					android:id="@+id/hostname_edit_text"
+					android:layout_width="match_parent"
+					android:layout_height="wrap_content"
+					android:hint="@string/hostpref_hostname_title"
+					android:maxLines="1"
+					android:inputType="textNoSuggestions"
+					/>
+
+			</android.support.design.widget.TextInputLayout>
+
+			<android.support.design.widget.TextInputLayout
+				android:id="@+id/port_field_container"
+				android:layout_width="match_parent"
+				android:layout_height="wrap_content"
+				>
+
+				<EditText
+					android:id="@+id/port_edit_text"
+					android:layout_width="match_parent"
+					android:layout_height="wrap_content"
+					android:inputType="number"
+					android:hint="@string/hostpref_port_title"
+					android:maxLines="1"
+					/>
+
+			</android.support.design.widget.TextInputLayout>
+
+		</LinearLayout>
+
+		<View style="@style/Divider"
 			/>
+
+		<android.support.design.widget.TextInputLayout
+			android:layout_width="match_parent"
+			android:layout_height="wrap_content"
+			>
+
+			<EditText
+				android:id="@+id/nickname_field"
+				android:layout_width="match_parent"
+				android:layout_height="wrap_content"
+				android:maxLines="1"
+				android:inputType="text"
+				android:hint="@string/hostpref_nickname_title"
+				/>
+
+		</android.support.design.widget.TextInputLayout>
+
+		<LinearLayout
+			android:layout_width="match_parent"
+			android:layout_height="wrap_content"
+			android:orientation="vertical"
+			android:layout_marginStart="4dp"
+			android:layout_marginLeft="4dp"
+			android:layout_marginBottom="4dp"
+			>
+
+			<TextView
+				android:layout_width="wrap_content"
+				android:layout_height="wrap_content"
+				android:text="@string/hostpref_color_title"
+				android:textSize="12sp"
+				/>
+
+			<Spinner
+				android:id="@+id/color_selector"
+				android:layout_width="wrap_content"
+				android:layout_height="wrap_content"
+				android:entries="@array/list_colors"
+				android:entryValues="@array/list_color_values"
+				/>
+
+		</LinearLayout>
+
+		<LinearLayout
+			android:layout_width="match_parent"
+			android:layout_height="wrap_content"
+			android:orientation="vertical"
+			android:layout_marginStart="4dp"
+			android:layout_marginLeft="4dp"
+			android:layout_marginBottom="4dp"
+			>
+
+			<LinearLayout
+				android:layout_width="match_parent"
+				android:layout_height="wrap_content"
+				>
+
+				<TextView
+					android:layout_width="wrap_content"
+					android:layout_height="wrap_content"
+					android:text="@string/hostpref_fontsize_title"
+					android:textSize="12sp"
+					/>
+
+				<TextView
+					android:id="@+id/font_size_text"
+					android:layout_width="wrap_content"
+					android:layout_height="wrap_content"
+					android:textSize="12sp"
+					/>
+
+			</LinearLayout>
+
+			<SeekBar
+				android:id="@+id/font_size_bar"
+				android:layout_width="match_parent"
+				android:layout_height="wrap_content"
+				android:max="32"
+				/>
+
+		</LinearLayout>
+
+		<View style="@style/Divider"
+			/>
+
+		<LinearLayout
+			android:layout_width="wrap_content"
+			android:layout_height="wrap_content"
+			android:orientation="vertical"
+			android:layout_marginStart="4dp"
+			android:layout_marginLeft="4dp"
+			android:layout_marginBottom="4dp"
+			>
+
+			<TextView
+				android:layout_width="wrap_content"
+				android:layout_height="wrap_content"
+				android:text="@string/hostpref_pubkeyid_title"
+				android:textSize="12sp"
+				/>
+
+			<Spinner
+				android:id="@+id/pubkey_spinner"
+				android:layout_width="wrap_content"
+				android:layout_height="wrap_content"
+				android:entries="@array/list_pubkeyids"
+				android:entryValues="@array/list_pubkeyids_value"
+				/>
+
+		</LinearLayout>
+
+		<LinearLayout
+			android:layout_width="match_parent"
+			android:layout_height="wrap_content"
+			android:orientation="vertical"
+			>
+
+			<RelativeLayout
+				android:layout_width="match_parent"
+				android:layout_height="wrap_content"
+				>
+
+				<TextView
+					android:layout_width="match_parent"
+					android:layout_height="wrap_content"
+					android:text="@string/hostpref_authagent_title"
+					/>
+
+				<android.support.v7.widget.SwitchCompat
+					android:id="@+id/use_ssh_auth_switch"
+					android:layout_width="wrap_content"
+					android:layout_height="wrap_content"
+					android:layout_alignParentRight="true"
+					/>
+
+			</RelativeLayout>
+
+			<RelativeLayout
+				android:id="@+id/ssh_confirmation_container"
+				android:layout_width="match_parent"
+				android:layout_height="wrap_content"
+				android:visibility="gone"
+				>
+
+				<TextView
+					android:layout_width="match_parent"
+					android:layout_height="wrap_content"
+					android:text="@string/hostpref_authagent_with_confirmation"
+					/>
+
+				<android.support.v7.widget.AppCompatCheckBox
+					android:id="@+id/ssh_auth_confirmation_checkbox"
+					android:layout_width="wrap_content"
+					android:layout_height="wrap_content"
+					android:layout_alignParentRight="true"
+					/>
+
+			</RelativeLayout>
+
+		</LinearLayout>
+
+		<RelativeLayout
+			android:layout_width="match_parent"
+			android:layout_height="wrap_content"
+			>
+
+			<TextView
+				android:layout_width="match_parent"
+				android:layout_height="wrap_content"
+				android:text="@string/hostpref_compression_title"
+				/>
+
+			<android.support.v7.widget.SwitchCompat
+				android:id="@+id/compression_switch"
+				android:layout_width="wrap_content"
+				android:layout_height="wrap_content"
+				android:layout_alignParentRight="true"
+				/>
+
+		</RelativeLayout>
+
+		<RelativeLayout
+			android:layout_width="match_parent"
+			android:layout_height="wrap_content"
+			>
+
+			<TextView
+				android:layout_width="match_parent"
+				android:layout_height="wrap_content"
+				android:text="@string/hostpref_wantsession_title"
+				/>
+
+			<android.support.v7.widget.SwitchCompat
+				android:id="@+id/start_shell_switch"
+				android:layout_width="wrap_content"
+				android:layout_height="wrap_content"
+				android:layout_alignParentRight="true"
+				/>
+
+		</RelativeLayout>
+
+		<RelativeLayout
+			android:layout_width="match_parent"
+			android:layout_height="wrap_content"
+			>
+
+			<TextView
+				android:layout_width="match_parent"
+				android:layout_height="wrap_content"
+				android:text="@string/hostpref_stayconnected_title"
+				/>
+
+			<android.support.v7.widget.SwitchCompat
+				android:id="@+id/stay_connected_switch"
+				android:layout_width="wrap_content"
+				android:layout_height="wrap_content"
+				android:layout_alignParentRight="true"
+				/>
+
+		</RelativeLayout>
+
+		<RelativeLayout
+			android:layout_width="match_parent"
+			android:layout_height="wrap_content"
+			>
+
+			<TextView
+				android:layout_width="match_parent"
+				android:layout_height="wrap_content"
+				android:text="@string/hostpref_quickdisconnect_title"
+				/>
+
+			<android.support.v7.widget.SwitchCompat
+				android:id="@+id/close_on_disconnect_switch"
+				android:layout_width="wrap_content"
+				android:layout_height="wrap_content"
+				android:layout_alignParentRight="true"
+				/>
+
+		</RelativeLayout>
+
+		<RelativeLayout
+			android:layout_width="match_parent"
+			android:layout_height="wrap_content"
+			>
+
+			<TextView
+				android:layout_width="match_parent"
+				android:layout_height="wrap_content"
+				android:text="@string/hostpref_postlogin_title"
+				/>
+
+			<EditText
+				android:id="@+id/post_login_automation_field"
+				android:layout_height="wrap_content"
+				android:layout_width="fill_parent"
+				android:inputType="textMultiLine"
+				android:lines="8"
+				android:minLines="2"
+				/>
+
+		</RelativeLayout>
+
+		<LinearLayout
+			android:layout_width="wrap_content"
+			android:layout_height="wrap_content"
+			android:orientation="vertical"
+			android:layout_marginStart="4dp"
+			android:layout_marginLeft="4dp"
+			android:layout_marginBottom="4dp"
+			>
+
+			<TextView
+				android:layout_width="wrap_content"
+				android:layout_height="wrap_content"
+				android:text="@string/hostpref_delkey_title"
+				android:textSize="12sp"
+				/>
+
+			<Spinner
+				android:id="@+id/del_key_spinner"
+				android:layout_width="wrap_content"
+				android:layout_height="wrap_content"
+				android:entries="@array/list_delkey"
+				android:entryValues="@array/list_delkey_values"
+				/>
+
+		</LinearLayout>
+
+		<LinearLayout
+			android:layout_width="wrap_content"
+			android:layout_height="wrap_content"
+			android:orientation="vertical"
+			android:layout_marginStart="4dp"
+			android:layout_marginLeft="4dp"
+			android:layout_marginBottom="4dp"
+				>
+
+			<TextView
+				android:layout_width="wrap_content"
+				android:layout_height="wrap_content"
+				android:text="@string/hostpref_encoding_title"
+				android:textSize="12sp"
+				/>
+
+			<Spinner
+				android:id="@+id/encoding_spinner"
+				android:layout_width="wrap_content"
+				android:layout_height="wrap_content"
+				/>
+
+		</LinearLayout>
 
 	</LinearLayout>
 
-	<View style="@style/Divider"
-		/>
-
-</LinearLayout>
+</ScrollView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -596,5 +596,6 @@
 	<string name="protocol_spinner_label">Protocol</string>
 	<!-- Label for button which expands/collapses section. -->
 	<string name="expand">Expand</string>
+	<string name="hostpref_authagent_with_confirmation">require confirmation</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -596,6 +596,7 @@
 	<string name="protocol_spinner_label">Protocol</string>
 	<!-- Label for button which expands/collapses section. -->
 	<string name="expand">Expand</string>
+	<!-- Label for checkbox which, when check, makes SSL authorization require confirmation. -->
 	<string name="hostpref_authagent_with_confirmation">require confirmation</string>
 
 </resources>


### PR DESCRIPTION
This PR adds all the remaining UI fields and hooks them up to the fragment's HostBean object.

Remaining work includes:
  1) Passing in initial data to the fragment if it exists.
  2) Saving the host after it has been edited.
  3) UI polish (pending specs from @bengolds). The current design is very raw/ugly.