### PR TITLE
Fill inserted lines with background color

### DIFF
--- a/app/src/main/java/de/mud/terminal/VDUBuffer.java
+++ b/app/src/main/java/de/mud/terminal/VDUBuffer.java
@@ -497,9 +497,10 @@ public class VDUBuffer {
    * up to fill the space and a blank line is inserted at the end of the
    * screen.
    * @param l the y-coordinate to insert the line
+   * @param attributes character attributes
    * @see #deleteLine
    */
-  public void deleteLine(int l) {
+  public void deleteLine(int l, long attributes) {
     int bottom = (l > bottomMargin ? height - 1:
             (l < topMargin?topMargin:bottomMargin + 1));
     int numRows = bottom - l - 1;

--- a/app/src/main/java/de/mud/terminal/VDUBuffer.java
+++ b/app/src/main/java/de/mud/terminal/VDUBuffer.java
@@ -286,23 +286,25 @@ public class VDUBuffer {
    * The current line and all previous lines are scrolled one line up. The
    * top line is lost. You need to call redraw() to update the screen.
    * @param l the y-coordinate to insert the line
+   * @param attributes character attributes
    * @see #deleteLine
    * @see #redraw
    */
-  public void insertLine(int l) {
-    insertLine(l, 1, SCROLL_UP);
+  public void insertLine(int l, long attributes) {
+    insertLine(l, attributes, 1, SCROLL_UP);
   }
 
   /**
    * Insert blank lines at a specific position.
    * You need to call redraw() to update the screen
    * @param l the y-coordinate to insert the line
+   * @param attributes character attributes
    * @param n amount of lines to be inserted
    * @see #deleteLine
    * @see #redraw
    */
-  public void insertLine(int l, int n) {
-    insertLine(l, n, SCROLL_UP);
+  public void insertLine(int l, long attributes, int n) {
+    insertLine(l, attributes, n, SCROLL_UP);
   }
 
   /**
@@ -310,14 +312,15 @@ public class VDUBuffer {
    * the argument.
    * You need to call redraw() to update the screen
    * @param l the y-coordinate to insert the line
+   * @param attributes character attributes
    * @param scrollDown scroll down
    * @see #deleteLine
    * @see #SCROLL_UP
    * @see #SCROLL_DOWN
    * @see #redraw
    */
-  public void insertLine(int l, boolean scrollDown) {
-    insertLine(l, 1, scrollDown);
+  public void insertLine(int l, long attributes, boolean scrollDown) {
+    insertLine(l, attributes, 1, scrollDown);
   }
 
   /**
@@ -325,6 +328,7 @@ public class VDUBuffer {
    * The current line and all previous lines are scrolled one line up. The
    * top line is lost. You need to call redraw() to update the screen.
    * @param l the y-coordinate to insert the line
+   * @param attributes character attributes
    * @param n number of lines to be inserted
    * @param scrollDown scroll down
    * @see #deleteLine
@@ -332,7 +336,7 @@ public class VDUBuffer {
    * @see #SCROLL_DOWN
    * @see #redraw
    */
-  public synchronized void insertLine(int l, int n, boolean scrollDown) {
+  public synchronized void insertLine(int l, long attributes, int n, boolean scrollDown) {
     char cbuf[][] = null;
     long abuf[][] = null;
     int offset = 0;

--- a/app/src/main/java/de/mud/terminal/VDUBuffer.java
+++ b/app/src/main/java/de/mud/terminal/VDUBuffer.java
@@ -476,6 +476,7 @@ public class VDUBuffer {
       cbuf[(newScreenBase + l) + (scrollDown ? i : -i)] = new char[width];
       Arrays.fill(cbuf[(newScreenBase + l) + (scrollDown ? i : -i)], ' ');
       abuf[(newScreenBase + l) + (scrollDown ? i : -i)] = new long[width];
+      Arrays.fill(abuf[(newScreenBase + l) + (scrollDown ? i : -i)], attributes);
     }
 
     charArray = cbuf;
@@ -519,7 +520,7 @@ public class VDUBuffer {
     charArray[newBottomRow] = discardedChars;
     charAttributes[newBottomRow] = discardedAttributes;
     Arrays.fill(charArray[newBottomRow], ' ');
-    Arrays.fill(charAttributes[newBottomRow], 0);
+    Arrays.fill(charAttributes[newBottomRow], attributes);
 
     markLine(l, bottom - l);
   }

--- a/app/src/main/java/de/mud/terminal/vt320.java
+++ b/app/src/main/java/de/mud/terminal/vt320.java
@@ -1638,7 +1638,7 @@ public void setScreenSize(int c, int r, boolean broadcast) {
               if (R > getTopMargin())
                 R--;
               else
-                insertLine(R, 1, SCROLL_DOWN);
+                insertLine(R, SCROLL_DOWN);
               if (debug > 1)
                 debug("RI");
               break;
@@ -1654,7 +1654,7 @@ public void setScreenSize(int c, int r, boolean broadcast) {
                 debugStr.setLength(0);
               }
               if (R == getBottomMargin() || R == rows - 1)
-                insertLine(R, 1, SCROLL_UP);
+                insertLine(R);
               else
                 R++;
               if (debug > 1)
@@ -1662,7 +1662,7 @@ public void setScreenSize(int c, int r, boolean broadcast) {
               break;
             case NEL:
               if (R == getBottomMargin() || R == rows - 1)
-                insertLine(R, 1, SCROLL_UP);
+                insertLine(R);
               else
                 R++;
               C = 0;
@@ -1737,7 +1737,7 @@ public void setScreenSize(int c, int r, boolean broadcast) {
               /*C = 0;*/
             }
             if (R == getBottomMargin() || R >= rows - 1)
-              insertLine(R, 1, SCROLL_UP);
+              insertLine(R);
             else
               R++;
             break;
@@ -1783,7 +1783,7 @@ public void setScreenSize(int c, int r, boolean broadcast) {
                     R++;
                   else {
                     if (debug > 3) debug("scrolling due to wrap at " + R);
-                    insertLine(R, 1, SCROLL_UP);
+                    insertLine(R);
                   }
                   C = 0;
                 } else {
@@ -1863,7 +1863,7 @@ public void setScreenSize(int c, int r, boolean broadcast) {
                       R++;
                     else {
                       if (debug > 3) debug("scrolling due to wrap at " + R);
-                      insertLine(R, 1, SCROLL_UP);
+                      insertLine(R);
                     }
                     C = 0;
                   } else {
@@ -1970,11 +1970,11 @@ public void setScreenSize(int c, int r, boolean broadcast) {
             if (C >= columns) C = columns - 1;
             break;
           case 'I': // RI
-            insertLine(R, 1, SCROLL_DOWN);
+            insertLine(R, SCROLL_DOWN);
             break;
           case 'E': /* NEL */
             if (R == getBottomMargin() || R == rows - 1)
-              insertLine(R, 1, SCROLL_UP);
+              insertLine(R);
             else
               R++;
             C = 0;
@@ -1983,7 +1983,7 @@ public void setScreenSize(int c, int r, boolean broadcast) {
             break;
           case 'D': /* IND */
             if (R == getBottomMargin() || R == rows - 1)
-              insertLine(R, 1, SCROLL_UP);
+              insertLine(R);
             else
               R++;
             if (debug > 1)
@@ -2004,7 +2004,7 @@ public void setScreenSize(int c, int r, boolean broadcast) {
             if (R > getTopMargin()) { // just go up 1 line.
               R--;
             } else { // scroll down
-              insertLine(R, 1, SCROLL_DOWN);
+              insertLine(R, SCROLL_DOWN);
             }
             /* else do nothing ; */
             if (debug > 2)
@@ -2745,9 +2745,9 @@ public void setScreenSize(int c, int r, boolean broadcast) {
             break;
           case 'S': /* ind aka 'scroll forward' */
             if (DCEvars[0] == 0)
-              insertLine(getBottomMargin(), SCROLL_UP);
+              insertLine(getBottomMargin());
             else
-              insertLine(getBottomMargin(), DCEvars[0], SCROLL_UP);
+              insertLine(getBottomMargin(), DCEvars[0]);
             break;
           case 'L':
             /* insert n lines */

--- a/app/src/main/java/de/mud/terminal/vt320.java
+++ b/app/src/main/java/de/mud/terminal/vt320.java
@@ -2768,10 +2768,10 @@ public void setScreenSize(int c, int r, boolean broadcast) {
             if (debug > 1)
               debug("ESC [ " + DCEvars[0] + "" + (c) + " at R=" + R);
             if (DCEvars[0] == 0)
-              deleteLine(R);
+              deleteLine(R, NORMAL);
             else
               for (int i = 0; i < DCEvars[0]; i++)
-                deleteLine(R);
+                deleteLine(R, NORMAL);
             break;
           case 'K':
             if (debug > 1)

--- a/app/src/main/java/de/mud/terminal/vt320.java
+++ b/app/src/main/java/de/mud/terminal/vt320.java
@@ -1638,7 +1638,7 @@ public void setScreenSize(int c, int r, boolean broadcast) {
               if (R > getTopMargin())
                 R--;
               else
-                insertLine(R, SCROLL_DOWN);
+                insertLine(R, NORMAL, SCROLL_DOWN);
               if (debug > 1)
                 debug("RI");
               break;
@@ -1654,7 +1654,7 @@ public void setScreenSize(int c, int r, boolean broadcast) {
                 debugStr.setLength(0);
               }
               if (R == getBottomMargin() || R == rows - 1)
-                insertLine(R);
+                insertLine(R, NORMAL);
               else
                 R++;
               if (debug > 1)
@@ -1662,7 +1662,7 @@ public void setScreenSize(int c, int r, boolean broadcast) {
               break;
             case NEL:
               if (R == getBottomMargin() || R == rows - 1)
-                insertLine(R);
+                insertLine(R, NORMAL);
               else
                 R++;
               C = 0;
@@ -1737,7 +1737,7 @@ public void setScreenSize(int c, int r, boolean broadcast) {
               /*C = 0;*/
             }
             if (R == getBottomMargin() || R >= rows - 1)
-              insertLine(R);
+              insertLine(R, NORMAL);
             else
               R++;
             break;
@@ -1783,7 +1783,7 @@ public void setScreenSize(int c, int r, boolean broadcast) {
                     R++;
                   else {
                     if (debug > 3) debug("scrolling due to wrap at " + R);
-                    insertLine(R);
+                    insertLine(R, NORMAL);
                   }
                   C = 0;
                 } else {
@@ -1863,7 +1863,7 @@ public void setScreenSize(int c, int r, boolean broadcast) {
                       R++;
                     else {
                       if (debug > 3) debug("scrolling due to wrap at " + R);
-                      insertLine(R);
+                      insertLine(R, NORMAL);
                     }
                     C = 0;
                   } else {
@@ -1970,11 +1970,11 @@ public void setScreenSize(int c, int r, boolean broadcast) {
             if (C >= columns) C = columns - 1;
             break;
           case 'I': // RI
-            insertLine(R, SCROLL_DOWN);
+            insertLine(R, NORMAL, SCROLL_DOWN);
             break;
           case 'E': /* NEL */
             if (R == getBottomMargin() || R == rows - 1)
-              insertLine(R);
+              insertLine(R, NORMAL);
             else
               R++;
             C = 0;
@@ -1983,7 +1983,7 @@ public void setScreenSize(int c, int r, boolean broadcast) {
             break;
           case 'D': /* IND */
             if (R == getBottomMargin() || R == rows - 1)
-              insertLine(R);
+              insertLine(R, NORMAL);
             else
               R++;
             if (debug > 1)
@@ -2004,7 +2004,7 @@ public void setScreenSize(int c, int r, boolean broadcast) {
             if (R > getTopMargin()) { // just go up 1 line.
               R--;
             } else { // scroll down
-              insertLine(R, SCROLL_DOWN);
+              insertLine(R, NORMAL, SCROLL_DOWN);
             }
             /* else do nothing ; */
             if (debug > 2)
@@ -2745,24 +2745,24 @@ public void setScreenSize(int c, int r, boolean broadcast) {
             break;
           case 'S': /* ind aka 'scroll forward' */
             if (DCEvars[0] == 0)
-              insertLine(getBottomMargin());
+              insertLine(getBottomMargin(), NORMAL);
             else
-              insertLine(getBottomMargin(), DCEvars[0]);
+              insertLine(getBottomMargin(), NORMAL, DCEvars[0]);
             break;
           case 'L':
             /* insert n lines */
             if (DCEvars[0] == 0)
-              insertLine(R, SCROLL_DOWN);
+              insertLine(R, NORMAL, SCROLL_DOWN);
             else
-              insertLine(R, DCEvars[0], SCROLL_DOWN);
+              insertLine(R, NORMAL, DCEvars[0], SCROLL_DOWN);
             if (debug > 1)
               debug("ESC [ " + DCEvars[0] + "" + (c) + " (at R " + R + ")");
             break;
           case 'T': /* 'ri' aka scroll backward */
             if (DCEvars[0] == 0)
-              insertLine(getTopMargin(), SCROLL_DOWN);
+              insertLine(getTopMargin(), NORMAL, SCROLL_DOWN);
             else
-              insertLine(getTopMargin(), DCEvars[0], SCROLL_DOWN);
+              insertLine(getTopMargin(), NORMAL, DCEvars[0], SCROLL_DOWN);
             break;
           case 'M':
             if (debug > 1)

--- a/app/src/main/java/de/mud/terminal/vt320.java
+++ b/app/src/main/java/de/mud/terminal/vt320.java
@@ -1638,7 +1638,7 @@ public void setScreenSize(int c, int r, boolean broadcast) {
               if (R > getTopMargin())
                 R--;
               else
-                insertLine(R, NORMAL, SCROLL_DOWN);
+                insertLine(R, attributes & COLOR_BG, SCROLL_DOWN);
               if (debug > 1)
                 debug("RI");
               break;
@@ -1654,7 +1654,7 @@ public void setScreenSize(int c, int r, boolean broadcast) {
                 debugStr.setLength(0);
               }
               if (R == getBottomMargin() || R == rows - 1)
-                insertLine(R, NORMAL);
+                insertLine(R, attributes & COLOR_BG);
               else
                 R++;
               if (debug > 1)
@@ -1662,7 +1662,7 @@ public void setScreenSize(int c, int r, boolean broadcast) {
               break;
             case NEL:
               if (R == getBottomMargin() || R == rows - 1)
-                insertLine(R, NORMAL);
+                insertLine(R, attributes & COLOR_BG);
               else
                 R++;
               C = 0;
@@ -1737,7 +1737,7 @@ public void setScreenSize(int c, int r, boolean broadcast) {
               /*C = 0;*/
             }
             if (R == getBottomMargin() || R >= rows - 1)
-              insertLine(R, NORMAL);
+              insertLine(R, attributes & COLOR_BG);
             else
               R++;
             break;
@@ -1783,6 +1783,7 @@ public void setScreenSize(int c, int r, boolean broadcast) {
                     R++;
                   else {
                     if (debug > 3) debug("scrolling due to wrap at " + R);
+                    // Don't fill wrapped line with background color
                     insertLine(R, NORMAL);
                   }
                   C = 0;
@@ -1863,6 +1864,7 @@ public void setScreenSize(int c, int r, boolean broadcast) {
                       R++;
                     else {
                       if (debug > 3) debug("scrolling due to wrap at " + R);
+                      // Don't fill wrapped line with background color
                       insertLine(R, NORMAL);
                     }
                     C = 0;
@@ -1970,11 +1972,11 @@ public void setScreenSize(int c, int r, boolean broadcast) {
             if (C >= columns) C = columns - 1;
             break;
           case 'I': // RI
-            insertLine(R, NORMAL, SCROLL_DOWN);
+            insertLine(R, attributes & COLOR_BG, SCROLL_DOWN);
             break;
           case 'E': /* NEL */
             if (R == getBottomMargin() || R == rows - 1)
-              insertLine(R, NORMAL);
+              insertLine(R, attributes & COLOR_BG);
             else
               R++;
             C = 0;
@@ -1983,7 +1985,7 @@ public void setScreenSize(int c, int r, boolean broadcast) {
             break;
           case 'D': /* IND */
             if (R == getBottomMargin() || R == rows - 1)
-              insertLine(R, NORMAL);
+              insertLine(R, attributes & COLOR_BG);
             else
               R++;
             if (debug > 1)
@@ -2004,7 +2006,7 @@ public void setScreenSize(int c, int r, boolean broadcast) {
             if (R > getTopMargin()) { // just go up 1 line.
               R--;
             } else { // scroll down
-              insertLine(R, NORMAL, SCROLL_DOWN);
+              insertLine(R, attributes & COLOR_BG, SCROLL_DOWN);
             }
             /* else do nothing ; */
             if (debug > 2)
@@ -2745,33 +2747,33 @@ public void setScreenSize(int c, int r, boolean broadcast) {
             break;
           case 'S': /* ind aka 'scroll forward' */
             if (DCEvars[0] == 0)
-              insertLine(getBottomMargin(), NORMAL);
+              insertLine(getBottomMargin(), attributes & COLOR_BG);
             else
-              insertLine(getBottomMargin(), NORMAL, DCEvars[0]);
+              insertLine(getBottomMargin(), attributes & COLOR_BG, DCEvars[0]);
             break;
           case 'L':
             /* insert n lines */
             if (DCEvars[0] == 0)
-              insertLine(R, NORMAL, SCROLL_DOWN);
+              insertLine(R, attributes & COLOR_BG, SCROLL_DOWN);
             else
-              insertLine(R, NORMAL, DCEvars[0], SCROLL_DOWN);
+              insertLine(R, attributes & COLOR_BG, DCEvars[0], SCROLL_DOWN);
             if (debug > 1)
               debug("ESC [ " + DCEvars[0] + "" + (c) + " (at R " + R + ")");
             break;
           case 'T': /* 'ri' aka scroll backward */
             if (DCEvars[0] == 0)
-              insertLine(getTopMargin(), NORMAL, SCROLL_DOWN);
+              insertLine(getTopMargin(), attributes & COLOR_BG, SCROLL_DOWN);
             else
-              insertLine(getTopMargin(), NORMAL, DCEvars[0], SCROLL_DOWN);
+              insertLine(getTopMargin(), attributes & COLOR_BG, DCEvars[0], SCROLL_DOWN);
             break;
           case 'M':
             if (debug > 1)
               debug("ESC [ " + DCEvars[0] + "" + (c) + " at R=" + R);
             if (DCEvars[0] == 0)
-              deleteLine(R, NORMAL);
+              deleteLine(R, attributes & COLOR_BG);
             else
               for (int i = 0; i < DCEvars[0]; i++)
-                deleteLine(R, NORMAL);
+                deleteLine(R, attributes & COLOR_BG);
             break;
           case 'K':
             if (debug > 1)


### PR DESCRIPTION
When a CRLF or scroll code is given, the new line should be filled
with the currently set background color.  As with VTE, fill with the
_default_ color if a new line was caused by line-wrap.