### PR TITLE
Support multiple known keys per host

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,8 +23,14 @@ buildscript {
     }
 }
 
+repositories {
+    maven {
+        url 'https://oss.jfrog.org/artifactory/oss-snapshot-local/'
+    }
+}
+
 dependencies {
-    compile 'org.connectbot:sshlib:2.2.3'
+    compile 'org.connectbot:sshlib:2.2.4-SNAPSHOT'
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:1.10.19'

--- a/app/src/main/java/org/connectbot/HostEditorActivity.java
+++ b/app/src/main/java/org/connectbot/HostEditorActivity.java
@@ -75,7 +75,6 @@ public class HostEditorActivity extends AppCompatPreferenceActivity implements O
 			if (cursor.moveToFirst()) {
 				for (int i = 0; i < cursor.getColumnCount(); i++) {
 					String key = cursor.getColumnName(i);
-					if (key.equals(HostDatabase.FIELD_HOST_HOSTKEY)) continue;
 					String value = cursor.getString(i);
 					values.put(key, value);
 				}

--- a/app/src/main/java/org/connectbot/data/HostStorage.java
+++ b/app/src/main/java/org/connectbot/data/HostStorage.java
@@ -78,9 +78,19 @@ public interface HostStorage {
 	KnownHosts getKnownHosts();
 
 	/**
+	 * Returns the list of host key algorithms known for the host.
+	 */
+	List<String> getHostKeyAlgorithmsForHost(String hostname, int port);
+
+	/**
 	 * Adds a known host to the database for later retrieval using {@link #getKnownHosts()}.
 	 */
 	void saveKnownHost(String hostname, int port, String serverHostKeyAlgorithm, byte[] serverHostKey);
+
+	/**
+	 * Removes a known host from the database.
+	 */
+	void removeKnownHost(String host, int port, String serverHostKeyAlgorithm, byte[] serverHostKey);
 
 	/**
 	 * Return all port forwards for the given {@code host}.

--- a/app/src/main/java/org/connectbot/transport/SSH.java
+++ b/app/src/main/java/org/connectbot/transport/SSH.java
@@ -62,10 +62,10 @@ import com.trilead.ssh2.Connection;
 import com.trilead.ssh2.ConnectionInfo;
 import com.trilead.ssh2.ConnectionMonitor;
 import com.trilead.ssh2.DynamicPortForwarder;
+import com.trilead.ssh2.ExtendedServerHostKeyVerifier;
 import com.trilead.ssh2.InteractiveCallback;
 import com.trilead.ssh2.KnownHosts;
 import com.trilead.ssh2.LocalPortForwarder;
-import com.trilead.ssh2.ServerHostKeyVerifier;
 import com.trilead.ssh2.Session;
 import com.trilead.ssh2.crypto.PEMDecoder;
 import com.trilead.ssh2.signature.DSASHA1Verify;
@@ -136,7 +136,7 @@ public class SSH extends AbsTransport implements ConnectionMonitor, InteractiveC
 	private String useAuthAgent = HostDatabase.AUTHAGENT_NO;
 	private String agentLockPassphrase;
 
-	public class HostKeyVerifier implements ServerHostKeyVerifier {
+	public class HostKeyVerifier extends ExtendedServerHostKeyVerifier {
 		public boolean verifyServerHostKey(String hostname, int port,
 				String serverHostKeyAlgorithm, byte[] serverHostKey) throws IOException {
 
@@ -209,6 +209,20 @@ public class SSH extends AbsTransport implements ConnectionMonitor, InteractiveC
 			}
 		}
 
+		@Override
+		public List<String> getKnownKeyAlgorithmsForHost(String host, int port) {
+			return manager.hostdb.getHostKeyAlgorithmsForHost(host, port);
+		}
+
+		@Override
+		public void removeServerHostKey(String host, int port, String algorithm, byte[] hostKey) {
+			manager.hostdb.removeKnownHost(host, port, algorithm, hostKey);
+		}
+
+		@Override
+		public void addServerHostKey(String host, int port, String algorithm, byte[] hostKey) {
+			manager.hostdb.saveKnownHost(host, port, algorithm, hostKey);
+		}
 	}
 
 	private void authenticate() {


### PR DESCRIPTION
This will allow hosts we originally saw with a certain hostkey algorithm
to continue to use those keys without warning us.