### PR TITLE
Scroll to the previously selected view asynchronously.

### DIFF
--- a/app/src/main/java/org/connectbot/ConsoleActivity.java
+++ b/app/src/main/java/org/connectbot/ConsoleActivity.java
@@ -170,10 +170,15 @@ public class ConsoleActivity extends AppCompatActivity implements BridgeDisconne
 
 			// create views for all bridges on this service
 			adapter.notifyDataSetChanged();
-			int requestedIndex = bound.getBridges().indexOf(requestedBridge);
+			final int requestedIndex = bound.getBridges().indexOf(requestedBridge);
 
 			if (requestedIndex != -1) {
-				setDisplayedTerminal(requestedIndex);
+				pager.post(new Runnable() {
+					@Override
+					public void run() {
+						setDisplayedTerminal(requestedIndex);
+					}
+				});
 			}
 		}
 

--- a/app/src/main/java/org/connectbot/ConsoleActivity.java
+++ b/app/src/main/java/org/connectbot/ConsoleActivity.java
@@ -183,9 +183,9 @@ public class ConsoleActivity extends AppCompatActivity implements BridgeDisconne
 		}
 
 		public void onServiceDisconnected(ComponentName className) {
+			bound = null;
 			adapter.notifyDataSetChanged();
 			updateEmptyVisible();
-			bound = null;
 		}
 	};
 
@@ -1040,8 +1040,8 @@ public class ConsoleActivity extends AppCompatActivity implements BridgeDisconne
 		// Maintain selected host if connected.
 		if (adapter.getCurrentTerminalView() != null
 				&& !adapter.getCurrentTerminalView().bridge.isDisconnected()) {
-			Uri uri = adapter.getCurrentTerminalView().bridge.host.getUri();
-			savedInstanceState.putString(STATE_SELECTED_URI, uri.toString());
+			requested = adapter.getCurrentTerminalView().bridge.host.getUri();
+			savedInstanceState.putString(STATE_SELECTED_URI, requested.toString());
 		}
 
 		super.onSaveInstanceState(savedInstanceState);


### PR DESCRIPTION
This avoids a race condition in ViewPager. See #301. Note that
this still looks a bit janky because the pager noticeably scrolls
away and back to the right view. A bug has been filed with the
support library team to look into a better solution.