### PR TITLE
Update from Support Library 23.0.1 to 23.1.0.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,7 +6,7 @@ apply from: '../config/translations.gradle'
 apply from: '../config/jacoco.gradle'
 
 ext {
-    supportLibraryVersion = '23.0.1'
+    supportLibraryVersion = '23.1.0'
     testRunnerVersion = '0.3'
     espressoVersion = '2.2'
 }


### PR DESCRIPTION
This also fixes background issues with FABs for pre Android 4.0 devices.

Fixes #247.