### PR TITLE
Avoid creating relay thread in sessionless mode

### DIFF
--- a/app/src/main/java/org/connectbot/service/TerminalBridge.java
+++ b/app/src/main/java/org/connectbot/service/TerminalBridge.java
@@ -417,12 +417,14 @@ public class TerminalBridge implements VDUDisplay {
 		else
 			((vt320) buffer).setBackspace(vt320.DELETE_IS_DEL);
 
-		// create thread to relay incoming connection data to buffer
-		relay = new Relay(this, transport, (vt320) buffer, host.getEncoding());
-		Thread relayThread = new Thread(relay);
-		relayThread.setDaemon(true);
-		relayThread.setName("Relay");
-		relayThread.start();
+		if (isSessionOpen()) {
+			// create thread to relay incoming connection data to buffer
+			relay = new Relay(this, transport, (vt320) buffer, host.getEncoding());
+			Thread relayThread = new Thread(relay);
+			relayThread.setDaemon(true);
+			relayThread.setName("Relay");
+			relayThread.start();
+		}
 
 		// force font-size to make sure we resizePTY as needed
 		setFontSize(fontSizeDp);


### PR DESCRIPTION
Fixe issue #391 (High CPU usage when 'Start shell session' disabled).
This patch is from Nishino Daisuke.
Original message:
https://code.google.com/archive/p/connectbot/issues/643

This patch doesn't introduce any new Android lint issues, and all checks and tests pass.