### PR TITLE
Fix EntropyView with prompt messages without spaces

### DIFF
--- a/app/src/main/java/org/connectbot/util/EntropyView.java
+++ b/app/src/main/java/org/connectbot/util/EntropyView.java
@@ -94,6 +94,8 @@ public class EntropyView extends View {
 				mPaint.measureText(prompt) > (getWidth() * 0.8)) {
 			if (splitText == 0)
 				splitText = prompt.indexOf(' ', prompt.length() / 2);
+			if (splitText < 0)
+				splitText = prompt.length() / 2;
 
 			c.drawText(prompt.substring(0, splitText),
 					getWidth() / 2.0f,


### PR DESCRIPTION
Fixes #493

Just cut the string in half so that it won't crash.

At least in Chinese, Japanese and Korean, words are not separated by spaces. There are some packages that can identify words from sentences like jieba. [1] But it doesn't sound great to bring in a big dependency for this minor problem.

[1] https://github.com/huaban/jieba-analysis