### PR TITLE
Restore TerminalBridge.promptHelper.setHandler() in onServiceConnected()

### DIFF
--- a/app/src/main/java/org/connectbot/ConsoleActivity.java
+++ b/app/src/main/java/org/connectbot/ConsoleActivity.java
@@ -172,6 +172,10 @@ public class ConsoleActivity extends AppCompatActivity implements BridgeDisconne
 			adapter.notifyDataSetChanged();
 			final int requestedIndex = bound.getBridges().indexOf(requestedBridge);
 
+			if (requestedBridge != null)
+				requestedBridge.promptHelper.setHandler(promptHandler);
+
+
 			if (requestedIndex != -1) {
 				pager.post(new Runnable() {
 					@Override


### PR DESCRIPTION
Resolved #228

In TeminalManager.onUnbind() there is a call to bridge.promptHelper.setHandler(null) that is never restored.


