### PR TITLE
Integrate EditHostActivity into the app.

### DIFF
--- a/app/src/main/java/org/connectbot/EditHostActivity.java
+++ b/app/src/main/java/org/connectbot/EditHostActivity.java
@@ -94,18 +94,21 @@ public class EditHostActivity extends AppCompatActivity implements HostEditorFra
 		// Note that the lists must be explicitly declared as ArrayLists because Bundle only accepts
 		// ArrayLists of Strings.
 		ArrayList<String> pubkeyNames = new ArrayList<>();
+		ArrayList<String> pubkeyValues = new ArrayList<>();
+
+		// First, add default pubkey names and values (e.g., "use any" and "don't use any").
 		TypedArray defaultPubkeyNames = getResources().obtainTypedArray(R.array.list_pubkeyids);
 		for (int i = 0; i < defaultPubkeyNames.length(); i++) {
 			pubkeyNames.add(defaultPubkeyNames.getString(i));
 		}
-		for (CharSequence cs : mPubkeyDb.allValues(PubkeyDatabase.FIELD_PUBKEY_NICKNAME)) {
-			pubkeyNames.add(cs.toString());
-		}
-
-		ArrayList<String> pubkeyValues = new ArrayList<>();
 		TypedArray defaultPubkeyValues = getResources().obtainTypedArray(R.array.list_pubkeyids_value);
 		for (int i = 0; i < defaultPubkeyValues.length(); i++) {
 			pubkeyValues.add(defaultPubkeyValues.getString(i));
+		}
+
+		// Now, add pubkeys which have been added by the user.
+		for (CharSequence cs : mPubkeyDb.allValues(PubkeyDatabase.FIELD_PUBKEY_NICKNAME)) {
+			pubkeyNames.add(cs.toString());
 		}
 		for (CharSequence cs : mPubkeyDb.allValues("_id")) {
 			pubkeyValues.add(cs.toString());
@@ -131,6 +134,8 @@ public class EditHostActivity extends AppCompatActivity implements HostEditorFra
 				menu);
 
 		mSaveHostButton = menu.getItem(0);
+
+		// If the new host is being created, it can't be added until modifications have been made.
 		mSaveHostButton.setEnabled(!mIsCreating);
 
 		return super.onCreateOptionsMenu(menu);
@@ -205,7 +210,9 @@ public class EditHostActivity extends AppCompatActivity implements HostEditorFra
 			mSaveHostButton.setEnabled(false);
 	}
 
-	public static class CharsetHolder {
+	// Private static class used to generate a list of available Charsets. Note that this class
+	// must not be initialized by the UI thread because it blocks on disk access.
+	private static class CharsetHolder {
 		private static boolean mInitialized = false;
 
 		// Map from Charset display name to Charset value (i.e., unique ID).

--- a/app/src/main/java/org/connectbot/EditHostActivity.java
+++ b/app/src/main/java/org/connectbot/EditHostActivity.java
@@ -19,10 +19,7 @@ package org.connectbot;
 
 import java.nio.charset.Charset;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
 import java.util.Map;
 
 import android.content.ComponentName;
@@ -32,7 +29,6 @@ import android.content.ServiceConnection;
 import android.content.res.TypedArray;
 import android.os.AsyncTask;
 import android.os.IBinder;
-import android.support.annotation.Nullable;
 import android.support.v4.app.FragmentManager;
 import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
@@ -124,6 +120,9 @@ public class EditHostActivity extends AppCompatActivity implements HostEditorFra
 			getSupportFragmentManager().beginTransaction()
 					.add(R.id.fragment_container, fragment).commit();
 		}
+
+		defaultPubkeyNames.recycle();
+		defaultPubkeyValues.recycle();
 	}
 
 	@Override
@@ -173,7 +172,7 @@ public class EditHostActivity extends AppCompatActivity implements HostEditorFra
 		} else {
 			// If CharsetHolder is uninitialized, initialize it in an AsyncTask. This is necessary
 			// because Charset must touch the disk, which cannot be performed on the UI thread.
-			new AsyncTask<Void, Void, Void>() {
+			AsyncTask<Void, Void, Void> charsetTask = new AsyncTask<Void, Void, Void>() {
 
 				@Override
 				protected Void doInBackground(Void... unused) {
@@ -185,7 +184,8 @@ public class EditHostActivity extends AppCompatActivity implements HostEditorFra
 				protected void onPostExecute(Void unused) {
 					fragment.setCharsetData(CharsetHolder.getCharsetData());
 				}
-			}.execute();
+			};
+			charsetTask.execute();
 		}
 	}
 
@@ -219,7 +219,7 @@ public class EditHostActivity extends AppCompatActivity implements HostEditorFra
 		private static Map<String, String> mData;
 
 		public static Map<String, String> getCharsetData() {
-			if (mData== null)
+			if (mData == null)
 				initialize();
 
 			return mData;

--- a/app/src/main/java/org/connectbot/EditHostActivity.java
+++ b/app/src/main/java/org/connectbot/EditHostActivity.java
@@ -17,27 +17,229 @@
 
 package org.connectbot;
 
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.content.ServiceConnection;
+import android.content.res.TypedArray;
+import android.os.AsyncTask;
+import android.os.IBinder;
+import android.support.annotation.Nullable;
+import android.support.v4.app.FragmentManager;
 import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
 
 import org.connectbot.bean.HostBean;
+import org.connectbot.service.TerminalBridge;
+import org.connectbot.service.TerminalManager;
+import org.connectbot.util.HostDatabase;
+import org.connectbot.util.PubkeyDatabase;
 
 public class EditHostActivity extends AppCompatActivity implements HostEditorFragment.Listener {
+
+	private static final String EXTRA_EXISTING_HOST_ID = "org.connectbot.existing_host_id";
+	private static final long NO_HOST_ID = -1;
+
+	private HostDatabase mHostDb;
+	private PubkeyDatabase mPubkeyDb;
+	private ServiceConnection mTerminalConnection;
+	private HostBean mHost;
+	private TerminalBridge mBridge;
+	private boolean mIsCreating;
+	private MenuItem mSaveHostButton;
+
+	public static Intent createIntentForExistingHost(Context context, long existingHostId) {
+		Intent i = new Intent(context, EditHostActivity.class);
+		i.putExtra(EXTRA_EXISTING_HOST_ID, existingHostId);
+		return i;
+	}
+
+	public static Intent createIntentForNewHost(Context context) {
+		return createIntentForExistingHost(context, NO_HOST_ID);
+	}
 
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
-		setContentView(R.layout.activity_edit_host);
 
-		if (savedInstanceState == null) {
-			HostEditorFragment editor = HostEditorFragment.newInstance(null);
+		mHostDb = HostDatabase.get(this);
+		mPubkeyDb = PubkeyDatabase.get(this);
+
+		mTerminalConnection = new ServiceConnection() {
+			public void onServiceConnected(ComponentName className, IBinder service) {
+				TerminalManager bound = ((TerminalManager.TerminalBinder) service).getService();
+				mBridge = bound.getConnectedBridge(mHost);
+			}
+
+			public void onServiceDisconnected(ComponentName name) {
+				mBridge = null;
+			}
+		};
+
+		long hostId = getIntent().getLongExtra(EXTRA_EXISTING_HOST_ID, NO_HOST_ID);
+		mIsCreating = hostId == NO_HOST_ID;
+		mHost = mIsCreating ? null : mHostDb.findHostById(hostId);
+
+		// Note that the lists must be explicitly declared as ArrayLists because Bundle only accepts
+		// ArrayLists of Strings.
+		ArrayList<String> pubkeyNames = new ArrayList<>();
+		TypedArray defaultPubkeyNames = getResources().obtainTypedArray(R.array.list_pubkeyids);
+		for (int i = 0; i < defaultPubkeyNames.length(); i++) {
+			pubkeyNames.add(defaultPubkeyNames.getString(i));
+		}
+		for (CharSequence cs : mPubkeyDb.allValues(PubkeyDatabase.FIELD_PUBKEY_NICKNAME)) {
+			pubkeyNames.add(cs.toString());
+		}
+
+		ArrayList<String> pubkeyValues = new ArrayList<>();
+		TypedArray defaultPubkeyValues = getResources().obtainTypedArray(R.array.list_pubkeyids_value);
+		for (int i = 0; i < defaultPubkeyValues.length(); i++) {
+			pubkeyValues.add(defaultPubkeyValues.getString(i));
+		}
+		for (CharSequence cs : mPubkeyDb.allValues("_id")) {
+			pubkeyValues.add(cs.toString());
+		}
+
+		setContentView(R.layout.activity_edit_host);
+		FragmentManager fm = getSupportFragmentManager();
+		HostEditorFragment fragment =
+				(HostEditorFragment) fm.findFragmentById(R.id.fragment_container);
+
+		if (fragment == null) {
+			fragment = HostEditorFragment.newInstance(mHost, pubkeyNames, pubkeyValues);
 			getSupportFragmentManager().beginTransaction()
-					.add(R.id.fragment_container, editor).commit();
+					.add(R.id.fragment_container, fragment).commit();
 		}
 	}
 
 	@Override
-	public void onHostUpdated(HostBean host) {
+	public boolean onCreateOptionsMenu(Menu menu) {
+		MenuInflater inflater = getMenuInflater();
+		inflater.inflate(
+				mIsCreating ? R.menu.edit_host_activity_add_menu : R.menu.edit_host_activity_edit_menu,
+				menu);
 
+		mSaveHostButton = menu.getItem(0);
+		mSaveHostButton.setEnabled(!mIsCreating);
+
+		return super.onCreateOptionsMenu(menu);
+	}
+
+	@Override
+	public boolean onOptionsItemSelected(MenuItem item) {
+		switch (item.getItemId()) {
+			case R.id.save:
+				mHostDb.saveHost(mHost);
+
+				if (mBridge != null) {
+					// If the console is already open, apply the new encoding now. If the console
+					// was not yet opened, this will be applied automatically when it is opened.
+					mBridge.setCharset(mHost.getEncoding());
+				}
+				finish();
+				return true;
+			default:
+				return super.onOptionsItemSelected(item);
+		}
+	}
+
+	@Override
+	public void onStart() {
+		super.onStart();
+
+		bindService(new Intent(
+				this, TerminalManager.class), mTerminalConnection, Context.BIND_AUTO_CREATE);
+
+		final HostEditorFragment fragment = (HostEditorFragment) getSupportFragmentManager().
+				findFragmentById(R.id.fragment_container);
+		if (CharsetHolder.isInitialized()) {
+			fragment.setCharsetData(CharsetHolder.getCharsetData());
+		} else {
+			// If CharsetHolder is uninitialized, initialize it in an AsyncTask. This is necessary
+			// because Charset must touch the disk, which cannot be performed on the UI thread.
+			new AsyncTask<Void, Void, Void>() {
+
+				@Override
+				protected Void doInBackground(Void... unused) {
+					CharsetHolder.initialize();
+					return null;
+				}
+
+				@Override
+				protected void onPostExecute(Void unused) {
+					fragment.setCharsetData(CharsetHolder.getCharsetData());
+				}
+			}.execute();
+		}
+	}
+
+	@Override
+	public void onStop() {
+		super.onStop();
+
+		unbindService(mTerminalConnection);
+	}
+
+	@Override
+	public void onValidHostConfigured(HostBean host) {
+		mHost = host;
+		if (mSaveHostButton != null)
+			mSaveHostButton.setEnabled(true);
+	}
+
+	@Override
+	public void onHostInvalidated() {
+		mHost = null;
+		if (mSaveHostButton != null)
+			mSaveHostButton.setEnabled(false);
+	}
+
+	public static class CharsetHolder {
+		private static boolean mInitialized = false;
+
+		// Map from Charset display name to Charset value (i.e., unique ID).
+		private static Map<String, String> mData;
+
+		public static Map<String, String> getCharsetData() {
+			if (mData== null)
+				initialize();
+
+			return mData;
+		}
+
+		private synchronized static void initialize() {
+			if (mInitialized)
+				return;
+
+			mData = new HashMap<>();
+			for (Map.Entry<String, Charset> entry : Charset.availableCharsets().entrySet()) {
+				Charset c = entry.getValue();
+				if (c.canEncode() && c.isRegistered()) {
+					String key = entry.getKey();
+					if (key.startsWith("cp")) {
+						// Custom CP437 charset changes.
+						mData.put("CP437", "CP437");
+					}
+					mData.put(c.displayName(), entry.getKey());
+				}
+			}
+
+			mInitialized = true;
+		}
+
+		public static boolean isInitialized() {
+			return mInitialized;
+		}
 	}
 }

--- a/app/src/main/java/org/connectbot/HostEditorFragment.java
+++ b/app/src/main/java/org/connectbot/HostEditorFragment.java
@@ -553,6 +553,12 @@ public class HostEditorFragment extends Fragment {
 		handleHostChange();
 	}
 
+	/**
+	 * Handles a change in the host caused by the user adjusting the values of one of the widgets
+	 * in this fragment. If the change has resulted in a valid host, the new value is sent back
+	 * to the listener; however, if the change ha resulted in an invalid host, the listener is
+	 * notified.
+	 */
 	private void handleHostChange() {
 		String protocol = (String) mTransportSpinner.getSelectedItem();
 		String quickConnectString = mQuickConnectField.getText().toString();

--- a/app/src/main/java/org/connectbot/HostListActivity.java
+++ b/app/src/main/java/org/connectbot/HostListActivity.java
@@ -222,8 +222,8 @@ public class HostListActivity extends AppCompatListActivity implements OnHostSta
 		addHostButton.setOnClickListener(new View.OnClickListener() {
 			@Override
 			public void onClick(View v) {
-				DialogFragment dialog = new AddHostDialogFragment();
-				dialog.show(getSupportFragmentManager(), "AddHostDialogFragment");
+				Intent intent = EditHostActivity.createIntentForNewHost(HostListActivity.this);
+				startActivityForResult(intent, REQUEST_EDIT);
 			}
 
 			public void onNothingSelected(AdapterView<?> arg0) {}
@@ -438,8 +438,8 @@ public class HostListActivity extends AppCompatListActivity implements OnHostSta
 			MenuItem edit = menu.add(R.string.list_host_edit);
 			edit.setOnMenuItemClickListener(new OnMenuItemClickListener() {
 				public boolean onMenuItemClick(MenuItem item) {
-					Intent intent = new Intent(HostListActivity.this, HostEditorActivity.class);
-					intent.putExtra(Intent.EXTRA_TITLE, host.getId());
+					Intent intent = EditHostActivity.createIntentForExistingHost(
+							HostListActivity.this, host.getId());
 					HostListActivity.this.startActivityForResult(intent, REQUEST_EDIT);
 					return true;
 				}

--- a/app/src/main/java/org/connectbot/bean/HostBean.java
+++ b/app/src/main/java/org/connectbot/bean/HostBean.java
@@ -47,7 +47,7 @@ public class HostBean extends AbstractBean {
 	private boolean useKeys = true;
 	private String useAuthAgent = HostDatabase.AUTHAGENT_NO;
 	private String postLogin = null;
-	private long pubkeyId = -1;
+	private long pubkeyId = HostDatabase.PUBKEYID_ANY;
 	private boolean wantSession = true;
 	private String delKey = HostDatabase.DELKEY_DEL;
 	private int fontSize = DEFAULT_FONT_SIZE;
@@ -226,8 +226,8 @@ public class HostBean extends AbstractBean {
 		values.put(HostDatabase.FIELD_HOST_FONTSIZE, fontSize);
 		values.put(HostDatabase.FIELD_HOST_COMPRESSION, Boolean.toString(compression));
 		values.put(HostDatabase.FIELD_HOST_ENCODING, encoding);
-		values.put(HostDatabase.FIELD_HOST_STAYCONNECTED, stayConnected);
-		values.put(HostDatabase.FIELD_HOST_QUICKDISCONNECT, quickDisconnect);
+		values.put(HostDatabase.FIELD_HOST_STAYCONNECTED, Boolean.toString(stayConnected));
+		values.put(HostDatabase.FIELD_HOST_QUICKDISCONNECT, Boolean.toString(quickDisconnect));
 
 		return values;
 	}

--- a/app/src/main/java/org/connectbot/util/HostDatabase.java
+++ b/app/src/main/java/org/connectbot/util/HostDatabase.java
@@ -200,7 +200,7 @@ public class HostDatabase extends RobustSQLiteOpenHelper implements HostStorage,
 				+ FIELD_HOST_WANTSESSION + " TEXT DEFAULT '" + Boolean.toString(true) + "', "
 				+ FIELD_HOST_COMPRESSION + " TEXT DEFAULT '" + Boolean.toString(false) + "', "
 				+ FIELD_HOST_ENCODING + " TEXT DEFAULT '" + ENCODING_DEFAULT + "', "
-				+ FIELD_HOST_STAYCONNECTED + " TEXT, "
+				+ FIELD_HOST_STAYCONNECTED + " TEXT DEFAULT '" + Boolean.toString(false) + "', "
 				+ FIELD_HOST_QUICKDISCONNECT + " TEXT DEFAULT '" + Boolean.toString(false) + "')");
 
 		db.execSQL("CREATE TABLE " + TABLE_PORTFORWARDS

--- a/app/src/main/res/menu/edit_host_activity_add_menu.xml
+++ b/app/src/main/res/menu/edit_host_activity_add_menu.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ ConnectBot: simple, powerful, open-source SSH client for Android
+  ~ Copyright 2015 Kenny Root, Jeffrey Sharkey
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<menu
+	xmlns:android="http://schemas.android.com/apk/res/android"
+	xmlns:yourapp="http://schemas.android.com/apk/res-auto"
+	>
+
+	<item android:id="@+id/save"
+		android:icon="@drawable/ic_add"
+		android:title="@string/hostpref_add_host"
+		yourapp:showAsAction="always|withText"
+		/>
+
+</menu>

--- a/app/src/main/res/menu/edit_host_activity_add_menu.xml
+++ b/app/src/main/res/menu/edit_host_activity_add_menu.xml
@@ -18,13 +18,13 @@
 
 <menu
 	xmlns:android="http://schemas.android.com/apk/res/android"
-	xmlns:yourapp="http://schemas.android.com/apk/res-auto"
+	xmlns:connectbot="http://schemas.android.com/apk/res-auto"
 	>
 
 	<item android:id="@+id/save"
 		android:icon="@drawable/ic_add"
 		android:title="@string/hostpref_add_host"
-		yourapp:showAsAction="always|withText"
+        connectbot:showAsAction="always|withText"
 		/>
 
 </menu>

--- a/app/src/main/res/menu/edit_host_activity_edit_menu.xml
+++ b/app/src/main/res/menu/edit_host_activity_edit_menu.xml
@@ -18,13 +18,13 @@
 
 <menu
 	xmlns:android="http://schemas.android.com/apk/res/android"
-	xmlns:yourapp="http://schemas.android.com/apk/res-auto"
+	xmlns:connectbot="http://schemas.android.com/apk/res-auto"
 	>
 
 	<item android:id="@+id/save"
 		android:icon="@drawable/ic_add"
 		android:title="@string/hostpref_edit_host"
-		yourapp:showAsAction="always|withText"
+        connectbot:showAsAction="always|withText"
 		/>
 
 </menu>

--- a/app/src/main/res/menu/edit_host_activity_edit_menu.xml
+++ b/app/src/main/res/menu/edit_host_activity_edit_menu.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ ConnectBot: simple, powerful, open-source SSH client for Android
+  ~ Copyright 2015 Kenny Root, Jeffrey Sharkey
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<menu
+	xmlns:android="http://schemas.android.com/apk/res/android"
+	xmlns:yourapp="http://schemas.android.com/apk/res-auto"
+	>
+
+	<item android:id="@+id/save"
+		android:icon="@drawable/ic_add"
+		android:title="@string/hostpref_edit_host"
+		yourapp:showAsAction="always|withText"
+		/>
+
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -598,5 +598,9 @@
 	<string name="expand">Expand</string>
 	<!-- Label for checkbox which, when check, makes SSL authorization require confirmation. -->
 	<string name="hostpref_authagent_with_confirmation">require confirmation</string>
+	<!-- Text for button which, when clicked, adds a new host. -->
+	<string name="hostpref_add_host">Add host</string>
+	<!-- Text for button which, when clicked, saves an existing host. -->
+	<string name="hostpref_edit_host">Save host</string>
 
 </resources>


### PR DESCRIPTION
This PR integrates the new add/edit host view into the app and saves any host edits in the database. It's functionally complete, AFAICT.

Two remaining issues:
1) Polish UI so that it looks nice, according to mocks.
2) Remove the old HostEditorActivity.