### PR TITLE
Fixed a possible resource leak linked to a SQL cursor

### DIFF
--- a/app/src/main/java/org/connectbot/TerminalView.java
+++ b/app/src/main/java/org/connectbot/TerminalView.java
@@ -642,21 +642,20 @@ public class TerminalView extends FrameLayout implements FontSizeChangedListener
 						Uri.parse("content://" + screenReader.serviceInfo.packageName
 								+ ".providers.StatusProvider"), null, null, null, null);
 				if (cursor != null) {
-					if (cursor.moveToFirst()) {
-					/*
-					 * These content providers use a special cursor that only has
-					 * one element, an integer that is 1 if the screen reader is
-					 * running.
-					 */
+					try {
+						cursor.moveToFirst();
+						/*
+						 * These content providers use a special cursor that only has
+						 * one element, an integer that is 1 if the screen reader is
+						 * running.
+						 */
 						final int status = cursor.getInt(0);
-
-						cursor.close();
 
 						if (status == 1) {
 							foundScreenReader = true;
 							break;
 						}
-					} else {
+					} finally {
 						cursor.close();
 					}
 				}

--- a/app/src/main/java/org/connectbot/TerminalView.java
+++ b/app/src/main/java/org/connectbot/TerminalView.java
@@ -641,19 +641,23 @@ public class TerminalView extends FrameLayout implements FontSizeChangedListener
 				final Cursor cursor = cr.query(
 						Uri.parse("content://" + screenReader.serviceInfo.packageName
 								+ ".providers.StatusProvider"), null, null, null, null);
-				if (cursor != null && cursor.moveToFirst()) {
+				if (cursor != null) {
+					if (cursor.moveToFirst()) {
 					/*
 					 * These content providers use a special cursor that only has
 					 * one element, an integer that is 1 if the screen reader is
 					 * running.
 					 */
-					final int status = cursor.getInt(0);
+						final int status = cursor.getInt(0);
 
-					cursor.close();
+						cursor.close();
 
-					if (status == 1) {
-						foundScreenReader = true;
-						break;
+						if (status == 1) {
+							foundScreenReader = true;
+							break;
+						}
+					} else {
+						cursor.close();
 					}
 				}
 			}


### PR DESCRIPTION
I was using [Infer](http://fbinfer.com) to check Android apps for bugs and found this in your codebase. There were 9 additional null dereference bugs but I think they may be false positives.

Please let me know if this is useful at all - I did not have the chance to run extensive testing of the changes.

Here is the full output of running `infer -- ./gradlew assemble` on the master branch before the changes in this PR (notice the `RESOURCE_LEAK` problem now resolved):
```
Found 10 issues

app/src/main/java/org/connectbot/ConsoleActivity.java:434: error: NULL_DEREFERENCE
  object ConsoleActivity.actionBar last accessed on line 434 is annotated with @Nullable and is dereferenced without a null check at line 434
  432.   		}
  433.   		if (showActionBar) {
  434. > 			actionBar.show();
  435.   		}
  436.   		autoHideEmulatedKeys();
  437.

app/src/main/java/org/connectbot/PubkeyListActivity.java:317: error: NULL_DEREFERENCE
  object returned by keybean.getPrivateKey() could be null and is dereferenced by call to String(...) at line 317
  315.   			// load specific key using pem format
  316.   			try {
  317. > 				pair = PEMDecoder.decode(new String(keybean.getPrivateKey()).toCharArray(), password);
  318.   			} catch (Exception e) {
  319.   				String message = getResources().getString(R.string.pubkey_failed_add, keybean.getNickname());
  320.

app/src/main/java/org/connectbot/PubkeyListActivity.java:587: error: NULL_DEREFERENCE
  object returned by PubkeyListActivity$PubkeyViewHolder$4.this$1.pubkey.getPrivateKey() could be null and is dereferenced by call to String(...) at line 587
  585.   						if (imported)
  586.   							data = new String(pubkey.getPrivateKey());
  587. > 						else {
  588.   							PrivateKey pk = PubkeyUtils.decodePrivate(pubkey.getPrivateKey(), pubkey.getType());
  589.

app/src/main/java/org/connectbot/PubkeyListActivity.java:736: error: NULL_DEREFERENCE
  object returned by pubkey.getPrivateKey() could be null and is dereferenced by call to String(...) at line 736
  734.   			if (imported) {
  735.   				try {
  736. > 					PEMStructure struct = PEMDecoder.parsePEM(new String(pubkey.getPrivateKey()).toCharArray());
  737.   					String type;
  738.   					if (struct.pemType == PEMDecoder.PEM_RSA_PRIVATE_KEY) {
  739.

app/src/main/java/org/connectbot/TerminalView.java:644: error: RESOURCE_LEAK
   resource of type android.database.sqlite.SQLiteCursor acquired to cursor by call to query(...) at line 641 is not released after line 644
  642.   						Uri.parse("content://" + screenReader.serviceInfo.packageName
  643.   								+ ".providers.StatusProvider"), null, null, null, null);
  644. > 				if (cursor != null && cursor.moveToFirst()) {
  645.   					/*
  646.   					 * These content providers use a special cursor that only has
  647.

app/src/main/java/org/connectbot/bean/HostBean.java:342: error: NULL_DEREFERENCE
  object returned by getTransport(HostBean.protocol) could be null and is dereferenced at line 342
  340.   			return "";
  341.
  342. > 		int defaultPort = TransportFactory.getTransport(protocol).getDefaultPort();
  343.
  344.   		if (SSH.getProtocolName().equals(protocol)) {
  345.

app/src/main/java/org/connectbot/service/TerminalBridge.java:160: error: NULL_DEREFERENCE
  object TerminalBridge.manager last assigned on line 145 could be null and is dereferenced by call to TerminalKeyListener(...) at line 160
  158.   		transport = null;
  159.
  160. > 		keyListener = new TerminalKeyListener(manager, this, buffer, null);
  161.   	}
  162.

app/src/main/java/org/connectbot/service/TerminalBridge.java:266: error: NULL_DEREFERENCE
  object TerminalBridge.transport last assigned on line 265 could be null and is dereferenced at line 266
  264.   	protected void startConnection() {
  265.   		transport = TransportFactory.getTransport(host.getProtocol());
  266. > 		transport.setBridge(this);
  267.   		transport.setManager(manager);
  268.   		transport.setHost(host);
  269.

app/src/main/java/org/connectbot/transport/SSH.java:358: error: NULL_DEREFERENCE
  object returned by pubkey.getPrivateKey() could be null and is dereferenced by call to String(...) at line 358
  356.   			if (PubkeyDatabase.KEY_TYPE_IMPORTED.equals(pubkey.getType())) {
  357.   				// load specific key using pem format
  358. > 				pair = PEMDecoder.decode(new String(pubkey.getPrivateKey()).toCharArray(), password);
  359.   			} else {
  360.   				// load using internal generated format
  361.

app/src/main/java/org/connectbot/transport/TransportFactory.java:122: error: NULL_DEREFERENCE
  object transport last assigned on line 118 could be null and is dereferenced at line 122
  120.   		Map<String, String> selection = new HashMap<String, String>();
  121.
  122. > 		transport.getSelectionArgs(uri, selection);
  123.   		if (selection.isEmpty()) {
  124.   			Log.e(TAG, String.format("Transport %s failed to do something useful with URI=%s",
  125.

Summary of the reports

  NULL_DEREFERENCE: 9
     RESOURCE_LEAK: 1
```