### PR TITLE
Update to buildtools v23.0.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ android:
   components:
     - platform-tools
     - tools
-    - build-tools-22.0.1
+    - build-tools-23.0.1
     - android-23
     - extra-android-support
     - extra-android-m2repository

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,7 +37,7 @@ dependencies {
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "22.0.1"
+    buildToolsVersion "23.0.1"
 
     defaultConfig {
         applicationId "org.connectbot"


### PR DESCRIPTION
Since we use target API 23, we should use buildtools 23.

https://developer.android.com/tools/revisions/build-tools.html