### PR TITLE
Revert "Use vector drawables"

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -69,8 +69,6 @@ android {
             ldLibs "log"
         }
 
-        vectorDrawables.useSupportLibrary = true
-
         testApplicationId "org.connectbot.tests"
         testInstrumentationRunner "org.connectbot.FixJacocoTestRunner"
     }


### PR DESCRIPTION
This reverts commit b2f020d8b103c4afccead82218c84596c9be677c.

We haven't updated the codebase to support vectors everywhere needed.