### PR TITLE
Add Travis build status badge on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![Build Status](https://travis-ci.org/connectbot/connectbot.svg?branch=master)](
+https://travis-ci.org/connectbot/connectbot)
+
 Google Play
 ----------------
 


### PR DESCRIPTION
Adds a nice badge at the top of the front page, indicating build status, see how it looks at https://github.com/freshp86/connectbot.