### PR TITLE
Set accessibility buffer to final to avoid null

### DIFF
--- a/app/src/main/java/org/connectbot/TerminalView.java
+++ b/app/src/main/java/org/connectbot/TerminalView.java
@@ -101,8 +101,8 @@ public class TerminalView extends FrameLayout implements FontSizeChangedListener
 	// Related to Accessibility Features
 	private boolean mAccessibilityInitialized = false;
 	private boolean mAccessibilityActive = true;
-	private Object[] mAccessibilityLock = new Object[0];
-	private StringBuffer mAccessibilityBuffer;
+	private final Object[] mAccessibilityLock = new Object[0];
+	private final StringBuffer mAccessibilityBuffer;
 	private Pattern mControlCodes = null;
 	private Matcher mCodeMatcher = null;
 	private AccessibilityEventSender mEventSender = null;
@@ -577,19 +577,22 @@ public class TerminalView extends FrameLayout implements FontSizeChangedListener
 		public void run() {
 			synchronized (mAccessibilityLock) {
 				if (mCodeMatcher == null) {
-					mCodeMatcher = mControlCodes.matcher(mAccessibilityBuffer);
+					mCodeMatcher = mControlCodes.matcher(mAccessibilityBuffer.toString());
 				} else {
-					mCodeMatcher.reset(mAccessibilityBuffer);
+					mCodeMatcher.reset(mAccessibilityBuffer.toString());
 				}
 
 				// Strip all control codes out.
-				mAccessibilityBuffer = new StringBuffer(mCodeMatcher.replaceAll(" "));
+				mAccessibilityBuffer.setLength(0);
+				while (mCodeMatcher.find()) {
+					mCodeMatcher.appendReplacement(mAccessibilityBuffer, " ");
+				}
 
 				// Apply Backspaces using backspace character sequence
 				int i = mAccessibilityBuffer.indexOf(BACKSPACE_CODE);
 				while (i != -1) {
-					mAccessibilityBuffer = mAccessibilityBuffer.replace(i == 0 ? 0 : i - 1, i
-							+ BACKSPACE_CODE.length(), "");
+					mAccessibilityBuffer.replace(i == 0 ? 0 : i - 1,
+							i + BACKSPACE_CODE.length(), "");
 					i = mAccessibilityBuffer.indexOf(BACKSPACE_CODE);
 				}
 
@@ -680,7 +683,10 @@ public class TerminalView extends FrameLayout implements FontSizeChangedListener
 				mEventSender = new AccessibilityEventSender();
 				postDelayed(mEventSender, ACCESSIBILITY_EVENT_THRESHOLD);
 			} else {
-				mAccessibilityBuffer = null;
+				synchronized (mAccessibilityLock) {
+					mAccessibilityBuffer.setLength(0);
+					mAccessibilityBuffer.trimToSize();
+				}
 			}
 		}
 	}

--- a/app/src/main/java/org/connectbot/TerminalView.java
+++ b/app/src/main/java/org/connectbot/TerminalView.java
@@ -359,11 +359,6 @@ public class TerminalView extends FrameLayout implements FontSizeChangedListener
 		bridge.redraw();
 	}
 
-	public void destroy() {
-		// tell bridge to destroy its bitmap
-		bridge.parentDestroyed();
-	}
-
 	@Override
 	protected void onSizeChanged(int w, int h, int oldw, int oldh) {
 		super.onSizeChanged(w, h, oldw, oldh);

--- a/app/src/main/java/org/connectbot/TerminalView.java
+++ b/app/src/main/java/org/connectbot/TerminalView.java
@@ -499,8 +499,8 @@ public class TerminalView extends FrameLayout implements FontSizeChangedListener
 
 	/**
 	 * Ask the {@link TerminalBridge} we're connected to to resize to a specific size.
-	 * @param width
-	 * @param height
+	 * @param width width in characters
+	 * @param height heigh in characters
 	 */
 	public void forceSize(int width, int height) {
 		bridge.resizeComputed(width, height, getWidth(), getHeight());


### PR DESCRIPTION
The accessibility buffer can be final to avoid having to do null checks
all over the place. This also avoids NPE when it's assumed to have been
created already.

This fixes #411.