### PR TITLE
Prevent a cursor being displayed within terminal text.

### DIFF
--- a/app/src/main/java/org/connectbot/util/TerminalTextViewOverlay.java
+++ b/app/src/main/java/org/connectbot/util/TerminalTextViewOverlay.java
@@ -329,7 +329,8 @@ public class TerminalTextViewOverlay extends TextView {
 
 	@Override
 	public boolean onCheckIsTextEditor() {
-		return true;
+		// This prevents a cursor being displayed within the text.
+		return false;
 	}
 
 	@Override


### PR DESCRIPTION
Fixes the issue pictured below:

![cursro](https://cloud.githubusercontent.com/assets/1788374/10527861/aabd5cd0-7347-11e5-9175-b25221da547d.png)
