### PR TITLE
Fix the method to calculate scroll, fix #519

### DIFF
--- a/app/src/main/java/org/connectbot/util/TerminalTextViewOverlay.java
+++ b/app/src/main/java/org/connectbot/util/TerminalTextViewOverlay.java
@@ -168,12 +168,12 @@ public class TerminalTextViewOverlay extends TextView {
 
 	@Override
 	public void scrollTo(int x, int y) {
-		int lineMultiple = y / getLineHeight();
+		int lineMultiple = (y * 2 + 1) / (getLineHeight() * 2);
 
 		TerminalBridge bridge = terminalView.bridge;
 		bridge.buffer.setWindowBase(lineMultiple);
 
-		super.scrollTo(0, lineMultiple * getLineHeight());
+		super.scrollTo(0, y);
 	}
 
 	@Override
@@ -181,6 +181,8 @@ public class TerminalTextViewOverlay extends TextView {
 		if (event.getAction() == MotionEvent.ACTION_DOWN) {
 			// Selection may be beginning. Sync the TextView with the buffer.
 			refreshTextFromBuffer();
+		} else if (event.getAction() == MotionEvent.ACTION_UP) {
+			super.scrollTo(0, terminalView.bridge.buffer.getWindowBase() * getLineHeight());
 		}
 
 		// Mouse input is treated differently:


### PR DESCRIPTION
The original code [here](https://github.com/connectbot/connectbot/blob/94c1907df5a76726d3492e959c6c08778c893d76/app/src/main/java/org/connectbot/util/TerminalTextViewOverlay.java#L176) is setting the line position to int on every `scrollTo` event. So scrolling up several pixels will cause 1 line up, and scrolling down several pixels will cause nothing. This leads to #519.

In this PR, the round to int work is only done on touch up event.

There is another issue causing the scrolling no so smooth: [`refreshTextFromBuffer`](https://github.com/connectbot/connectbot/blob/94c1907df5a76726d3492e959c6c08778c893d76/app/src/main/java/org/connectbot/util/TerminalTextViewOverlay.java#L183) can run for seconds, so the view will not respond to scrolling for the first few seconds. I have no idea how to fix this. Is there any suggestions or I should open another issue?