### PR TITLE
do not prefix urls with http://

### DIFF
--- a/app/src/main/java/org/connectbot/ConsoleActivity.java
+++ b/app/src/main/java/org/connectbot/ConsoleActivity.java
@@ -1185,9 +1185,6 @@ public class ConsoleActivity extends AppCompatActivity implements BridgeDisconne
 				TextView urlView = (TextView) view;
 
 				String url = urlView.getText().toString();
-				if (url.contains("://"))
-					url = "http://" + url;
-
 				Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
 				context.startActivity(intent);
 			} catch (Exception e) {


### PR DESCRIPTION
this was broken by inverted logic in
36b4b5ea92bc3ede9626d73503d9139f97044cc4 -- http:// was being prepended
to urls which already contained it. But since URL scan doesn't seem to
pick up URLs without scheme anyway, this check is redundant.

fixes https://github.com/connectbot/connectbot/issues/521 & https://github.com/connectbot/connectbot/issues/517