### PR TITLE
Avoid stair-stepping local text output

### DIFF
--- a/app/src/main/java/org/connectbot/service/TerminalBridge.java
+++ b/app/src/main/java/org/connectbot/service/TerminalBridge.java
@@ -320,23 +320,31 @@ public class TerminalBridge implements VDUDisplay {
 	}
 
 	/**
-	 * Convenience method for writing a line into the underlying MUD buffer.
+	 * Convenience method for writing text into the underlying terminal buffer.
 	 * Should never be called once the session is established.
 	 */
-	public final void outputLine(String line) {
-		if (transport != null && transport.isSessionOpen())
-			Log.e(TAG, "Session established, cannot use outputLine!", new IOException("outputLine call traceback"));
+	public final void outputLine(String output) {
+		if (transport != null && transport.isSessionOpen()) {
+			Log.e(TAG, "Session established, cannot use outputLine!",
+					new IOException("outputLine call traceback"));
+		}
 
 		synchronized (localOutput) {
-			final String s = line + "\r\n";
+			for (String line : output.split("\n")) {
+				if (line.length() > 0 && line.charAt(line.length() - 1) == '\r') {
+					line = line.substring(0, line.length() - 1);
+				}
 
-			localOutput.add(s);
+				final String s = line + "\r\n";
 
-			((vt320) buffer).putString(s);
+				localOutput.add(s);
 
-			// For accessibility
-			final char[] charArray = s.toCharArray();
-			propagateConsoleText(charArray, charArray.length);
+				((vt320) buffer).putString(s);
+
+				// For accessibility
+				final char[] charArray = s.toCharArray();
+				propagateConsoleText(charArray, charArray.length);
+			}
 		}
 	}
 

--- a/app/src/main/java/org/connectbot/transport/SSH.java
+++ b/app/src/main/java/org/connectbot/transport/SSH.java
@@ -185,8 +185,10 @@ public class SSH extends AbsTransport implements ConnectionMonitor, InteractiveC
 				String border = new String(atsigns);
 
 				bridge.outputLine(border);
-				bridge.outputLine(manager.res.getString(R.string.host_verification_failure_warning));
+				bridge.outputLine(header);
 				bridge.outputLine(border);
+
+				bridge.outputLine(manager.res.getString(R.string.host_verification_failure_warning));
 
 				bridge.outputLine(String.format(manager.res.getString(R.string.host_fingerprint),
 						algorithmName, fingerprint));


### PR DESCRIPTION
When multi-line output was used, this was creating a stair-step effect.
This was most noticable during host-key-has-changed warnings.