### PR TITLE
Move setting of hardware acceleration to view that needs it

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -170,7 +170,6 @@
 		<activity
 			android:name=".ConsoleActivity"
 			android:configChanges="keyboardHidden|orientation"
-			android:hardwareAccelerated="false"
 			android:launchMode="singleTop"
 			android:theme="@style/Theme.AppCompat"
 			android:windowSoftInputMode="stateAlwaysVisible|adjustResize">

--- a/app/src/main/java/org/connectbot/TerminalView.java
+++ b/app/src/main/java/org/connectbot/TerminalView.java
@@ -57,6 +57,7 @@ import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.MotionEvent;
+import android.view.View;
 import android.view.ViewConfiguration;
 import android.view.ViewGroup.LayoutParams;
 import android.view.accessibility.AccessibilityEvent;
@@ -136,6 +137,14 @@ public class TerminalView extends TextView implements FontSizeChangedListener {
 		setLayoutParams(new LayoutParams(LayoutParams.FILL_PARENT, LayoutParams.FILL_PARENT));
 		setFocusable(true);
 		setFocusableInTouchMode(true);
+
+		// Some things TerminalView uses is unsupported in hardware acceleration
+		// so this is using software rendering until we can replace all the
+		// instances.
+		// See: https://developer.android.com/guide/topics/graphics/hardware-accel.html#unsupported
+		if (Build.VERSION.SDK_INT >= 11) {
+			setLayerTypeToSoftware();
+		}
 
 		paint = new Paint();
 
@@ -248,6 +257,11 @@ public class TerminalView extends TextView implements FontSizeChangedListener {
 				return super.onSingleTapConfirmed(e);
 			}
 		});
+	}
+
+	@TargetApi(11)
+	private void setLayerTypeToSoftware() {
+		setLayerType(View.LAYER_TYPE_SOFTWARE, null);
 	}
 
 	@TargetApi(11)


### PR DESCRIPTION
Hardware acceleration was previously disabled for the entire activity,
but we only need it specifically for TerminalView.