### PR TITLE
Need to include string.h for strerror()

### DIFF
--- a/app/src/main/cpp/com_google_ase_Exec.cpp
+++ b/app/src/main/cpp/com_google_ase_Exec.cpp
@@ -19,6 +19,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <stdlib.h>
+#include <string.h>
 #include <sys/ioctl.h>
 #include <sys/types.h>
 #include <sys/wait.h>


### PR DESCRIPTION
Something has caused the build to break for some people and for Travis.  I suspect it was NDK update.
Regardless of the cause, the strerror function is declared in string.h, and so that header needs to be included.