### PR TITLE
TextView in terminal for better text selection

### DIFF
--- a/app/src/main/java/org/connectbot/ConsoleActivity.java
+++ b/app/src/main/java/org/connectbot/ConsoleActivity.java
@@ -30,7 +30,6 @@ import org.connectbot.service.TerminalKeyListener;
 import org.connectbot.service.TerminalManager;
 import org.connectbot.util.PreferenceConstants;
 
-import android.annotation.TargetApi;
 import android.app.AlertDialog;
 import android.app.Dialog;
 import android.content.ComponentName;
@@ -662,6 +661,15 @@ public class ConsoleActivity extends AppCompatActivity implements BridgeDisconne
 		if (tabs != null)
 			setupTabLayoutWithViewPager();
 
+		pager.setOnClickListener(new OnClickListener() {
+			@Override
+			public void onClick(View v) {
+				if (keyboardGroup.getVisibility() == View.GONE) {
+					showEmulatedKeys(false);
+				}
+			}
+		});
+
 		if (Build.VERSION.SDK_INT < Build.VERSION_CODES.HONEYCOMB) {
 			pager.setOnTouchListener(new OnTouchListener() {
 				public boolean onTouch(View v, MotionEvent event) {
@@ -669,10 +677,6 @@ public class ConsoleActivity extends AppCompatActivity implements BridgeDisconne
 
 					boolean isCopyingInProgress =
 						(copySource != null && copySource.isSelectingForCopy());
-
-					if (!isCopyingInProgress && keyboardGroup.getVisibility() == View.GONE) {
-						showEmulatedKeys(true);
-					}
 
 					// when copying, highlight the area
 					if (isCopyingInProgress) {

--- a/app/src/main/java/org/connectbot/ConsoleActivity.java
+++ b/app/src/main/java/org/connectbot/ConsoleActivity.java
@@ -22,7 +22,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.connectbot.bean.HostBean;
-import org.connectbot.bean.SelectionArea;
 import org.connectbot.service.BridgeDisconnectedListener;
 import org.connectbot.service.PromptHelper;
 import org.connectbot.service.TerminalBridge;

--- a/app/src/main/java/org/connectbot/ConsoleActivity.java
+++ b/app/src/main/java/org/connectbot/ConsoleActivity.java
@@ -29,6 +29,7 @@ import org.connectbot.service.TerminalBridge;
 import org.connectbot.service.TerminalKeyListener;
 import org.connectbot.service.TerminalManager;
 import org.connectbot.util.PreferenceConstants;
+import org.connectbot.util.TerminalViewPager;
 
 import android.app.AlertDialog;
 import android.app.Dialog;
@@ -53,7 +54,6 @@ import android.support.design.widget.TabLayout;
 import android.support.v4.app.ActivityCompat;
 import android.support.v4.view.MenuItemCompat;
 import android.support.v4.view.PagerAdapter;
-import android.support.v4.view.ViewPager;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
@@ -99,7 +99,7 @@ public class ConsoleActivity extends AppCompatActivity implements BridgeDisconne
 	private static final int KEYBOARD_REPEAT = 100;
 	private static final String STATE_SELECTED_URI = "selectedUri";
 
-	protected ViewPager pager = null;
+	protected TerminalViewPager pager = null;
 	protected TabLayout tabs = null;
 	protected Toolbar toolbar = null;
 	@Nullable
@@ -490,10 +490,10 @@ public class ConsoleActivity extends AppCompatActivity implements BridgeDisconne
 
 		toolbar = (Toolbar) findViewById(R.id.toolbar);
 
-		pager = (ViewPager) findViewById(R.id.console_flip);
+		pager = (TerminalViewPager) findViewById(R.id.console_flip);
 
 		pager.addOnPageChangeListener(
-				new ViewPager.SimpleOnPageChangeListener() {
+				new TerminalViewPager.SimpleOnPageChangeListener() {
 					@Override
 					public void onPageSelected(int position) {
 						setTitle(adapter.getPageTitle(position));

--- a/app/src/main/java/org/connectbot/ConsoleActivity.java
+++ b/app/src/main/java/org/connectbot/ConsoleActivity.java
@@ -50,10 +50,9 @@ import android.os.IBinder;
 import android.os.Message;
 import android.preference.PreferenceManager;
 import android.support.annotation.Nullable;
-import android.support.v4.app.ActivityCompat;
 import android.support.design.widget.TabLayout;
+import android.support.v4.app.ActivityCompat;
 import android.support.v4.view.MenuItemCompat;
-import android.support.v4.view.MotionEventCompat;
 import android.support.v4.view.PagerAdapter;
 import android.support.v4.view.ViewPager;
 import android.support.v7.app.ActionBar;
@@ -61,9 +60,6 @@ import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
 import android.text.ClipboardManager;
 import android.util.Log;
-import android.view.ContextMenu;
-import android.view.GestureDetector;
-import android.view.InputDevice;
 import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -74,7 +70,6 @@ import android.view.View;
 import android.view.View.OnClickListener;
 import android.view.View.OnKeyListener;
 import android.view.View.OnTouchListener;
-import android.view.ViewConfiguration;
 import android.view.ViewGroup;
 import android.view.Window;
 import android.view.WindowManager;
@@ -100,8 +95,6 @@ public class ConsoleActivity extends AppCompatActivity implements BridgeDisconne
 
 	protected static final int REQUEST_EDIT = 1;
 
-	private static final int CLICK_TIME = 400;
-	private static final float MAX_CLICK_DISTANCE = 25f;
 	private static final int KEYBOARD_DISPLAY_TIME = 3000;
 	private static final int KEYBOARD_REPEAT_INITIAL = 500;
 	private static final int KEYBOARD_REPEAT = 100;
@@ -140,7 +133,6 @@ public class ConsoleActivity extends AppCompatActivity implements BridgeDisconne
 	private Animation fade_out_delayed;
 
 	private Animation keyboard_fade_in, keyboard_fade_out;
-	private float lastX, lastY;
 
 	private InputMethodManager inputManager;
 
@@ -498,8 +490,9 @@ public class ConsoleActivity extends AppCompatActivity implements BridgeDisconne
 		inflater = LayoutInflater.from(this);
 
 		toolbar = (Toolbar) findViewById(R.id.toolbar);
+
 		pager = (ViewPager) findViewById(R.id.console_flip);
-		registerForContextMenu(pager);
+
 		pager.addOnPageChangeListener(
 				new ViewPager.SimpleOnPageChangeListener() {
 					@Override
@@ -669,255 +662,81 @@ public class ConsoleActivity extends AppCompatActivity implements BridgeDisconne
 		if (tabs != null)
 			setupTabLayoutWithViewPager();
 
-		// detect fling gestures to switch between terminals
-		final GestureDetector detect = new GestureDetector(this, new GestureDetector.SimpleOnGestureListener() {
-			private float totalY = 0;
+		if (Build.VERSION.SDK_INT < Build.VERSION_CODES.HONEYCOMB) {
+			pager.setOnTouchListener(new OnTouchListener() {
+				public boolean onTouch(View v, MotionEvent event) {
+					TerminalBridge bridge = adapter.getCurrentTerminalView().bridge;
 
-			@Override
-			public void onLongPress(MotionEvent e) {
-				super.onLongPress(e);
-				openContextMenu(pager);
-			}
+					boolean isCopyingInProgress =
+						(copySource != null && copySource.isSelectingForCopy());
 
-
-			@Override
-			public boolean onScroll(MotionEvent e1, MotionEvent e2, float distanceX, float distanceY) {
-
-				// if copying, then ignore
-				if (copySource != null && copySource.isSelectingForCopy())
-					return false;
-
-				if (e1 == null || e2 == null)
-					return false;
-
-				// if releasing then reset total scroll
-				if (e2.getAction() == MotionEvent.ACTION_UP) {
-					totalY = 0;
-				}
-
-				// activate consider if within x tolerance
-				int touchSlop = ViewConfiguration.get(ConsoleActivity.this).getScaledTouchSlop();
-				if (Math.abs(e1.getX() - e2.getX()) < touchSlop * 4) {
-
-					View view = adapter.getCurrentTerminalView();
-					if (view == null) return false;
-					TerminalView terminal = (TerminalView) view;
-
-					// estimate how many rows we have scrolled through
-					// accumulate distance that doesn't trigger immediate scroll
-					totalY += distanceY;
-					final int moved = (int) (totalY / terminal.bridge.charHeight);
-
-					// consume as scrollback only if towards right half of screen
-					if (e2.getX() > view.getWidth() / 2) {
-						if (moved != 0) {
-							int base = terminal.bridge.buffer.getWindowBase();
-							terminal.bridge.buffer.setWindowBase(base + moved);
-							totalY = 0;
-							return true;
-						}
-					} else {
-						// otherwise consume as pgup/pgdown for every 5 lines
-						if (moved > 5) {
-							((vt320) terminal.bridge.buffer).keyPressed(vt320.KEY_PAGE_DOWN, ' ', 0);
-							terminal.bridge.tryKeyVibrate();
-							totalY = 0;
-							return true;
-						} else if (moved < -5) {
-							((vt320) terminal.bridge.buffer).keyPressed(vt320.KEY_PAGE_UP, ' ', 0);
-							terminal.bridge.tryKeyVibrate();
-							totalY = 0;
-							return true;
-						}
-
+					if (!isCopyingInProgress && keyboardGroup.getVisibility() == View.GONE) {
+						showEmulatedKeys(true);
 					}
 
-				}
+					// when copying, highlight the area
+					if (isCopyingInProgress) {
+						SelectionArea area = copySource.getSelectionArea();
+						int row = (int) Math.floor(event.getY() / bridge.charHeight);
+						int col = (int) Math.floor(event.getX() / bridge.charWidth);
 
-				return false;
-			}
+						switch (event.getAction()) {
+						case MotionEvent.ACTION_DOWN:
+							// recording starting area
+							if (area.isSelectingOrigin()) {
+								area.setRow(row);
+								area.setColumn(col);
+								lastTouchRow = row;
+								lastTouchCol = col;
+								copySource.redraw();
+							}
+							return true;
+						case MotionEvent.ACTION_MOVE:
+							/* ignore when user hasn't moved since last time so
+							 * we can fine-tune with directional pad
+							 */
+							if (row == lastTouchRow && col == lastTouchCol)
+								return true;
 
+							// if the user moves, start the selection for other corner
+							area.finishSelectingOrigin();
 
-		});
-
-		pager.setLongClickable(true);
-		pager.setOnTouchListener(new OnTouchListener() {
-
-			public boolean onTouch(View v, MotionEvent event) {
-				TerminalBridge bridge = adapter.getCurrentTerminalView().bridge;
-
-				// Handle mouse-specific actions.
-				if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH &&
-						MotionEventCompat.getSource(event) == InputDevice.SOURCE_MOUSE) {
-					if (onMouseEvent(event, bridge)) {
-						return true;
-					}
-				}
-
-				// when copying, highlight the area
-				if (copySource != null && copySource.isSelectingForCopy()) {
-					SelectionArea area = copySource.getSelectionArea();
-					int row = (int) Math.floor(event.getY() / bridge.charHeight);
-					int col = (int) Math.floor(event.getX() / bridge.charWidth);
-
-					switch (event.getAction()) {
-					case MotionEvent.ACTION_DOWN:
-						// recording starting area
-						if (area.isSelectingOrigin()) {
+							// update selected area
 							area.setRow(row);
 							area.setColumn(col);
 							lastTouchRow = row;
 							lastTouchCol = col;
 							copySource.redraw();
-						}
-						return true;
-					case MotionEvent.ACTION_MOVE:
-						/* ignore when user hasn't moved since last time so
-						 * we can fine-tune with directional pad
-						 */
-						if (row == lastTouchRow && col == lastTouchCol)
 							return true;
+						case MotionEvent.ACTION_UP:
+							/* If they didn't move their finger, maybe they meant to
+							 * select the rest of the text with the directional pad.
+							 */
+							if (area.getLeft() == area.getRight() &&
+									area.getTop() == area.getBottom()) {
+								return true;
+							}
 
-						// if the user moves, start the selection for other corner
-						area.finishSelectingOrigin();
+							// copy selected area to clipboard
+							String copiedText = area.copyFrom(copySource.buffer);
 
-						// update selected area
-						area.setRow(row);
-						area.setColumn(col);
-						lastTouchRow = row;
-						lastTouchCol = col;
-						copySource.redraw();
-						return true;
-					case MotionEvent.ACTION_UP:
-						/* If they didn't move their finger, maybe they meant to
-						 * select the rest of the text with the directional pad.
-						 */
-						if (area.getLeft() == area.getRight() &&
-								area.getTop() == area.getBottom()) {
-							return true;
-						}
+							clipboard.setText(copiedText);
+							Toast.makeText(ConsoleActivity.this, getString(R.string.console_copy_done, copiedText.length()), Toast.LENGTH_LONG).show();
+							// fall through to clear state
 
-						// copy selected area to clipboard
-						String copiedText = area.copyFrom(copySource.buffer);
-
-						clipboard.setText(copiedText);
-						Toast.makeText(ConsoleActivity.this, getString(R.string.console_copy_done, copiedText.length()), Toast.LENGTH_LONG).show();
-						// fall through to clear state
-
-					case MotionEvent.ACTION_CANCEL:
-						// make sure we clear any highlighted area
-						area.reset();
-						copySource.setSelectingForCopy(false);
-						copySource.redraw();
-						return true;
-					}
-				}
-
-				if (event.getAction() == MotionEvent.ACTION_DOWN) {
-					lastX = event.getX();
-					lastY = event.getY();
-				} else if (event.getAction() == MotionEvent.ACTION_UP
-						&& keyboardGroup.getVisibility() == View.GONE
-						&& event.getEventTime() - event.getDownTime() < CLICK_TIME
-						&& Math.abs(event.getX() - lastX) < MAX_CLICK_DISTANCE
-						&& Math.abs(event.getY() - lastY) < MAX_CLICK_DISTANCE) {
-					showEmulatedKeys(true);
-				}
-
-				// pass any touch events back to detector
-				return detect.onTouchEvent(event);
-			}
-
-			/**
-			 * @param event
-			 * @param bridge
-			 * @return True if the event is handled.
-			 */
-			@TargetApi(14)
-			private boolean onMouseEvent(MotionEvent event, TerminalBridge bridge) {
-				int row = (int) Math.floor(event.getY() / bridge.charHeight);
-				int col = (int) Math.floor(event.getX() / bridge.charWidth);
-				int meta = event.getMetaState();
-				boolean shiftOn = (meta & KeyEvent.META_SHIFT_ON) != 0;
-				boolean mouseReport = ((vt320) bridge.buffer).isMouseReportEnabled();
-
-				// MouseReport can be "defeated" using the shift key.
-				if ((!mouseReport || shiftOn)) {
-					if (event.getAction() == MotionEvent.ACTION_DOWN) {
-						switch (event.getButtonState()) {
-						case MotionEvent.BUTTON_PRIMARY:
-							// Automatically start copy mode if using a mouse.
-							startCopyMode();
-							break;
-						case MotionEvent.BUTTON_SECONDARY:
-							openContextMenu(pager);
-							return true;
-						case MotionEvent.BUTTON_TERTIARY:
-							// Middle click pastes.
-							pasteIntoTerminal();
+						case MotionEvent.ACTION_CANCEL:
+							// make sure we clear any highlighted area
+							area.reset();
+							copySource.setSelectingForCopy(false);
+							copySource.redraw();
 							return true;
 						}
 					}
-				} else if (event.getAction() == MotionEvent.ACTION_DOWN) {
-					((vt320) bridge.buffer).mousePressed(
-							col, row, mouseEventToJavaModifiers(event));
-					return true;
-				} else if (event.getAction() == MotionEvent.ACTION_UP) {
-					((vt320) bridge.buffer).mouseReleased(col, row);
-					return true;
-				} else if (event.getAction() == MotionEvent.ACTION_MOVE) {
-					int buttonState = event.getButtonState();
-					int button = (buttonState & MotionEvent.BUTTON_PRIMARY) != 0 ? 0 :
-							(buttonState & MotionEvent.BUTTON_SECONDARY) != 0 ? 1 :
-									(buttonState & MotionEvent.BUTTON_TERTIARY) != 0 ? 2 : 3;
-					((vt320) bridge.buffer).mouseMoved(
-							button,
-							col,
-							row,
-							(meta & KeyEvent.META_CTRL_ON) != 0,
-							(meta & KeyEvent.META_SHIFT_ON) != 0,
-							(meta & KeyEvent.META_META_ON) != 0);
+
 					return true;
 				}
-
-				return false;
-			}
-
-		});
-	}
-
-	/**
-	 * Takes an android mouse event and produces a Java InputEvent modifiers int which can be
-	 * passed to vt320.
-	 * @param mouseEvent The {@link MotionEvent} which should be a mouse click or release.
-	 * @return A Java InputEvent modifier int. See
-	 * http://docs.oracle.com/javase/7/docs/api/java/awt/event/InputEvent.html
-	 */
-	@TargetApi(14)
-	private static int mouseEventToJavaModifiers(MotionEvent mouseEvent) {
-		if (MotionEventCompat.getSource(mouseEvent) != InputDevice.SOURCE_MOUSE) return 0;
-
-		int mods = 0;
-
-		// See http://docs.oracle.com/javase/7/docs/api/constant-values.html
-		int buttonState = mouseEvent.getButtonState();
-		if ((buttonState & MotionEvent.BUTTON_PRIMARY) != 0)
-			mods |= 16;
-		if ((buttonState & MotionEvent.BUTTON_SECONDARY) != 0)
-			mods |= 8;
-		if ((buttonState & MotionEvent.BUTTON_TERTIARY) != 0)
-			mods |= 4;
-
-		// Note: Meta and Ctrl are intentionally swapped here to keep logic in vt320 simple.
-		int meta = mouseEvent.getMetaState();
-		if ((meta & KeyEvent.META_META_ON) != 0)
-			mods |= 2;
-		if ((meta & KeyEvent.META_SHIFT_ON) != 0)
-			mods |= 1;
-		if ((meta & KeyEvent.META_CTRL_ON) != 0)
-			mods |= 4;
-
-		return mods;
+			});
+		}
 	}
 
 	/**
@@ -1011,19 +830,21 @@ public class ConsoleActivity extends AppCompatActivity implements BridgeDisconne
 			}
 		});
 
-		copy = menu.add(R.string.console_menu_copy);
-		if (hardKeyboard)
-			copy.setAlphabeticShortcut('c');
-		MenuItemCompat.setShowAsAction(copy, MenuItemCompat.SHOW_AS_ACTION_IF_ROOM);
-		copy.setIcon(R.drawable.ic_action_copy);
-		copy.setEnabled(activeTerminal);
-		copy.setOnMenuItemClickListener(new OnMenuItemClickListener() {
-			public boolean onMenuItemClick(MenuItem item) {
-				startCopyMode();
-				Toast.makeText(ConsoleActivity.this, getString(R.string.console_copy_start), Toast.LENGTH_LONG).show();
-				return true;
-			}
-		});
+		if (Build.VERSION.SDK_INT < Build.VERSION_CODES.HONEYCOMB) {
+			copy = menu.add(R.string.console_menu_copy);
+			if (hardKeyboard)
+				copy.setAlphabeticShortcut('c');
+			MenuItemCompat.setShowAsAction(copy, MenuItemCompat.SHOW_AS_ACTION_IF_ROOM);
+			copy.setIcon(R.drawable.ic_action_copy);
+			copy.setEnabled(activeTerminal);
+			copy.setOnMenuItemClickListener(new OnMenuItemClickListener() {
+				public boolean onMenuItemClick(MenuItem item) {
+					startCopyMode();
+					Toast.makeText(ConsoleActivity.this, getString(R.string.console_copy_start), Toast.LENGTH_LONG).show();
+					return true;
+				}
+			});
+		}
 
 		paste = menu.add(R.string.console_menu_paste);
 		if (hardKeyboard)
@@ -1144,7 +965,10 @@ public class ConsoleActivity extends AppCompatActivity implements BridgeDisconne
 			disconnect.setTitle(R.string.list_host_disconnect);
 		else
 			disconnect.setTitle(R.string.console_menu_close);
-		copy.setEnabled(activeTerminal);
+
+		if (Build.VERSION.SDK_INT < Build.VERSION_CODES.HONEYCOMB) {
+			copy.setEnabled(activeTerminal);
+		}
 		paste.setEnabled(clipboard.hasText() && sessionOpen);
 		portForward.setEnabled(sessionOpen && canForwardPorts);
 		urlscan.setEnabled(activeTerminal);
@@ -1171,32 +995,6 @@ public class ConsoleActivity extends AppCompatActivity implements BridgeDisconne
 		super.onOptionsMenuClosed(menu);
 
 		setVolumeControlStream(AudioManager.STREAM_MUSIC);
-	}
-
-	@Override
-	public void onCreateContextMenu(ContextMenu menu, View v, ContextMenu.ContextMenuInfo menuInfo) {
-		final TerminalView view = adapter.getCurrentTerminalView();
-		boolean activeTerminal = view != null;
-		boolean sessionOpen = false;
-
-		if (activeTerminal) {
-			TerminalBridge bridge = view.bridge;
-			sessionOpen = bridge.isSessionOpen();
-		}
-
-		MenuItem paste = menu.add(R.string.console_menu_paste);
-		if (hardKeyboard)
-			paste.setAlphabeticShortcut('v');
-		paste.setIcon(android.R.drawable.ic_menu_edit);
-		paste.setEnabled(clipboard.hasText() && sessionOpen);
-		paste.setOnMenuItemClickListener(new OnMenuItemClickListener() {
-			public boolean onMenuItemClick(MenuItem item) {
-				pasteIntoTerminal();
-				return true;
-			}
-		});
-
-
 	}
 
 	@Override
@@ -1308,6 +1106,9 @@ public class ConsoleActivity extends AppCompatActivity implements BridgeDisconne
 		super.onSaveInstanceState(savedInstanceState);
 	}
 
+	/**
+	 * Only intended for pre-Honeycomb devices.
+	 */
 	private void startCopyMode() {
 		// mark as copying and reset any previous bounds
 		TerminalView terminalView = (TerminalView) adapter.getCurrentTerminalView();
@@ -1494,7 +1295,7 @@ public class ConsoleActivity extends AppCompatActivity implements BridgeDisconne
 			overlay.setText(bridge.host.getNickname());
 
 			// and add our terminal view control, using index to place behind overlay
-			final TerminalView terminal = new TerminalView(container.getContext(), bridge);
+			final TerminalView terminal = new TerminalView(container.getContext(), bridge, pager);
 			terminal.setId(R.id.terminal_view);
 			view.addView(terminal, 0);
 
@@ -1572,7 +1373,9 @@ public class ConsoleActivity extends AppCompatActivity implements BridgeDisconne
 
 		public TerminalView getCurrentTerminalView() {
 			View currentView = pager.findViewWithTag(getBridgeAtPosition(pager.getCurrentItem()));
-			if (currentView == null) return null;
+			if (currentView == null) {
+				return null;
+			}
 			return (TerminalView) currentView.findViewById(R.id.terminal_view);
 		}
 	}

--- a/app/src/main/java/org/connectbot/TerminalView.java
+++ b/app/src/main/java/org/connectbot/TerminalView.java
@@ -26,8 +26,8 @@ import org.connectbot.service.FontSizeChangedListener;
 import org.connectbot.service.TerminalBridge;
 import org.connectbot.service.TerminalKeyListener;
 
-import android.annotation.TargetApi;
 import android.annotation.SuppressLint;
+import android.annotation.TargetApi;
 import android.content.ContentResolver;
 import android.content.Context;
 import android.content.Intent;
@@ -391,7 +391,20 @@ public class TerminalView extends TextView implements FontSizeChangedListener {
 			case MotionEvent.ACTION_SCROLL:
 				// Process scroll wheel movement:
 				float yDistance = MotionEventCompat.getAxisValue(event, MotionEvent.AXIS_VSCROLL);
-				if (yDistance != 0) {
+				boolean mouseReport = ((vt320) bridge.buffer).isMouseReportEnabled();
+				if (mouseReport) {
+					int row = (int) Math.floor(event.getY() / bridge.charHeight);
+					int col = (int) Math.floor(event.getX() / bridge.charWidth);
+
+							((vt320) bridge.buffer).mouseWheel(
+											yDistance > 0,
+											col,
+											row,
+											(event.getMetaState() & KeyEvent.META_CTRL_ON) != 0,
+											(event.getMetaState() & KeyEvent.META_SHIFT_ON) != 0,
+											(event.getMetaState() & KeyEvent.META_META_ON) != 0);
+					return true;
+				} else if (yDistance != 0) {
 					int base = bridge.buffer.getWindowBase();
 					bridge.buffer.setWindowBase(base - Math.round(yDistance));
 					return true;
@@ -530,10 +543,10 @@ public class TerminalView extends TextView implements FontSizeChangedListener {
 				SelectionArea area = bridge.getSelectionArea();
 				canvas.save(Canvas.CLIP_SAVE_FLAG);
 				canvas.clipRect(
-						area.getLeft() * bridge.charWidth,
-						area.getTop() * bridge.charHeight,
-						(area.getRight() + 1) * bridge.charWidth,
-						(area.getBottom() + 1) * bridge.charHeight
+					area.getLeft() * bridge.charWidth,
+					area.getTop() * bridge.charHeight,
+					(area.getRight() + 1) * bridge.charWidth,
+					(area.getBottom() + 1) * bridge.charHeight
 				);
 				canvas.drawPaint(cursorPaint);
 				canvas.restore();

--- a/app/src/main/java/org/connectbot/TerminalView.java
+++ b/app/src/main/java/org/connectbot/TerminalView.java
@@ -25,6 +25,7 @@ import org.connectbot.bean.SelectionArea;
 import org.connectbot.service.FontSizeChangedListener;
 import org.connectbot.service.TerminalBridge;
 import org.connectbot.service.TerminalKeyListener;
+import org.connectbot.util.TerminalViewPager;
 
 import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
@@ -44,7 +45,6 @@ import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Build;
 import android.support.v4.view.MotionEventCompat;
-import android.support.v4.view.ViewPager;
 import android.text.ClipboardManager;
 import android.view.ActionMode;
 import android.view.GestureDetector;
@@ -77,7 +77,7 @@ public class TerminalView extends TextView implements FontSizeChangedListener {
 	private final Context context;
 	public final TerminalBridge bridge;
 
-	private final ViewPager viewPager;
+	private final TerminalViewPager viewPager;
 	private GestureDetector gestureDetector;
 
 	private ClipboardManager clipboard;
@@ -114,7 +114,7 @@ public class TerminalView extends TextView implements FontSizeChangedListener {
 	private static final String SCREENREADER_INTENT_ACTION = "android.accessibilityservice.AccessibilityService";
 	private static final String SCREENREADER_INTENT_CATEGORY = "android.accessibilityservice.category.FEEDBACK_SPOKEN";
 
-	public TerminalView(Context context, TerminalBridge bridge, ViewPager pager) {
+	public TerminalView(Context context, TerminalBridge bridge, TerminalViewPager pager) {
 		super(context);
 
 		this.context = context;
@@ -292,6 +292,7 @@ public class TerminalView extends TextView implements FontSizeChangedListener {
 			if (onMouseEvent(event, bridge)) {
 				return true;
 			}
+			viewPager.setPagingEnabled(true);
 		}
 
 		super.onTouchEvent(event);
@@ -327,24 +328,26 @@ public class TerminalView extends TextView implements FontSizeChangedListener {
 				}
 			}
 		} else if (event.getAction() == MotionEvent.ACTION_DOWN) {
+			viewPager.setPagingEnabled(false);
 			((vt320) bridge.buffer).mousePressed(
-					col, row, mouseEventToJavaModifiers(event));
+				col, row, mouseEventToJavaModifiers(event));
 			return true;
 		} else if (event.getAction() == MotionEvent.ACTION_UP) {
+			viewPager.setPagingEnabled(true);
 			((vt320) bridge.buffer).mouseReleased(col, row);
 			return true;
 		} else if (event.getAction() == MotionEvent.ACTION_MOVE) {
 			int buttonState = event.getButtonState();
 			int button = (buttonState & MotionEvent.BUTTON_PRIMARY) != 0 ? 0 :
-					(buttonState & MotionEvent.BUTTON_SECONDARY) != 0 ? 1 :
-							(buttonState & MotionEvent.BUTTON_TERTIARY) != 0 ? 2 : 3;
+				(buttonState & MotionEvent.BUTTON_SECONDARY) != 0 ? 1 :
+				(buttonState & MotionEvent.BUTTON_TERTIARY) != 0 ? 2 : 3;
 			((vt320) bridge.buffer).mouseMoved(
-					button,
-					col,
-					row,
-					(meta & KeyEvent.META_CTRL_ON) != 0,
-					(meta & KeyEvent.META_SHIFT_ON) != 0,
-					(meta & KeyEvent.META_META_ON) != 0);
+				button,
+				col,
+				row,
+				(meta & KeyEvent.META_CTRL_ON) != 0,
+				(meta & KeyEvent.META_SHIFT_ON) != 0,
+				(meta & KeyEvent.META_META_ON) != 0);
 			return true;
 		}
 

--- a/app/src/main/java/org/connectbot/TerminalView.java
+++ b/app/src/main/java/org/connectbot/TerminalView.java
@@ -288,11 +288,10 @@ public class TerminalView extends TextView implements FontSizeChangedListener {
 
 			menu.clear();
 
-			// TODO: these need to be localized
-			menu.add(0, COPY, 0, "Copy")
+			menu.add(0, COPY, 0, R.string.console_menu_copy)
 					.setIcon(R.drawable.ic_action_copy)
 					.setShowAsAction(MenuItem.SHOW_AS_ACTION_WITH_TEXT | MenuItem.SHOW_AS_ACTION_IF_ROOM);
-			menu.add(0, PASTE, 1, "Paste")
+			menu.add(0, PASTE, 1, R.string.console_menu_paste)
 					.setIcon(R.drawable.ic_action_paste)
 					.setShowAsAction(MenuItem.SHOW_AS_ACTION_WITH_TEXT | MenuItem.SHOW_AS_ACTION_IF_ROOM);
 

--- a/app/src/main/java/org/connectbot/TerminalView.java
+++ b/app/src/main/java/org/connectbot/TerminalView.java
@@ -269,7 +269,9 @@ public class TerminalView extends TextView implements FontSizeChangedListener {
 
 	@Override
 	protected void onSelectionChanged(int selStart, int selEnd) {
-		currentSelection = getText().toString().substring(selStart, selEnd);
+		if (selStart <= selEnd) {
+			currentSelection = getText().toString().substring(selStart, selEnd);
+		}
 		super.onSelectionChanged(selStart, selEnd);
 	}
 

--- a/app/src/main/java/org/connectbot/TerminalView.java
+++ b/app/src/main/java/org/connectbot/TerminalView.java
@@ -35,6 +35,7 @@ import android.content.Intent;
 import android.content.pm.ResolveInfo;
 import android.database.Cursor;
 import android.graphics.Canvas;
+import android.graphics.Color;
 import android.graphics.Matrix;
 import android.graphics.Paint;
 import android.graphics.Path;
@@ -173,7 +174,7 @@ public class TerminalView extends TextView implements FontSizeChangedListener {
 
 		clipboard = (ClipboardManager) context.getSystemService(Context.CLIPBOARD_SERVICE);
 
-		setTextColor(0x00000000);
+		setTextColor(Color.TRANSPARENT);
 		setTypeface(Typeface.MONOSPACE);
 		onFontSizeChanged(bridge.getFontSize());
 

--- a/app/src/main/java/org/connectbot/TerminalView.java
+++ b/app/src/main/java/org/connectbot/TerminalView.java
@@ -54,7 +54,6 @@ import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.MotionEvent;
-import android.view.View;
 import android.view.ViewGroup.LayoutParams;
 import android.view.accessibility.AccessibilityEvent;
 import android.view.accessibility.AccessibilityManager;
@@ -67,7 +66,7 @@ import de.mud.terminal.VDUBuffer;
 import de.mud.terminal.vt320;
 
 /**
- * User interface {@link View} for showing a TerminalBridge in an
+ * User interface {@link TextView} for showing a TerminalBridge in an
  * {@link android.app.Activity}. Handles drawing bitmap updates and passing keystrokes down
  * to terminal.
  *

--- a/app/src/main/java/org/connectbot/TerminalView.java
+++ b/app/src/main/java/org/connectbot/TerminalView.java
@@ -162,7 +162,7 @@ public class TerminalView extends TextView implements FontSizeChangedListener {
 		scaleMatrix = new Matrix();
 
 		bridge.addFontSizeChangedListener(this);
-		bridge.terminalView = this;
+		bridge.parentChanged(this);
 
 		// connect our view up to the bridge
 		setOnKeyListener(bridge.getKeyHandler());

--- a/app/src/main/java/org/connectbot/TerminalView.java
+++ b/app/src/main/java/org/connectbot/TerminalView.java
@@ -402,7 +402,8 @@ public class TerminalView extends TextView implements FontSizeChangedListener {
 		int col = (int) Math.floor(event.getX() / bridge.charWidth);
 		int meta = event.getMetaState();
 		boolean shiftOn = (meta & KeyEvent.META_SHIFT_ON) != 0;
-		boolean mouseReport = ((vt320) bridge.buffer).isMouseReportEnabled();
+		vt320 vtBuffer = (vt320) bridge.buffer;
+		boolean mouseReport = vtBuffer.isMouseReportEnabled();
 
 		// MouseReport can be "defeated" using the shift key.
 		if (!mouseReport || shiftOn) {
@@ -439,19 +440,19 @@ public class TerminalView extends TextView implements FontSizeChangedListener {
 			}
 		} else if (event.getAction() == MotionEvent.ACTION_DOWN) {
 			viewPager.setPagingEnabled(false);
-			((vt320) bridge.buffer).mousePressed(
-				col, row, mouseEventToJavaModifiers(event));
+			vtBuffer.mousePressed(
+					col, row, mouseEventToJavaModifiers(event));
 			return true;
 		} else if (event.getAction() == MotionEvent.ACTION_UP) {
 			viewPager.setPagingEnabled(true);
-			((vt320) bridge.buffer).mouseReleased(col, row);
+			vtBuffer.mouseReleased(col, row);
 			return true;
 		} else if (event.getAction() == MotionEvent.ACTION_MOVE) {
 			int buttonState = event.getButtonState();
 			int button = (buttonState & MotionEvent.BUTTON_PRIMARY) != 0 ? 0 :
 				(buttonState & MotionEvent.BUTTON_SECONDARY) != 0 ? 1 :
 				(buttonState & MotionEvent.BUTTON_TERTIARY) != 0 ? 2 : 3;
-			((vt320) bridge.buffer).mouseMoved(
+			vtBuffer.mouseMoved(
 				button,
 				col,
 				row,
@@ -506,18 +507,19 @@ public class TerminalView extends TextView implements FontSizeChangedListener {
 			case MotionEvent.ACTION_SCROLL:
 				// Process scroll wheel movement:
 				float yDistance = MotionEventCompat.getAxisValue(event, MotionEvent.AXIS_VSCROLL);
-				boolean mouseReport = ((vt320) bridge.buffer).isMouseReportEnabled();
+				vt320 vtBuffer = (vt320) bridge.buffer;
+				boolean mouseReport = vtBuffer.isMouseReportEnabled();
 				if (mouseReport) {
 					int row = (int) Math.floor(event.getY() / bridge.charHeight);
 					int col = (int) Math.floor(event.getX() / bridge.charWidth);
 
-							((vt320) bridge.buffer).mouseWheel(
-											yDistance > 0,
-											col,
-											row,
-											(event.getMetaState() & KeyEvent.META_CTRL_ON) != 0,
-											(event.getMetaState() & KeyEvent.META_SHIFT_ON) != 0,
-											(event.getMetaState() & KeyEvent.META_META_ON) != 0);
+					vtBuffer.mouseWheel(
+							yDistance > 0,
+							col,
+							row,
+							(event.getMetaState() & KeyEvent.META_CTRL_ON) != 0,
+							(event.getMetaState() & KeyEvent.META_SHIFT_ON) != 0,
+							(event.getMetaState() & KeyEvent.META_META_ON) != 0);
 					return true;
 				} else if (yDistance != 0) {
 					int base = bridge.buffer.getWindowBase();

--- a/app/src/main/java/org/connectbot/TerminalView.java
+++ b/app/src/main/java/org/connectbot/TerminalView.java
@@ -46,6 +46,7 @@ import android.os.AsyncTask;
 import android.os.Build;
 import android.support.v4.view.MotionEventCompat;
 import android.text.ClipboardManager;
+import android.util.Log;
 import android.view.ActionMode;
 import android.view.GestureDetector;
 import android.view.InputDevice;
@@ -421,7 +422,7 @@ public class TerminalView extends TextView implements FontSizeChangedListener {
 
 	private void copyBufferToText() {
 		if (Build.VERSION.SDK_INT < Build.VERSION_CODES.HONEYCOMB) {
-			// It is pointless to run this function because the textView is not selectable pre-Honeycomb.
+			// Do not run this function because the textView is not selectable pre-Honeycomb.
 			return;
 		}
 
@@ -463,7 +464,27 @@ public class TerminalView extends TextView implements FontSizeChangedListener {
 	public void onFontSizeChanged(float size) {
 		scaleCursors();
 		setTextSize(size);
-		setLineSpacing(0.0f, 1.1f); // KLUDGE: doesnt work on certain font sizes
+
+		int iterationGuard = 100;
+		int heightDifference = 100;
+		float lineSpacingMultiplier = 1.0f;
+
+		while (Math.abs(heightDifference) > 0) {
+			if (heightDifference > 0) {
+				lineSpacingMultiplier += 0.01f;
+			} else {
+				lineSpacingMultiplier -= 0.01f;
+			}
+
+			setLineSpacing(0.0f, lineSpacingMultiplier);
+			heightDifference = bridge.charHeight - getLineHeight();
+
+			iterationGuard--;
+			if (iterationGuard < 0) {
+				break;
+			}
+		}
+
 		copyBufferToText();
 	}
 

--- a/app/src/main/java/org/connectbot/TerminalView.java
+++ b/app/src/main/java/org/connectbot/TerminalView.java
@@ -27,7 +27,6 @@ import org.connectbot.service.TerminalBridge;
 import org.connectbot.service.TerminalKeyListener;
 import org.connectbot.util.TerminalViewPager;
 
-import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
 import android.app.Activity;
 import android.content.ContentResolver;
@@ -181,43 +180,7 @@ public class TerminalView extends TextView implements FontSizeChangedListener {
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
 			setTextIsSelectable(true);
 
-			this.setCustomSelectionActionModeCallback(new ActionMode.Callback() {
-				private static final int PASTE = 0;
-
-				@Override
-				@SuppressLint("NewApi")
-				public boolean onCreateActionMode(ActionMode mode, Menu menu) {
-					TerminalView.this.selectionActionMode = mode;
-
-					menu.add(0, PASTE, 2, "Paste")
-							.setIcon(R.drawable.ic_action_paste)
-							.setShowAsAction(MenuItem.SHOW_AS_ACTION_WITH_TEXT | MenuItem.SHOW_AS_ACTION_ALWAYS);
-
-					return true;
-				}
-
-				@Override
-				@SuppressLint("NewApi")
-				public boolean onActionItemClicked(ActionMode mode, MenuItem item) {
-					if (item.getItemId() == PASTE) {
-						String clip = clipboard.getText().toString();
-						TerminalView.this.bridge.injectString(clip);
-						mode.finish();
-						return true;
-					}
-
-					return false;
-				}
-
-				@Override
-				public boolean onPrepareActionMode(ActionMode mode, Menu menu) {
-					return false;
-				}
-
-				@Override
-				public void onDestroyActionMode(ActionMode mode) {
-				}
-			});
+			initSelectionCallback();
 
 			gestureDetector = new GestureDetector(context, new GestureDetector.SimpleOnGestureListener() {
 				private TerminalBridge bridge = TerminalView.this.bridge;
@@ -251,6 +214,45 @@ public class TerminalView extends TextView implements FontSizeChangedListener {
 				}
 			});
 		}
+	}
+
+	@TargetApi(11)
+	private void initSelectionCallback() {
+		this.setCustomSelectionActionModeCallback(new ActionMode.Callback() {
+			private static final int PASTE = 0;
+
+			@Override
+			public boolean onCreateActionMode(ActionMode mode, Menu menu) {
+				TerminalView.this.selectionActionMode = mode;
+
+				menu.add(0, PASTE, 2, "Paste")
+						.setIcon(R.drawable.ic_action_paste)
+						.setShowAsAction(MenuItem.SHOW_AS_ACTION_WITH_TEXT | MenuItem.SHOW_AS_ACTION_IF_ROOM);
+
+				return true;
+			}
+
+			@Override
+			public boolean onActionItemClicked(ActionMode mode, MenuItem item) {
+				if (item.getItemId() == PASTE) {
+					String clip = clipboard.getText().toString();
+					TerminalView.this.bridge.injectString(clip);
+					mode.finish();
+					return true;
+				}
+
+				return false;
+			}
+
+			@Override
+			public boolean onPrepareActionMode(ActionMode mode, Menu menu) {
+				return false;
+			}
+
+			@Override
+			public void onDestroyActionMode(ActionMode mode) {
+			}
+		});
 	}
 
 	public void copyCurrentSelectionToClipboard() {

--- a/app/src/main/java/org/connectbot/TerminalView.java
+++ b/app/src/main/java/org/connectbot/TerminalView.java
@@ -253,9 +253,11 @@ public class TerminalView extends TextView implements FontSizeChangedListener {
 	@Override
 	public boolean onTouchEvent(MotionEvent event) {
 		if (event.getAction() == MotionEvent.ACTION_DOWN) {
+			// Selection may be beginning. Sync the TextView with the buffer.
 			refreshTextFromBuffer();
 		}
 
+		// Mouse input is treated differently:
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH &&
 				MotionEventCompat.getSource(event) == InputDevice.SOURCE_MOUSE) {
 			if (onMouseEvent(event, bridge)) {
@@ -263,6 +265,7 @@ public class TerminalView extends TextView implements FontSizeChangedListener {
 			}
 			viewPager.setPagingEnabled(true);
 		} else if (gestureDetector != null) {
+			// The gesture detector should not be called if touch event was from mouse.
 			gestureDetector.onTouchEvent(event);
 		}
 

--- a/app/src/main/java/org/connectbot/TerminalView.java
+++ b/app/src/main/java/org/connectbot/TerminalView.java
@@ -209,8 +209,6 @@ public class TerminalView extends TextView implements FontSizeChangedListener {
 					int base = bridge.buffer.getWindowBase();
 					bridge.buffer.setWindowBase(base + moved);
 					totalY = 0;
-
-					refreshTextFromBuffer();
 				}
 
 				return true;
@@ -253,13 +251,11 @@ public class TerminalView extends TextView implements FontSizeChangedListener {
 	}
 
 	@Override
-	public boolean performLongClick() {
-		refreshTextFromBuffer();
-		return super.performLongClick();
-	}
-
-	@Override
 	public boolean onTouchEvent(MotionEvent event) {
+		if (event.getAction() == MotionEvent.ACTION_DOWN) {
+			refreshTextFromBuffer();
+		}
+
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH &&
 				MotionEventCompat.getSource(event) == InputDevice.SOURCE_MOUSE) {
 			if (onMouseEvent(event, bridge)) {
@@ -416,7 +412,7 @@ public class TerminalView extends TextView implements FontSizeChangedListener {
 				}
 
 				// Begin "selection mode"
-				refreshTextFromBuffer();
+
 				if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
 					closeSelectionActionMode();
 				}

--- a/app/src/main/java/org/connectbot/TerminalView.java
+++ b/app/src/main/java/org/connectbot/TerminalView.java
@@ -202,7 +202,7 @@ public class TerminalView extends TextView implements FontSizeChangedListener {
 						bridge.buffer.setWindowBase(base + moved);
 						totalY = 0;
 
-						copyBufferToText();
+						refreshTextFromBuffer();
 					}
 
 					return true;
@@ -280,7 +280,7 @@ public class TerminalView extends TextView implements FontSizeChangedListener {
 
 	@Override
 	public boolean performLongClick() {
-		copyBufferToText();
+		refreshTextFromBuffer();
 		return super.performLongClick();
 	}
 
@@ -422,7 +422,7 @@ public class TerminalView extends TextView implements FontSizeChangedListener {
 		return super.onGenericMotionEvent(event);
 	}
 
-	private void copyBufferToText() {
+	private void refreshTextFromBuffer() {
 		if (Build.VERSION.SDK_INT < Build.VERSION_CODES.HONEYCOMB) {
 			// Do not run this function because the textView is not selectable pre-Honeycomb.
 			return;

--- a/app/src/main/java/org/connectbot/service/TerminalBridge.java
+++ b/app/src/main/java/org/connectbot/service/TerminalBridge.java
@@ -71,7 +71,6 @@ public class TerminalBridge implements VDUDisplay {
 	public int defaultBg = HostDatabase.DEFAULT_BG_COLOR;
 
 	protected final TerminalManager manager;
-	public TerminalView terminalView;
 
 	public HostBean host;
 
@@ -363,8 +362,8 @@ public class TerminalBridge implements VDUDisplay {
 	}
 
 	public void copyCurrentSelection() {
-		if (terminalView != null) {
-			terminalView.copyCurrentSelectionToClipboard();
+		if (parent != null) {
+			parent.copyCurrentSelectionToClipboard();
 		}
 	}
 

--- a/app/src/main/java/org/connectbot/service/TerminalBridge.java
+++ b/app/src/main/java/org/connectbot/service/TerminalBridge.java
@@ -71,6 +71,7 @@ public class TerminalBridge implements VDUDisplay {
 	public int defaultBg = HostDatabase.DEFAULT_BG_COLOR;
 
 	protected final TerminalManager manager;
+	public TerminalView terminalView;
 
 	public HostBean host;
 
@@ -341,6 +342,33 @@ public class TerminalBridge implements VDUDisplay {
 	}
 
 	/**
+	 * Only intended for pre-Honeycomb devices.
+	 */
+	public void setSelectingForCopy(boolean selectingForCopy) {
+		this.selectingForCopy = selectingForCopy;
+	}
+
+	/**
+	 * Only intended for pre-Honeycomb devices.
+	 */
+	public boolean isSelectingForCopy() {
+		return selectingForCopy;
+	}
+
+	/**
+	 * Only intended for pre-Honeycomb devices.
+	 */
+	public SelectionArea getSelectionArea() {
+		return selectionArea;
+	}
+
+	public void copyCurrentSelection() {
+		if (terminalView != null) {
+			terminalView.copyCurrentSelectionToClipboard();
+		}
+	}
+
+	/**
 	 * Inject a specific string into this terminal. Used for post-login strings
 	 * and pasting clipboard.
 	 */
@@ -482,18 +510,6 @@ public class TerminalBridge implements VDUDisplay {
 		}
 	}
 
-	public void setSelectingForCopy(boolean selectingForCopy) {
-		this.selectingForCopy = selectingForCopy;
-	}
-
-	public boolean isSelectingForCopy() {
-		return selectingForCopy;
-	}
-
-	public SelectionArea getSelectionArea() {
-		return selectionArea;
-	}
-
 	public synchronized void tryKeyVibrate() {
 		manager.tryKeyVibrate();
 	}
@@ -536,6 +552,10 @@ public class TerminalBridge implements VDUDisplay {
 		manager.hostdb.saveHost(host);
 
 		forcedSize = false;
+	}
+
+	public float getFontSize() {
+		return fontSizeDp;
 	}
 
 	/**

--- a/app/src/main/java/org/connectbot/service/TerminalKeyListener.java
+++ b/app/src/main/java/org/connectbot/service/TerminalKeyListener.java
@@ -299,6 +299,14 @@ public class TerminalKeyListener implements OnKeyListener, OnSharedPreferenceCha
 					return true;
 			}
 
+			// CTRL-SHIFT-C to copy.
+			if (keyCode == KeyEvent.KEYCODE_C
+					&& (derivedMetaState & HC_META_CTRL_ON) != 0
+					&& (derivedMetaState & KeyEvent.META_SHIFT_ON) != 0) {
+				bridge.copyCurrentSelection();
+				return true;
+			}
+
 			// CTRL-SHIFT-V to paste.
 			if (keyCode == KeyEvent.KEYCODE_V
 					&& (derivedMetaState & HC_META_CTRL_ON) != 0

--- a/app/src/main/java/org/connectbot/util/TerminalViewPager.java
+++ b/app/src/main/java/org/connectbot/util/TerminalViewPager.java
@@ -1,0 +1,54 @@
+/*
+ * ConnectBot: simple, powerful, open-source SSH client for Android
+ * Copyright 2015 Kenny Root, Jeffrey Sharkey
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.connectbot.util;
+
+import android.content.Context;
+import android.support.v4.view.ViewPager;
+import android.util.AttributeSet;
+import android.view.MotionEvent;
+
+public class TerminalViewPager extends ViewPager {
+	private boolean enabled;
+
+	public TerminalViewPager(Context context, AttributeSet attrs) {
+		super(context, attrs);
+		this.enabled = true;
+	}
+
+	@Override
+	public boolean onTouchEvent(MotionEvent event) {
+		if (this.enabled) {
+			return super.onTouchEvent(event);
+		}
+
+		return false;
+	}
+
+	@Override
+	public boolean onInterceptTouchEvent(MotionEvent event) {
+		if (this.enabled) {
+			return super.onInterceptTouchEvent(event);
+		}
+
+		return false;
+	}
+
+	public void setPagingEnabled(boolean enabled) {
+		this.enabled = enabled;
+	}
+}

--- a/app/src/main/java/org/connectbot/util/TerminalViewPager.java
+++ b/app/src/main/java/org/connectbot/util/TerminalViewPager.java
@@ -22,6 +22,13 @@ import android.support.v4.view.ViewPager;
 import android.util.AttributeSet;
 import android.view.MotionEvent;
 
+/**
+ * Custom ViewPager {@link ViewPager} which is used to swipe between TerminalViews
+ * {@link org.connectbot.TerminalView}. Also allows temporary disabling of paging
+ * functionality to prevent event intercepts.
+ *
+ * @author rhansby
+ */
 public class TerminalViewPager extends ViewPager {
 	private boolean enabled;
 

--- a/app/src/main/res/layout-large/act_console.xml
+++ b/app/src/main/res/layout-large/act_console.xml
@@ -53,7 +53,7 @@
 		android:text="@string/terminal_no_hosts_connected"
 		android:textAppearance="?android:attr/textAppearanceMedium"/>
 
-	<android.support.v4.view.ViewPager
+	<org.connectbot.util.TerminalViewPager
 		android:id="@+id/console_flip"
 		android:layout_width="fill_parent"
 		android:layout_height="fill_parent"

--- a/app/src/main/res/layout/act_console.xml
+++ b/app/src/main/res/layout/act_console.xml
@@ -33,7 +33,7 @@
 		android:text="@string/terminal_no_hosts_connected"
 		android:textAppearance="?android:attr/textAppearanceMedium"/>
 
-	<android.support.v4.view.ViewPager
+	<org.connectbot.util.TerminalViewPager
 		android:id="@+id/console_flip"
 		android:layout_width="fill_parent"
 		android:layout_height="fill_parent"


### PR DESCRIPTION
Fixes #232, #265, and possibly other issues.

Accidentally fixes #270. Should it? 

Extends off of #129. Big thanks to @alescdb for the initial work! (I recommend that #129 be closed now)

Long pressing on text now allows users to naturally select text as they would elsewhere in the OS. Font changes are also handled properly (see GIF).

Pre-Honeycomb devices will use the old selection method, as text selection APIs are not available for them.

GIF attached:

![output-opt](https://cloud.githubusercontent.com/assets/1788374/10318099/b2edfb76-6c1c-11e5-83cd-e18075b8ceaa.gif)