### PR TITLE
Change the lint script to use message instead of summary

### DIFF
--- a/scripts/check-lint-count.bash
+++ b/scripts/check-lint-count.bash
@@ -32,7 +32,7 @@ lint_results="$tmp_dir/lint.txt"
 hist_results="$tmp_dir/hist.txt"
 
 run_query() {
-  local xqilla_script='string-join(//issue/location/(concat("file=", @file, " line=", @line, " column=", @column, " reason=", ../@summary)), "&#10;")'
+  local xqilla_script='string-join(//issue/location/(concat("file=", @file, " line=", @line, " column=", @column, " message=", ../@message)), "&#10;")'
   xqilla -i "$1" <(echo "$xqilla_script") | sed "s,$PWD/,,g" > "$2"
 }
 


### PR DESCRIPTION
The message has a better explanation (i.e., specific to the instance
it's talking about) than the summary which is fairly generic.