### PR TITLE
Added authentication retry preference

### DIFF
--- a/app/src/main/java/org/connectbot/service/TerminalBridge.java
+++ b/app/src/main/java/org/connectbot/service/TerminalBridge.java
@@ -74,6 +74,8 @@ public class TerminalBridge implements VDUDisplay {
 
 	public HostBean host;
 
+	public int authTries;	// max authentication attempts for SSH connections
+
 	/* package */ AbsTransport transport;
 
 	final Paint defaultPaint;
@@ -270,6 +272,7 @@ public class TerminalBridge implements VDUDisplay {
 		// TODO make this more abstract so we don't litter on AbsTransport
 		transport.setCompression(host.getCompression());
 		transport.setUseAuthAgent(host.getUseAuthAgent());
+		transport.setAuthTries(authTries);
 		transport.setEmulation(emulation);
 
 		if (transport.canForwardPorts()) {

--- a/app/src/main/java/org/connectbot/service/TerminalManager.java
+++ b/app/src/main/java/org/connectbot/service/TerminalManager.java
@@ -226,6 +226,7 @@ public class TerminalManager extends Service implements BridgeDisconnectedListen
 
 		TerminalBridge bridge = new TerminalBridge(this, host);
 		bridge.setOnDisconnectedListener(this);
+		bridge.authTries = Integer.parseInt(prefs.getString(PreferenceConstants.AUTH_TRIES, "20"));
 		bridge.startConnection();
 
 		synchronized (bridges) {

--- a/app/src/main/java/org/connectbot/transport/AbsTransport.java
+++ b/app/src/main/java/org/connectbot/transport/AbsTransport.java
@@ -137,6 +137,10 @@ public abstract class AbsTransport {
 		// do nothing
 	}
 
+	public void setAuthTries(int authTries) {
+		// do nothing
+	}
+
 	public void setEmulation(String emulation) {
 		this.emulation = emulation;
 	}

--- a/app/src/main/java/org/connectbot/transport/SSH.java
+++ b/app/src/main/java/org/connectbot/transport/SSH.java
@@ -97,14 +97,13 @@ public class SSH extends AbsTransport implements ConnectionMonitor, InteractiveC
 		AUTH_PASSWORD = "password",
 		AUTH_KEYBOARDINTERACTIVE = "keyboard-interactive";
 
-	private final static int AUTH_TRIES = 20;
-
 	static final Pattern hostmask;
 	static {
 		hostmask = Pattern.compile("^(.+)@(([0-9a-z.-]+)|(\\[[a-f:0-9]+\\]))(:(\\d+))?$", Pattern.CASE_INSENSITIVE);
 	}
 
 	private boolean compression = false;
+	private int authTries = 20;
 	private volatile boolean authenticated = false;
 	private volatile boolean connected = false;
 	private volatile boolean sessionOpen = false;
@@ -471,7 +470,7 @@ public class SSH extends AbsTransport implements ConnectionMonitor, InteractiveC
 		try {
 			// enter a loop to keep trying until authentication
 			int tries = 0;
-			while (connected && !connection.isAuthenticationComplete() && tries++ < AUTH_TRIES) {
+			while (connected && !connection.isAuthenticationComplete() && tries++ < authTries) {
 				authenticate();
 
 				// sleep to make sure we dont kill system
@@ -865,6 +864,11 @@ public class SSH extends AbsTransport implements ConnectionMonitor, InteractiveC
 	@Override
 	public void setUseAuthAgent(String useAuthAgent) {
 		this.useAuthAgent = useAuthAgent;
+	}
+
+	@Override
+	public void setAuthTries(int authTries) {
+		this.authTries = authTries;
 	}
 
 	public Map<String, byte[]> retrieveIdentities() {

--- a/app/src/main/java/org/connectbot/util/PreferenceConstants.java
+++ b/app/src/main/java/org/connectbot/util/PreferenceConstants.java
@@ -66,6 +66,8 @@ public class PreferenceConstants {
 
 	public static final String WIFI_LOCK = "wifilock";
 
+	public static final String AUTH_TRIES = "authtries";
+
 	public static final String BUMPY_ARROWS = "bumpyarrows";
 
 	public static final String SORT_BY_COLOR = "sortByColor";

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -193,6 +193,14 @@
 
 	<string name="msg_copyright">"Copyright &#169; 2007-2008 Kenny Root http://the-b.org/, Jeffrey Sharkey http://jsharkey.org/"</string>
 
+	<!-- The category title for connection preferences. -->
+	<string name="pref_conn_category">"Connection"</string>
+
+	<!-- Name for the authentication tries preference -->
+	<string name="pref_authtries_title">"Maximum authentication attempts"</string>
+	<!-- Description of the authentication tries preference -->
+	<string name="pref_authtries_summary">"Number of retries when attempting to authenticate with an SSH server"</string>
+
 	<!-- The category title for terminal emulation preferences. -->
 	<string name="pref_emulation_category">"Terminal emulation"</string>
 

--- a/app/src/main/res/xml-v14/preferences.xml
+++ b/app/src/main/res/xml-v14/preferences.xml
@@ -20,26 +20,39 @@
 
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
 
-	<SwitchPreference
-		android:key="memkeys"
-		android:title="@string/pref_memkeys_title"
-		android:summary="@string/pref_memkeys_summary"
-		android:defaultValue="true"
-		/>
+	<PreferenceCategory
+		android:title="@string/pref_conn_category">
 
-	<SwitchPreference
-		android:key="connPersist"
-		android:title="@string/pref_conn_persist_title"
-		android:summary="@string/pref_conn_persist_summary"
-		android:defaultValue="true"
-		/>
+		<SwitchPreference
+			android:key="memkeys"
+			android:title="@string/pref_memkeys_title"
+			android:summary="@string/pref_memkeys_summary"
+			android:defaultValue="true"
+			/>
 
-	<SwitchPreference
-		android:key="wifilock"
-		android:title="@string/pref_wifilock_title"
-		android:summary="@string/pref_wifilock_summary"
-		android:defaultValue="true"
-		/>
+		<SwitchPreference
+			android:key="connPersist"
+			android:title="@string/pref_conn_persist_title"
+			android:summary="@string/pref_conn_persist_summary"
+			android:defaultValue="true"
+			/>
+
+		<SwitchPreference
+			android:key="wifilock"
+			android:title="@string/pref_wifilock_title"
+			android:summary="@string/pref_wifilock_summary"
+			android:defaultValue="true"
+			/>
+
+		<EditTextPreference
+			android:key="authtries"
+			android:title="@string/pref_authtries_title"
+			android:summary="@string/pref_authtries_summary"
+			android:defaultValue="20"
+			android:numeric="integer"
+			/>
+
+	</PreferenceCategory>
 
 	<PreferenceCategory
 		android:title="@string/pref_emulation_category">

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -20,26 +20,39 @@
 
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
 
-	<org.connectbot.util.SwitchCompatPreference
-		android:key="memkeys"
-		android:title="@string/pref_memkeys_title"
-		android:summary="@string/pref_memkeys_summary"
-		android:defaultValue="true"
-		/>
+	<PreferenceCategory
+		android:title="@string/pref_conn_category">
 
-	<org.connectbot.util.SwitchCompatPreference
-		android:key="connPersist"
-		android:title="@string/pref_conn_persist_title"
-		android:summary="@string/pref_conn_persist_summary"
-		android:defaultValue="true"
-		/>
+		<org.connectbot.util.SwitchCompatPreference
+			android:key="memkeys"
+			android:title="@string/pref_memkeys_title"
+			android:summary="@string/pref_memkeys_summary"
+			android:defaultValue="true"
+			/>
 
-	<org.connectbot.util.SwitchCompatPreference
-		android:key="wifilock"
-		android:title="@string/pref_wifilock_title"
-		android:summary="@string/pref_wifilock_summary"
-		android:defaultValue="true"
-		/>
+		<org.connectbot.util.SwitchCompatPreference
+			android:key="connPersist"
+			android:title="@string/pref_conn_persist_title"
+			android:summary="@string/pref_conn_persist_summary"
+			android:defaultValue="true"
+			/>
+
+		<org.connectbot.util.SwitchCompatPreference
+			android:key="wifilock"
+			android:title="@string/pref_wifilock_title"
+			android:summary="@string/pref_wifilock_summary"
+			android:defaultValue="true"
+			/>
+
+		<EditTextPreference
+			android:key="authtries"
+			android:title="@string/pref_authtries_title"
+			android:summary="@string/pref_authtries_summary"
+			android:defaultValue="20"
+			android:numeric="integer"
+			/>
+
+	</PreferenceCategory>
 
 	<PreferenceCategory
 		android:title="@string/pref_emulation_category">


### PR DESCRIPTION
Added a preference to change the number of authentication retries from 20. Users can lower this setting to avoid getting banned from servers as highlighted in issue #33. Also added a new category in the preferences to group this preference with related preferences, and English strings for both the category heading and the new preference.
