### PR TITLE
Add authentication support via sshauthentication-api

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -205,6 +205,7 @@ tasks.withType(JavaCompile) {
 // Dependencies must be below the android block to allow productFlavor specific deps.
 dependencies {
     implementation 'org.connectbot:sshlib:2.2.6'
+    implementation 'org.sufficientlysecure:sshauthentication-api:1.0'
     googleImplementation 'com.google.android.gms:play-services-base:15.0.1'
     ossImplementation 'org.conscrypt:conscrypt-android:1.1.3'
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -167,6 +167,11 @@
 			android:configChanges="keyboardHidden|orientation"
 			android:description="@string/service_desc"/>
 
+		<service
+			android:name="org.connectbot.service.AgentManager"
+			android:configChanges="keyboardHidden|orientation"
+			android:description="@string/agent_service_desc"/>
+
 		<activity
 			android:name=".ConsoleActivity"
 			android:configChanges="keyboardHidden|orientation"
@@ -187,6 +192,11 @@
 				<!-- format:  local://  -->
 			</intent-filter>
 		</activity>
+
+		<activity
+			android:name=".AgentActivity"
+			android:theme="@style/Theme.AppCompat.Transparent"
+			android:windowSoftInputMode="stateUnchanged"/>
 
 		<meta-data
 			android:name="com.google.android.backup.api_key"

--- a/app/src/main/java/org/connectbot/AgentActivity.java
+++ b/app/src/main/java/org/connectbot/AgentActivity.java
@@ -1,0 +1,106 @@
+/*
+ * ConnectBot: simple, powerful, open-source SSH client for Android
+ * Copyright (C) 2017 Christian Hagau <ach@hagau.se>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.connectbot;
+
+import org.connectbot.service.AgentManager;
+
+import android.app.Activity;
+import android.app.PendingIntent;
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentSender;
+import android.content.ServiceConnection;
+import android.os.Bundle;
+import android.os.IBinder;
+import android.support.v7.app.AppCompatActivity;
+import android.util.Log;
+
+public class AgentActivity extends AppCompatActivity {
+	private final static String TAG = "CB.AgentActivity";
+	private final static String PENDING_INTENT_SENT = "pendingIntentSent";
+
+	private AgentManager mAgentManager = null;
+	private boolean mPendingIntentSent;
+
+	private ServiceConnection mAgentConnection = new ServiceConnection() {
+		public void onServiceConnected(ComponentName className, IBinder service) {
+			mAgentManager = ((AgentManager.AgentBinder) service).getService();
+			if (!mPendingIntentSent) {
+				startPendingIntent();
+			}
+		}
+
+		public void onServiceDisconnected(ComponentName className) {
+			mAgentManager = null;
+		}
+	};
+
+	@Override
+	public void onCreate(Bundle icicle) {
+		super.onCreate(icicle);
+
+		if (icicle != null) {
+			mPendingIntentSent = icicle.getBoolean(PENDING_INTENT_SENT);
+		}
+
+		bindService(new Intent(this, AgentManager.class), mAgentConnection,
+				Context.BIND_AUTO_CREATE);
+	}
+
+	@Override
+	public void onDestroy() {
+		super.onDestroy();
+
+		unbindService(mAgentConnection);
+	}
+
+	@Override
+	public void onSaveInstanceState(Bundle icicle) {
+		icicle.putBoolean(PENDING_INTENT_SENT, mPendingIntentSent);
+
+		super.onSaveInstanceState(icicle);
+	}
+
+	private void startPendingIntent() {
+		Intent intent = getIntent();
+		PendingIntent pendingIntent = intent.getParcelableExtra(AgentManager.AGENT_PENDING_INTENT);
+		try {
+			startIntentSenderForResult(pendingIntent.getIntentSender(),
+					AgentManager.AGENT_REQUEST_CODE, null,
+					0, 0, 0);
+
+			mPendingIntentSent = true;
+		} catch (IntentSender.SendIntentException e) {
+			Log.e(TAG, "Couldn't start PendingIntent", e);
+			mAgentManager.abortPendingIntent();
+		}
+	}
+
+	@Override
+	protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+		super.onActivityResult(requestCode, resultCode, data);
+
+		if (requestCode == AgentManager.AGENT_REQUEST_CODE) {
+			mAgentManager.processPendingIntentResult(resultCode, data);
+		}
+
+		setResult(Activity.RESULT_OK);
+		finish();
+	}
+}

--- a/app/src/main/java/org/connectbot/AgentSelectionDialog.java
+++ b/app/src/main/java/org/connectbot/AgentSelectionDialog.java
@@ -1,0 +1,213 @@
+/*
+ * ConnectBot: simple, powerful, open-source SSH client for Android
+ * Copyright (C) 2017 Christian Hagau <ach@hagau.se>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.connectbot;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.pm.PackageManager;
+import android.content.res.Resources;
+import android.graphics.drawable.Drawable;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.v4.app.DialogFragment;
+import android.support.v4.content.res.ResourcesCompat;
+import android.support.v4.graphics.drawable.DrawableCompat;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
+import android.util.Log;
+import android.view.GestureDetector;
+import android.view.LayoutInflater;
+import android.view.MotionEvent;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+public class AgentSelectionDialog extends DialogFragment {
+	public static final String TAG = "CB.AgentSelectionDialog";
+	private static final String AGENTLIST = "agentList";
+	private static final String AGENTNAMELIST = "agentNameList";
+	private Button mSelect;
+	private Button mCancel;
+	private RecyclerView mAgentRecyclerView;
+
+	private int mSelection;
+
+	private List<Drawable> mAgentIcons;
+	private List<String> mAgentList;
+	private List<String> mAgentNameList;
+	private AgentAdapter mAgentAdapter;
+
+	private HostEditorFragment mHostEditorFragment;
+
+	public static AgentSelectionDialog newInstance(List<String> agentList,
+			List<String> agentNameList) {
+		Bundle args = new Bundle();
+		args.putStringArrayList(AGENTLIST, new ArrayList<>(agentList));
+		args.putStringArrayList(AGENTNAMELIST, new ArrayList<>(agentNameList));
+
+		AgentSelectionDialog fragment = new AgentSelectionDialog();
+		fragment.setArguments(args);
+		return fragment;
+	}
+
+	private List<Drawable> loadIcons(Context context, List<String> agentList) {
+		List<Drawable> agentIcons = new ArrayList<>(agentList.size());
+		for (String agent : agentList) {
+			try {
+				agentIcons.add(context.getPackageManager().getApplicationIcon(agent));
+			} catch (PackageManager.NameNotFoundException e) {
+				throw new IllegalArgumentException("Couldn't load app icon for " + agent, e);
+			}
+		}
+		return agentIcons;
+	}
+
+	@Nullable
+	@Override
+	public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container,
+			@Nullable Bundle savedInstanceState) {
+		Activity activity = getActivity();
+		View view = inflater.inflate(R.layout.agent_selection_dialog, container, false);
+
+		mHostEditorFragment = (HostEditorFragment) getFragmentManager()
+				.findFragmentById(R.id.fragment_container);
+
+		mSelect = (Button) view.findViewById(R.id.button_select);
+		mSelect.setEnabled(false);
+		mCancel = (Button) view.findViewById(R.id.button_cancel);
+
+		mAgentRecyclerView = (RecyclerView) view.findViewById(R.id.agent_recycler);
+
+		mAgentList = getArguments().getStringArrayList(AGENTLIST);
+		mAgentNameList = getArguments().getStringArrayList(AGENTNAMELIST);
+
+		mAgentIcons = loadIcons(getContext(), mAgentList);
+
+		mAgentAdapter = new AgentAdapter(mAgentNameList, mAgentIcons, getResources());
+		mAgentRecyclerView.setAdapter(mAgentAdapter);
+
+		mAgentRecyclerView.setLayoutManager(new LinearLayoutManager(activity));
+
+		mCancel.setOnClickListener(new View.OnClickListener() {
+			@Override
+			public void onClick(View v) {
+				mHostEditorFragment.onAgentSelected(null);
+				dismiss();
+			}
+		});
+		mSelect.setOnClickListener(new View.OnClickListener() {
+			@Override
+			public void onClick(View v) {
+				mHostEditorFragment.onAgentSelected(mAgentList.get(mSelection));
+				dismiss();
+			}
+		});
+
+		mAgentRecyclerView.addOnItemTouchListener(new RecyclerView.SimpleOnItemTouchListener() {
+			GestureDetector mTapDetector = new GestureDetector(getContext(),
+					new GestureDetector.SimpleOnGestureListener() {
+						@Override
+						public boolean onSingleTapUp(MotionEvent e) {
+							return true;
+						}
+					});
+
+			@Override
+			public boolean onInterceptTouchEvent(RecyclerView view, MotionEvent e) {
+				View itemView = view.findChildViewUnder(e.getX(), e.getY());
+				if (itemView != null && mTapDetector.onTouchEvent(e)) {
+					int position = view.getChildAdapterPosition(itemView);
+					mSelection = position;
+					mAgentAdapter.select(position);
+					mSelect.setEnabled(true);
+					return true;
+				}
+				return false;
+			}
+		});
+
+		return view;
+	}
+
+	public static class AgentAdapter extends RecyclerView.Adapter<AgentViewHolder> {
+		private List<String> mAgentList;
+		private List<Drawable> mAgentIcons;
+		private int mSelectedItem = -1;
+		private Resources mResources;
+
+		public AgentAdapter(List<String> agentList, List<Drawable> agentIcons, Resources resources) {
+			mAgentList = agentList;
+			mAgentIcons = agentIcons;
+			mResources = resources;
+		}
+
+		@Override
+		public AgentViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
+			final View agentItemView = LayoutInflater.from(parent.getContext())
+					.inflate(R.layout.agent_selection_item, parent, false);
+			final AgentViewHolder viewHolder = new AgentViewHolder(agentItemView);
+
+			return viewHolder;
+		}
+
+		@Override
+		public void onBindViewHolder(AgentViewHolder holder, int position) {
+			holder.vName.setText(mAgentList.get(position));
+			if (mSelectedItem != position) {
+				Drawable icon = mAgentIcons.get(position);
+				Drawable.ConstantState constantState = icon.getConstantState();
+				if (constantState != null) {
+					Drawable tintedIcon = constantState.newDrawable(mResources);
+					DrawableCompat.setTint(tintedIcon.mutate(),
+							ResourcesCompat.getColor(mResources, R.color.key_background_normal,
+									null));
+					holder.vIcon.setImageDrawable(tintedIcon);
+				}
+			} else {
+				holder.vIcon.setImageDrawable(mAgentIcons.get(position));
+			}
+		}
+
+		@Override
+		public int getItemCount() {
+			return mAgentList.size();
+		}
+
+		public void select(int position) {
+			mSelectedItem = position;
+			notifyDataSetChanged();
+		}
+	}
+
+	private static class AgentViewHolder extends RecyclerView.ViewHolder {
+		public final TextView vName;
+		public final ImageView vIcon;
+
+		AgentViewHolder(View itemView) {
+			super(itemView);
+
+			vName = (TextView) itemView.findViewById(R.id.agentName);
+			vIcon = (ImageView) itemView.findViewById(R.id.agentIcon);
+		}
+	}
+}

--- a/app/src/main/java/org/connectbot/bean/AgentBean.java
+++ b/app/src/main/java/org/connectbot/bean/AgentBean.java
@@ -1,0 +1,139 @@
+/*
+ * ConnectBot: simple, powerful, open-source SSH client for Android
+ * Copyright 2017 Jonas Dippel, Michael Perk, Marc Totzke
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.connectbot.bean;
+
+import org.connectbot.R;
+import org.connectbot.util.AgentDatabase;
+
+import android.content.ContentValues;
+import android.content.Context;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageManager;
+
+public class AgentBean extends AbstractBean {
+	public static final String BEAN_NAME = "agent";
+
+	private long id = -1;
+	private String keyIdentifier;
+	private String keyType;
+	private byte[] publicKey;
+
+	private String packageName;
+
+	private String description;
+
+	public AgentBean() {
+	}
+
+	public AgentBean(String keyIdentifier, String keyType, String packageName, String description,
+			byte[] publicKey) {
+		this.keyIdentifier = keyIdentifier;
+		this.keyType = keyType;
+		this.description = description;
+		this.packageName = packageName;
+		this.publicKey = publicKey;
+	}
+
+	public String getKeyType() {
+		return keyType;
+	}
+
+	public void setKeyType(String keyType) {
+		this.keyType = keyType;
+	}
+
+	public long getId() {
+		return id;
+	}
+
+	public void setId(long id) {
+		this.id = id;
+	}
+
+	public String getKeyIdentifier() {
+		return keyIdentifier;
+	}
+
+	public void setKeyIdentifier(String keyIdentifier) {
+		this.keyIdentifier = keyIdentifier;
+	}
+
+	public String getPackageName() {
+		return packageName;
+	}
+
+	public void setPackageName(String packageName) {
+		this.packageName = packageName;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
+	}
+
+	public String getDescription() {
+		return description;
+	}
+
+	public byte[] getPublicKey() {
+		if (publicKey != null) {
+			return publicKey.clone();
+		} else {
+			return null;
+		}
+	}
+
+	public void setPublicKey(byte[] encoded) {
+		if (encoded == null)
+			publicKey = null;
+		else
+			publicKey = encoded.clone();
+	}
+
+	public String getAgentAppName(Context context) {
+		PackageManager packageManager = context.getPackageManager();
+		ApplicationInfo applicationInfo;
+		try {
+			applicationInfo = packageManager.getApplicationInfo(getPackageName(), 0);
+		} catch (final PackageManager.NameNotFoundException e) {
+			return context.getString(R.string.agent_unknown);
+		}
+		if (applicationInfo != null) {
+			return (String) packageManager.getApplicationLabel(applicationInfo);
+		} else {
+			return context.getString(R.string.agent_unknown);
+		}
+	}
+
+	@Override
+	public ContentValues getValues() {
+		ContentValues values = new ContentValues();
+
+		values.put(AgentDatabase.FIELD_AGENT_KEY_IDENTIFIER, keyIdentifier);
+		values.put(AgentDatabase.FIELD_AGENT_KEY_TYPE, keyType);
+		values.put(AgentDatabase.FIELD_AGENT_DESCRIPTION, description);
+		values.put(AgentDatabase.FIELD_AGENT_PACKAGE_NAME, packageName);
+		values.put(AgentDatabase.FIELD_AGENT_PUBLIC_KEY, publicKey);
+
+		return values;
+	}
+
+	@Override
+	public String getBeanName() {
+		return BEAN_NAME;
+	}
+}

--- a/app/src/main/java/org/connectbot/bean/HostBean.java
+++ b/app/src/main/java/org/connectbot/bean/HostBean.java
@@ -47,6 +47,7 @@ public class HostBean extends AbstractBean {
 	private String color;
 	private boolean useKeys = true;
 	private String useAuthAgent = HostDatabase.AUTHAGENT_NO;
+	private long authAgentId = HostDatabase.AGENTID_NONE;
 	private String postLogin = null;
 	private long pubkeyId = HostDatabase.PUBKEYID_ANY;
 	private boolean wantSession = true;
@@ -136,6 +137,12 @@ public class HostBean extends AbstractBean {
 	}
 	public String getUseAuthAgent() {
 		return useAuthAgent;
+	}
+	public long getAuthAgentId() {
+		return authAgentId;
+	}
+	public void setAuthAgentId(long authAgent) {
+		this.authAgentId = authAgent;
 	}
 	public void setPostLogin(String postLogin) {
 		this.postLogin = postLogin;
@@ -230,6 +237,7 @@ public class HostBean extends AbstractBean {
 		values.put(HostDatabase.FIELD_HOST_ENCODING, encoding);
 		values.put(HostDatabase.FIELD_HOST_STAYCONNECTED, Boolean.toString(stayConnected));
 		values.put(HostDatabase.FIELD_HOST_QUICKDISCONNECT, Boolean.toString(quickDisconnect));
+		values.put(HostDatabase.FIELD_HOST_AGENTID, authAgentId);
 
 		return values;
 	}
@@ -254,6 +262,7 @@ public class HostBean extends AbstractBean {
 		host.setEncoding(values.getAsString(HostDatabase.FIELD_HOST_ENCODING));
 		host.setStayConnected(values.getAsBoolean(HostDatabase.FIELD_HOST_STAYCONNECTED));
 		host.setQuickDisconnect(values.getAsBoolean(HostDatabase.FIELD_HOST_QUICKDISCONNECT));
+		host.setAuthAgentId(values.getAsLong(HostDatabase.FIELD_HOST_AGENTID));
 		return host;
 	}
 

--- a/app/src/main/java/org/connectbot/service/AgentManager.java
+++ b/app/src/main/java/org/connectbot/service/AgentManager.java
@@ -1,0 +1,192 @@
+/*
+ * ConnectBot: simple, powerful, open-source SSH client for Android
+ * Copyright (C) 2017 Christian Hagau <ach@hagau.se>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.connectbot.service;
+
+import java.util.ArrayDeque;
+
+import org.connectbot.AgentActivity;
+import org.connectbot.R;
+import org.connectbot.util.AgentRequest;
+import org.openintents.ssh.authentication.ISshAuthenticationService;
+import org.openintents.ssh.authentication.SshAuthenticationApi;
+import org.openintents.ssh.authentication.SshAuthenticationApiError;
+import org.openintents.ssh.authentication.SshAuthenticationConnection;
+
+import android.app.Activity;
+import android.app.PendingIntent;
+import android.app.Service;
+import android.content.Intent;
+import android.os.Binder;
+import android.os.IBinder;
+import android.support.annotation.Nullable;
+
+public class AgentManager extends Service {
+	private static final String TAG = "CB.AgentManager";
+
+	public static int AGENT_REQUEST_CODE = 1729;
+
+	public static final String AGENT_PENDING_INTENT = "pendingIntent";
+
+	private final ArrayDeque<AgentRequest> mPendingIntentsStack = new ArrayDeque<>();
+
+	private AgentRequest popPendingIntentRequest() {
+		synchronized (mPendingIntentsStack) {
+			return mPendingIntentsStack.pop();
+		}
+	}
+
+	private void pushPendingIntentRequest(AgentRequest request) {
+		synchronized (mPendingIntentsStack) {
+			mPendingIntentsStack.push(request);
+		}
+	}
+
+	public void abortPendingIntent() {
+		popPendingIntentRequest();
+	}
+
+	private void cancelRequest(AgentRequest request) {
+		request.getResultCallback().onAgentRequestCancel();
+	}
+
+	private void onRequestError(AgentRequest request, String errorMessage) {
+		request.getResultCallback().onAgentRequestError(errorMessage);
+	}
+
+	public class AgentBinder extends Binder {
+		public AgentManager getService() {
+			return AgentManager.this;
+		}
+	}
+
+	private final IBinder mAgentBinder = new AgentBinder();
+
+	@Nullable
+	@Override
+	public IBinder onBind(Intent intent) {
+		return mAgentBinder;
+	}
+
+	@Override
+	public int onStartCommand(Intent intent, int flags, int startId) {
+		/*
+		 * The lifecycle of this service is bound to the lifecycle of TerminalManager, since
+		 * authentication might need to occur in the background if connectivity is temporarily
+		 * lost, so this service needs to run as long as there are TerminalBridges active in
+		 * TerminalManager
+		 */
+		return START_STICKY;
+	}
+
+	public void execute(final AgentRequest request) {
+		final SshAuthenticationConnection agentConnection =
+				new SshAuthenticationConnection(getApplicationContext(),
+						request.getTargetPackage());
+
+		agentConnection.connect(new SshAuthenticationConnection.OnBound() {
+			@Override
+			public void onBound(ISshAuthenticationService sshAgent) {
+				executeInternal(sshAgent, request);
+				agentConnection.disconnect();
+			}
+
+			@Override
+			public void onError() {
+			}
+		});
+	}
+
+	private void executeInternal(ISshAuthenticationService sshAgent,
+			final AgentRequest request) {
+		SshAuthenticationApi agentApi = new SshAuthenticationApi(getApplicationContext(), sshAgent);
+
+		agentApi.executeApiAsync(request.getRequest(),
+				new SshAuthenticationApi.ISshAgentCallback() {
+					@Override
+					public void onReturn(Intent response) {
+						processResponse(response, request);
+					}
+				});
+	}
+
+	private void processResponse(Intent response, AgentRequest request) {
+		int resultCode = response.getIntExtra(SshAuthenticationApi.EXTRA_RESULT_CODE,
+				SshAuthenticationApi.RESULT_CODE_ERROR);
+
+		switch (resultCode) {
+		case SshAuthenticationApi.RESULT_CODE_SUCCESS:
+			sendSuccessResult(response, request);
+			return;
+
+		case SshAuthenticationApi.RESULT_CODE_ERROR:
+			SshAuthenticationApiError error = response
+					.getParcelableExtra(SshAuthenticationApi.EXTRA_ERROR);
+
+			sendRemoteErrorResult(error, request);
+			return;
+
+		case SshAuthenticationApi.RESULT_CODE_USER_INTERACTION_REQUIRED:
+			executePendingIntent(response, request);
+			return;
+
+		default:
+			onRequestError(request, getString(R.string.agent_unknown_result_code));
+		}
+	}
+
+	private void sendSuccessResult(Intent result, AgentRequest request) {
+		request.getResultCallback().onAgentRequestSuccess(result);
+	}
+
+	private void sendRemoteErrorResult(SshAuthenticationApiError error, AgentRequest request) {
+		request.getResultCallback().onAgentRequestRemoteError(error);
+	}
+
+	private void executePendingIntent(Intent response, AgentRequest request) {
+		PendingIntent pendingIntent = response
+				.getParcelableExtra(SshAuthenticationApi.EXTRA_PENDING_INTENT);
+
+		// push request onto a stack so we know which request to drop when cancelled
+		pushPendingIntentRequest(request);
+
+		Intent intent = new Intent(this, AgentActivity.class);
+		intent.putExtra(AGENT_PENDING_INTENT, pendingIntent);
+		startActivity(intent);
+	}
+
+
+	public void processPendingIntentResult(int resultCode, Intent result) {
+		// get the request belonging to this result
+		AgentRequest request = popPendingIntentRequest();
+
+		if (resultCode == Activity.RESULT_CANCELED) {
+			cancelRequest(request);
+			return;
+		}
+
+		if (result != null) {
+			request.setRequest(result);
+
+			// execute received Intent again for result
+			execute(request);
+		} else {
+			onRequestError(request, getString(R.string.agent_pending_intent_result_null));
+		}
+	}
+}
+

--- a/app/src/main/java/org/connectbot/service/TerminalManager.java
+++ b/app/src/main/java/org/connectbot/service/TerminalManager.java
@@ -35,6 +35,7 @@ import org.connectbot.bean.PubkeyBean;
 import org.connectbot.data.ColorStorage;
 import org.connectbot.data.HostStorage;
 import org.connectbot.transport.TransportFactory;
+import org.connectbot.util.AgentDatabase;
 import org.connectbot.util.HostDatabase;
 import org.connectbot.util.PreferenceConstants;
 import org.connectbot.util.ProviderLoader;
@@ -88,6 +89,7 @@ public class TerminalManager extends Service implements BridgeDisconnectedListen
 	public HostStorage hostdb;
 	public ColorStorage colordb;
 	public PubkeyDatabase pubkeydb;
+	public AgentDatabase agentdb;
 
 	protected SharedPreferences prefs;
 
@@ -130,6 +132,7 @@ public class TerminalManager extends Service implements BridgeDisconnectedListen
 		hostdb = HostDatabase.get(this);
 		colordb = HostDatabase.get(this);
 		pubkeydb = PubkeyDatabase.get(this);
+		agentdb = AgentDatabase.get(this);
 
 		// load all marked pubkeys into memory
 		updateSavingKeys();
@@ -158,6 +161,7 @@ public class TerminalManager extends Service implements BridgeDisconnectedListen
 		connectivityManager = new ConnectivityReceiver(this, lockingWifi);
 
 		ProviderLoader.load(this, this);
+
 	}
 
 	private void updateSavingKeys() {
@@ -501,6 +505,7 @@ public class TerminalManager extends Service implements BridgeDisconnectedListen
 	private void keepServiceAlive() {
 		stopIdleTimer();
 		startService(new Intent(this, TerminalManager.class));
+		startService(new Intent(this, AgentManager.class));
 	}
 
 	@Override
@@ -542,6 +547,7 @@ public class TerminalManager extends Service implements BridgeDisconnectedListen
 		@Override
 		public void run() {
 			Log.d(TAG, String.format("Stopping service after timeout of ~%d seconds", IDLE_TIMEOUT / 1000));
+			stopService(new Intent(TerminalManager.this, AgentManager.class));
 			TerminalManager.this.stopNow();
 		}
 	}

--- a/app/src/main/java/org/connectbot/transport/SSH.java
+++ b/app/src/main/java/org/connectbot/transport/SSH.java
@@ -422,6 +422,12 @@ public class SSH extends AbsTransport implements ConnectionMonitor, InteractiveC
 			return connection.authenticateWithPublicKey(username, sshAgentSignatureManager);
 		} catch (InvalidKeySpecException | NoSuchAlgorithmException | IOException e) {
 			Log.e(TAG , "Couldn't authenticate via agent", e);
+			String errorMsg = "\n" + e.getMessage() + "\n";
+			Throwable cause = e.getCause();
+			if (cause != null) {
+				errorMsg += cause.getMessage() + "\n";
+			}
+			bridge.outputLine(errorMsg);
 			return false;
 		}
 	}

--- a/app/src/main/java/org/connectbot/util/AgentDatabase.java
+++ b/app/src/main/java/org/connectbot/util/AgentDatabase.java
@@ -17,7 +17,7 @@
 
 package org.connectbot.util;
 
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.connectbot.bean.AgentBean;
@@ -162,7 +162,7 @@ public class AgentDatabase extends RobustSQLiteOpenHelper {
 	 * @param c cursor to read from
 	 */
 	private List<AgentBean> createAgentBeans(Cursor c) {
-		List<AgentBean> agents = new LinkedList<AgentBean>();
+		List<AgentBean> agents = new ArrayList<>();
 
 		final int COL_ID = c.getColumnIndexOrThrow("_id"),
 				COL_KEY_IDENTIFIER = c.getColumnIndexOrThrow(FIELD_AGENT_KEY_IDENTIFIER),

--- a/app/src/main/java/org/connectbot/util/AgentDatabase.java
+++ b/app/src/main/java/org/connectbot/util/AgentDatabase.java
@@ -1,0 +1,202 @@
+/*
+ * ConnectBot: simple, powerful, open-source SSH client for Android
+ * Copyright 2017 Jonas Dippel, Michael Perk, Marc Totzke
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.connectbot.util;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import org.connectbot.bean.AgentBean;
+
+import android.content.Context;
+import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
+import android.database.sqlite.SQLiteException;
+
+/**
+ * The agent database stores necessary data about connected agents. The data is then used to call
+ * the agents signing service and to generate the ssh authentication request.
+ */
+public class AgentDatabase extends RobustSQLiteOpenHelper {
+
+	public static final String TAG = "CB.AgentDatabase";
+	public static final String DB_NAME = "agents";
+
+	public static final int DB_VERSION = 1;
+
+	public static final String TABLE_AGENTS = "agents";
+
+	public static final String FIELD_AGENT_KEY_IDENTIFIER = "keyidentifier";
+	public static final String FIELD_AGENT_KEY_TYPE = "keytype";
+	public static final String FIELD_AGENT_DESCRIPTION = "description";
+	public static final String FIELD_AGENT_PACKAGE_NAME = "packagename";
+	public static final String FIELD_AGENT_PUBLIC_KEY = "publickey";
+
+	static {
+		addTableName(TABLE_AGENTS);
+	}
+
+	private static final Object sInstanceLock = new Object();
+
+	private static AgentDatabase sInstance;
+
+	private final SQLiteDatabase mDataBase;
+
+	public static AgentDatabase get(Context context) {
+		synchronized (sInstanceLock) {
+			if (sInstance != null) {
+				return sInstance;
+			}
+
+			Context AppContext = context.getApplicationContext();
+			sInstance = new AgentDatabase(AppContext);
+			return sInstance;
+		}
+	}
+
+	private AgentDatabase(Context context) {
+		super(context, DB_NAME, null, DB_VERSION);
+
+		mDataBase = getWritableDatabase();
+	}
+
+	@Override
+	public void onCreate(SQLiteDatabase db) {
+		super.onCreate(db);
+		createTables(db);
+	}
+
+	private void createTables(SQLiteDatabase Database) {
+		Database.execSQL("CREATE TABLE " + TABLE_AGENTS + " ( " +
+				"_id INTEGER PRIMARY KEY,"
+				+ FIELD_AGENT_KEY_IDENTIFIER + " TEXT, "
+				+ FIELD_AGENT_KEY_TYPE + " TEXT, "
+				+ FIELD_AGENT_DESCRIPTION + " TEXT, "
+				+ FIELD_AGENT_PACKAGE_NAME + " TEXT, "
+				+ FIELD_AGENT_PUBLIC_KEY + " BLOB)"
+		);
+	}
+
+	@Override
+	public void onRobustUpgrade(SQLiteDatabase db, int oldVersion, int newVersion)
+			throws SQLiteException {
+	}
+
+	/**
+	 * Gets an agent by its id.
+	 *
+	 * @param agentId The agent id.
+	 * @return The agent if it is present. Null otherwise.
+	 */
+	public AgentBean findAgentById(long agentId) {
+		Cursor c = mDataBase.query(TABLE_AGENTS, null,
+				"_id = ?", new String[] {String.valueOf(agentId)},
+				null, null, null);
+
+		return getFirstAgentBean(c);
+	}
+
+	/**
+	 * Inserts or updates the given agent into the agent database.
+	 *
+	 * @param agent The agent to insert or update
+	 * @return The agent. The field id is now synced with the id property.
+	 */
+	public AgentBean saveAgent(AgentBean agent) {
+		long id = agent.getId();
+
+		mDataBase.beginTransaction();
+		try {
+			if (id == -1) {
+				id = mDataBase.insert(TABLE_AGENTS, null, agent.getValues());
+			} else {
+				mDataBase.update(TABLE_AGENTS, agent.getValues(), "_id = ?",
+						new String[] {String.valueOf(id)});
+			}
+			mDataBase.setTransactionSuccessful();
+		} finally {
+			mDataBase.endTransaction();
+		}
+
+		agent.setId(id);
+
+		return agent;
+	}
+
+	/**
+	 * Deletes the agent with the supplied id from the database
+	 *
+	 * @param agentId Id of agent that should be deleted
+	 */
+	public void deleteAgentById(long agentId) {
+		if (agentId == HostDatabase.AGENTID_NONE) {
+			return;
+		}
+		mDataBase.beginTransaction();
+		try {
+			mDataBase.delete(TABLE_AGENTS, "_id = ?",
+					new String[] {Long.toString(agentId)});
+			mDataBase.setTransactionSuccessful();
+		} finally {
+			mDataBase.endTransaction();
+		}
+	}
+
+	/**
+	 * Creates a list of agent beans from a database cursor.
+	 *
+	 * @param c cursor to read from
+	 */
+	private List<AgentBean> createAgentBeans(Cursor c) {
+		List<AgentBean> agents = new LinkedList<AgentBean>();
+
+		final int COL_ID = c.getColumnIndexOrThrow("_id"),
+				COL_KEY_IDENTIFIER = c.getColumnIndexOrThrow(FIELD_AGENT_KEY_IDENTIFIER),
+				COL_KEY_TYPE = c.getColumnIndexOrThrow(FIELD_AGENT_KEY_TYPE),
+				COL_DESCRIPTION = c.getColumnIndexOrThrow(FIELD_AGENT_DESCRIPTION),
+				COL_PACKAGE_NAME = c.getColumnIndexOrThrow(FIELD_AGENT_PACKAGE_NAME),
+				COL_PUBLIC_KEY = c.getColumnIndexOrThrow(FIELD_AGENT_PUBLIC_KEY);
+
+		while (c.moveToNext()) {
+			AgentBean agent = new AgentBean();
+
+			agent.setId(c.getLong(COL_ID));
+			agent.setKeyIdentifier(c.getString(COL_KEY_IDENTIFIER));
+			agent.setKeyType(c.getString(COL_KEY_TYPE));
+			agent.setDescription(c.getString(COL_DESCRIPTION));
+			agent.setPackageName(c.getString(COL_PACKAGE_NAME));
+			agent.setPublicKey(c.getBlob(COL_PUBLIC_KEY));
+
+			agents.add(agent);
+		}
+
+		return agents;
+	}
+
+	private AgentBean getFirstAgentBean(Cursor c) {
+		AgentBean agent = null;
+
+		List<AgentBean> agents = createAgentBeans(c);
+
+		if (agents.size() > 0) {
+			agent = agents.get(0);
+		}
+		c.close();
+
+		return agent;
+	}
+}

--- a/app/src/main/java/org/connectbot/util/AgentKeySelection.java
+++ b/app/src/main/java/org/connectbot/util/AgentKeySelection.java
@@ -1,0 +1,239 @@
+/*
+ * ConnectBot: simple, powerful, open-source SSH client for Android
+ * Copyright (C) 2017 Christian Hagau <ach@hagau.se>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.connectbot.util;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.spec.InvalidKeySpecException;
+
+import org.connectbot.R;
+import org.connectbot.bean.AgentBean;
+import org.connectbot.bean.HostBean;
+import org.connectbot.service.AgentManager;
+import org.openintents.ssh.authentication.SshAuthenticationApi;
+import org.openintents.ssh.authentication.SshAuthenticationApiError;
+import org.openintents.ssh.authentication.request.KeySelectionRequest;
+import org.openintents.ssh.authentication.request.PublicKeyRequest;
+import org.openintents.ssh.authentication.response.KeySelectionResponse;
+import org.openintents.ssh.authentication.response.PublicKeyResponse;
+
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.content.ServiceConnection;
+import android.os.IBinder;
+import android.util.Log;
+
+
+public class AgentKeySelection implements AgentRequest.AgentRequestResultCallback {
+	public static final String TAG = "CB.AgentKeySelection";
+
+	private boolean mKeyIdSelected;
+
+	public interface AgentKeySelectionCallback {
+		void onAgentKeySelectionSuccess(AgentBean agentBean);
+
+		void onAgentKeySelectionError(String message);
+
+		void onAgentKeySelectionCancel();
+	}
+
+	private AgentManager mAgentManager = null;
+
+	private ServiceConnection mAgentConnection = new ServiceConnection() {
+		public void onServiceConnected(ComponentName className, IBinder service) {
+			mAgentManager = ((AgentManager.AgentBinder) service).getService();
+			getKeyId();
+		}
+
+		public void onServiceDisconnected(ComponentName className) {
+			mAgentManager = null;
+		}
+	};
+
+	private Context mAppContext;
+	private String mAgentName;
+
+	private HostBean mHostBean;
+	private AgentBean mAgentBean;
+
+	private AgentKeySelectionCallback mResultCallback;
+
+	public void setResultCallback(AgentKeySelectionCallback callback) {
+		mResultCallback = callback;
+	}
+
+	public AgentKeySelection(Context appContext, HostBean hostBean, String agentName,
+			AgentKeySelectionCallback resultCallback) {
+		mAppContext = appContext;
+		mAgentName = agentName;
+		mResultCallback = resultCallback;
+
+		mHostBean = hostBean;
+
+		mAgentBean = new AgentBean();
+		mAgentBean.setPackageName(mAgentName);
+	}
+
+	/**
+	 * Select a key from an external ssh-agent
+	 */
+	public void selectKeyFromAgent() {
+		mAppContext.bindService(new Intent(mAppContext, AgentManager.class), mAgentConnection,
+				Context.BIND_AUTO_CREATE);
+	}
+
+	protected void onResult(Intent response) {
+		int resultCode = response.getIntExtra(SshAuthenticationApi.EXTRA_RESULT_CODE,
+				SshAuthenticationApi.RESULT_CODE_ERROR);
+		if (resultCode != SshAuthenticationApi.RESULT_CODE_SUCCESS) {
+			finishError(getErrorMessage(response));
+		}
+
+		if (!mKeyIdSelected) {
+			onKeySelected(new KeySelectionResponse(response));
+		} else {
+			onPublicKey(new PublicKeyResponse(response));
+		}
+	}
+
+	private void finish() {
+		mAppContext.unbindService(mAgentConnection);
+	}
+
+	protected void finishCancel() {
+		mResultCallback.onAgentKeySelectionCancel();
+		finish();
+	}
+
+	protected void finishError(String message) {
+		mResultCallback.onAgentKeySelectionError(message);
+		finish();
+	}
+
+	protected void finishSuccess() {
+		mResultCallback.onAgentKeySelectionSuccess(mAgentBean);
+		finish();
+	}
+
+	private PublicKey decodePublicKey(byte[] encodedPublicKey, int algorithmFlag) {
+		PublicKey publicKey;
+		try {
+			publicKey = PubkeyUtils.decodePublic(encodedPublicKey,
+					translateAlgorithm(algorithmFlag));
+		} catch (NoSuchAlgorithmException e) {
+			Log.e(TAG, "Couldn't translate algorithm", e);
+			return null;
+		} catch (InvalidKeySpecException e) {
+			Log.e(TAG, "Couldn't decode public key", e);
+			return null;
+		}
+		return publicKey;
+	}
+
+	private String translateAlgorithm(int algorithm) throws NoSuchAlgorithmException {
+		switch (algorithm) {
+		case SshAuthenticationApi.RSA:
+			return "RSA";
+		case SshAuthenticationApi.DSA:
+			return "DSA";
+		case SshAuthenticationApi.ECDSA:
+			return "EC";
+		case SshAuthenticationApi.EDDSA:
+			return "Ed25519";
+		default:
+			throw new NoSuchAlgorithmException("Algorithm not supported: " + algorithm);
+		}
+	}
+
+	private void getKeyId() {
+		Intent request = new KeySelectionRequest().toIntent();
+
+		AgentRequest agentRequest = new AgentRequest(request, mAgentName);
+		agentRequest.setResultCallback(this);
+
+		mAgentManager.execute(agentRequest);
+	}
+
+	private void onKeySelected(KeySelectionResponse response) {
+		mAgentBean.setKeyIdentifier(response.getKeyId());
+		mAgentBean.setDescription(response.getKeyDescription());
+		mKeyIdSelected = true;
+		getPublicKey();
+	}
+
+	private void getPublicKey() {
+		Intent request = new PublicKeyRequest(mAgentBean.getKeyIdentifier()).toIntent();
+
+		AgentRequest agentRequest = new AgentRequest(request, mAgentName);
+		agentRequest.setResultCallback(this);
+
+		mAgentManager.execute(agentRequest);
+	}
+
+	private void onPublicKey(PublicKeyResponse response) {
+		byte[] encodedPublicKey = response.getEncodedPublicKey();
+		int algorithm = response.getKeyAlgorithm();
+
+		// try decoding the encoded key to make sure it can be used for authentication later
+		PublicKey publicKey = decodePublicKey(encodedPublicKey, algorithm);
+		if (publicKey == null) {
+			finishError(mAppContext.getString(R.string.agent_error_decoding_key));
+			return;
+		}
+
+		try {
+			mAgentBean.setKeyType(translateAlgorithm(algorithm));
+		} catch (NoSuchAlgorithmException e) {
+			Log.e(TAG, "Couldn't translate algorithm", e);
+			finishError(mAppContext.getString(R.string.agent_key_algorithm_not_supported));
+			return;
+		}
+		mAgentBean.setPublicKey(publicKey.getEncoded());
+
+		finishSuccess();
+	}
+
+	private String getErrorMessage(Intent errorResult) {
+		SshAuthenticationApiError error = errorResult
+				.getParcelableExtra(SshAuthenticationApi.EXTRA_ERROR);
+		return error.getMessage();
+	}
+
+	@Override
+	public void onAgentRequestSuccess(Intent result) {
+		onResult(result);
+	}
+
+	@Override
+	public void onAgentRequestError(String errorMessage) {
+		finishError(mAppContext.getString(R.string.agent_internal_error, errorMessage));
+	}
+
+	@Override
+	public void onAgentRequestRemoteError(SshAuthenticationApiError error) {
+		finishError(error.getMessage());
+	}
+
+	@Override
+	public void onAgentRequestCancel() {
+		finishCancel();
+	}
+
+}
+

--- a/app/src/main/java/org/connectbot/util/AgentKeySelectionRetainerFragment.java
+++ b/app/src/main/java/org/connectbot/util/AgentKeySelectionRetainerFragment.java
@@ -1,0 +1,43 @@
+/*
+ * ConnectBot: simple, powerful, open-source SSH client for Android
+ * Copyright (C) 2017 Christian Hagau <ach@hagau.se>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.connectbot.util;
+
+import org.connectbot.util.AgentKeySelection.AgentKeySelectionCallback;
+
+import android.os.Bundle;
+import android.support.v4.app.Fragment;
+
+public class AgentKeySelectionRetainerFragment extends Fragment {
+	public final static String TAG = "CB.AgentKeySelectionRetainerFragment";
+
+	private AgentKeySelection mAgentKeySelection;
+
+	@Override
+	public void onCreate(Bundle savedInstanceState) {
+		super.onCreate(savedInstanceState);
+		setRetainInstance(true);
+	}
+
+	public void setAgentKeySelection(AgentKeySelection agentKeySelection) {
+		mAgentKeySelection = agentKeySelection;
+	}
+
+	public void setResultCallback(AgentKeySelectionCallback callback) {
+		mAgentKeySelection.setResultCallback(callback);
+	}
+}

--- a/app/src/main/java/org/connectbot/util/AgentRequest.java
+++ b/app/src/main/java/org/connectbot/util/AgentRequest.java
@@ -1,0 +1,66 @@
+/*
+ * ConnectBot: simple, powerful, open-source SSH client for Android
+ * Copyright (C) 2017 Christian Hagau <ach@hagau.se>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.connectbot.util;
+
+import org.openintents.ssh.authentication.SshAuthenticationApiError;
+
+import android.content.Intent;
+
+public class AgentRequest {
+
+	public interface AgentRequestResultCallback {
+		void onAgentRequestSuccess(Intent result);
+
+		void onAgentRequestError(String errorMessage);
+
+		void onAgentRequestRemoteError(SshAuthenticationApiError error);
+
+		void onAgentRequestCancel();
+	}
+
+	private AgentRequestResultCallback mResultCallback;
+
+	private String mTargetPackage;
+
+	private Intent mRequest;
+
+	public AgentRequest(Intent request, String targetPackage) {
+		mRequest = request;
+		mTargetPackage = targetPackage;
+	}
+
+	public String getTargetPackage() {
+		return mTargetPackage;
+	}
+
+	public AgentRequestResultCallback getResultCallback() {
+		return mResultCallback;
+	}
+
+	public void setResultCallback(AgentRequestResultCallback resultCallback) {
+		mResultCallback = resultCallback;
+	}
+
+	public Intent getRequest() {
+		return mRequest;
+	}
+
+	public void setRequest(Intent request) {
+		mRequest = request;
+	}
+}

--- a/app/src/main/java/org/connectbot/util/AgentSignatureProxy.java
+++ b/app/src/main/java/org/connectbot/util/AgentSignatureProxy.java
@@ -1,0 +1,174 @@
+/*
+ * ConnectBot: simple, powerful, open-source SSH client for Android
+ * Copyright 2017 Jonas Dippel, Michael Perk, Marc Totzke
+ * Copyright (C) 2017 Christian Hagau <ach@hagau.se>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.connectbot.util;
+
+import java.io.IOException;
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
+import java.util.concurrent.CountDownLatch;
+
+import org.connectbot.bean.AgentBean;
+import org.connectbot.service.AgentManager;
+import org.openintents.ssh.authentication.SshAuthenticationApi;
+import org.openintents.ssh.authentication.SshAuthenticationApiError;
+import org.openintents.ssh.authentication.request.SigningRequest;
+
+import com.trilead.ssh2.auth.SignatureProxy;
+
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.content.ServiceConnection;
+import android.os.IBinder;
+
+
+public class AgentSignatureProxy extends SignatureProxy
+		implements AgentRequest.AgentRequestResultCallback {
+	private static final String TAG = "CB.AgentSignatureProxy";
+
+	public static final int RESULT_CODE_CANCELED = -1;
+	public static final int RESULT_CODE_SUCCESS = 0;
+	public static final int RESULT_CODE_ERROR = 1;
+	public static final int RESULT_CODE_REMOTE_ERROR = 2;
+
+	private Context mAppContext;
+
+	private AgentBean mAgentBean;
+
+	private AgentRequest mAgentRequest;
+
+	private byte[] mSignature;
+
+	private SshAuthenticationApiError mRemoteError;
+
+	private String mErrorMessage;
+
+	private int mResultCode;
+
+	private CountDownLatch mResultReadyLatch;
+
+	private AgentManager mAgentManager = null;
+
+	private ServiceConnection mAgentConnection = new ServiceConnection() {
+		public void onServiceConnected(ComponentName className, IBinder service) {
+			mAgentManager = ((AgentManager.AgentBinder) service).getService();
+			mAgentManager.execute(mAgentRequest);
+		}
+
+		public void onServiceDisconnected(ComponentName className) {
+			mAgentManager = null;
+		}
+	};
+
+	public AgentSignatureProxy(Context appContext, AgentBean agentBean)
+			throws InvalidKeySpecException, NoSuchAlgorithmException {
+		super(PubkeyUtils.decodePublic(agentBean.getPublicKey(), agentBean.getKeyType()));
+		mAppContext = appContext;
+		mAgentBean = agentBean;
+
+		mResultReadyLatch = new CountDownLatch(1);
+	}
+
+	@Override
+	public byte[] sign(final byte[] challenge, final String hashAlgorithm) throws IOException {
+		Intent request = new SigningRequest(challenge, mAgentBean.getKeyIdentifier(),
+				translateHashAlgorithm(hashAlgorithm)).toIntent();
+
+		mAgentRequest = new AgentRequest(request, mAgentBean.getPackageName());
+		mAgentRequest.setResultCallback(this);
+
+		mAppContext.bindService(new Intent(mAppContext, AgentManager.class), mAgentConnection,
+				Context.BIND_AUTO_CREATE);
+
+		try {
+			mResultReadyLatch.await();
+		} catch (InterruptedException e) {
+			throw new IOException("Error signing challenge: interrupted");
+		}
+		mAppContext.unbindService(mAgentConnection);
+
+		switch (mResultCode) {
+		case RESULT_CODE_SUCCESS:
+			if (mSignature != null) {
+				return mSignature;
+			} else {
+				throw new IOException("No signature in agent response");
+			}
+
+		case RESULT_CODE_CANCELED:
+			throw new IOException("Canceled signing challenge");
+
+		case RESULT_CODE_REMOTE_ERROR:
+			throw new IOException("Error signing challenge: " + mRemoteError.getMessage());
+
+		case RESULT_CODE_ERROR:
+			throw new IOException("Error signing challenge: " + mErrorMessage);
+
+		default:
+			throw new IOException("Error signing challenge");
+		}
+	}
+
+	private int translateHashAlgorithm(String hashAlgorithm) {
+		switch (hashAlgorithm) {
+		case SignatureProxy.SHA1:
+			return SshAuthenticationApi.SHA1;
+		case SignatureProxy.SHA256:
+			return SshAuthenticationApi.SHA256;
+		case SignatureProxy.SHA384:
+			return SshAuthenticationApi.SHA384;
+		case SignatureProxy.SHA512:
+			return SshAuthenticationApi.SHA512;
+		default:
+			return SshAuthenticationApiError.INVALID_HASH_ALGORITHM;
+		}
+	}
+
+	private void unlock() {
+		mResultReadyLatch.countDown();
+	}
+
+	@Override
+	public void onAgentRequestSuccess(Intent result) {
+		mResultCode = RESULT_CODE_SUCCESS;
+		mSignature = result.getByteArrayExtra(SshAuthenticationApi.EXTRA_SIGNATURE);
+		unlock();
+	}
+
+	@Override
+	public void onAgentRequestError(String errorMessage) {
+		mResultCode = RESULT_CODE_ERROR;
+		mErrorMessage = errorMessage;
+		unlock();
+	}
+
+	@Override
+	public void onAgentRequestRemoteError(SshAuthenticationApiError error) {
+		mResultCode = RESULT_CODE_REMOTE_ERROR;
+		mRemoteError = error;
+		unlock();
+	}
+
+	@Override
+	public void onAgentRequestCancel() {
+		mResultCode = RESULT_CODE_CANCELED;
+		unlock();
+	}
+}
+

--- a/app/src/main/java/org/connectbot/util/HostDatabase.java
+++ b/app/src/main/java/org/connectbot/util/HostDatabase.java
@@ -52,7 +52,7 @@ public class HostDatabase extends RobustSQLiteOpenHelper implements HostStorage,
 	public final static String TAG = "CB.HostDatabase";
 
 	public final static String DB_NAME = "hosts";
-	public final static int DB_VERSION = 25;
+	public final static int DB_VERSION = 26;
 
 	public final static String TABLE_HOSTS = "hosts";
 	public final static String FIELD_HOST_NICKNAME = "nickname";
@@ -64,6 +64,7 @@ public class HostDatabase extends RobustSQLiteOpenHelper implements HostStorage,
 	public final static String FIELD_HOST_COLOR = "color";
 	public final static String FIELD_HOST_USEKEYS = "usekeys";
 	public final static String FIELD_HOST_USEAUTHAGENT = "useauthagent";
+	public final static String FIELD_HOST_AGENTID = "agentid";
 	public final static String FIELD_HOST_POSTLOGIN = "postlogin";
 	public final static String FIELD_HOST_PUBKEYID = "pubkeyid";
 	public final static String FIELD_HOST_WANTSESSION = "wantsession";
@@ -118,8 +119,11 @@ public class HostDatabase extends RobustSQLiteOpenHelper implements HostStorage,
 
 	public final static String ENCODING_DEFAULT = Charset.defaultCharset().name();
 
+	public final static long PUBKEYID_AGENT = -3;
 	public final static long PUBKEYID_NEVER = -2;
 	public final static long PUBKEYID_ANY = -1;
+
+	public final static long AGENTID_NONE = -1;
 
 	public static final int DEFAULT_COLOR_SCHEME = 0;
 
@@ -134,6 +138,7 @@ public class HostDatabase extends RobustSQLiteOpenHelper implements HostStorage,
 			+ FIELD_HOST_COLOR + " TEXT, "
 			+ FIELD_HOST_USEKEYS + " TEXT, "
 			+ FIELD_HOST_USEAUTHAGENT + " TEXT, "
+			+ FIELD_HOST_AGENTID + " INTEGER DEFAULT " + AGENTID_NONE + ", "
 			+ FIELD_HOST_POSTLOGIN + " TEXT, "
 			+ FIELD_HOST_PUBKEYID + " INTEGER DEFAULT " + PUBKEYID_ANY + ", "
 			+ FIELD_HOST_DELKEY + " TEXT DEFAULT '" + DELKEY_DEL + "', "
@@ -396,6 +401,10 @@ public class HostDatabase extends RobustSQLiteOpenHelper implements HostStorage,
 					+ " FROM " + TABLE_HOSTS);
 			db.execSQL("DROP TABLE " + TABLE_HOSTS);
 			db.execSQL("ALTER TABLE " + TABLE_HOSTS + "_upgrade RENAME TO " + TABLE_HOSTS);
+
+		case 25:
+			db.execSQL("ALTER TABLE " + TABLE_HOSTS
+					+ " ADD COLUMN " + FIELD_HOST_AGENTID + " INTEGER DEFAULT '" + AGENTID_NONE + "'");
 		}
 	}
 
@@ -497,6 +506,7 @@ public class HostDatabase extends RobustSQLiteOpenHelper implements HostStorage,
 			COL_COLOR = c.getColumnIndexOrThrow(FIELD_HOST_COLOR),
 			COL_USEKEYS = c.getColumnIndexOrThrow(FIELD_HOST_USEKEYS),
 			COL_USEAUTHAGENT = c.getColumnIndexOrThrow(FIELD_HOST_USEAUTHAGENT),
+			COL_AGENTID = c.getColumnIndexOrThrow(FIELD_HOST_AGENTID),
 			COL_POSTLOGIN = c.getColumnIndexOrThrow(FIELD_HOST_POSTLOGIN),
 			COL_PUBKEYID = c.getColumnIndexOrThrow(FIELD_HOST_PUBKEYID),
 			COL_WANTSESSION = c.getColumnIndexOrThrow(FIELD_HOST_WANTSESSION),
@@ -520,6 +530,7 @@ public class HostDatabase extends RobustSQLiteOpenHelper implements HostStorage,
 			host.setColor(c.getString(COL_COLOR));
 			host.setUseKeys(Boolean.valueOf(c.getString(COL_USEKEYS)));
 			host.setUseAuthAgent(c.getString(COL_USEAUTHAGENT));
+			host.setAuthAgentId(c.getLong(COL_AGENTID));
 			host.setPostLogin(c.getString(COL_POSTLOGIN));
 			host.setPubkeyId(c.getLong(COL_PUBKEYID));
 			host.setWantSession(Boolean.valueOf(c.getString(COL_WANTSESSION)));

--- a/app/src/main/res/layout/agent_selection_dialog.xml
+++ b/app/src/main/res/layout/agent_selection_dialog.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+	xmlns:tools="http://schemas.android.com/tools"
+	android:layout_width="match_parent"
+	android:layout_height="match_parent"
+	android:orientation="vertical">
+
+	<LinearLayout
+		android:layout_width="match_parent"
+		android:layout_height="wrap_content"
+		android:background="@color/accent"
+		android:elevation="4dp"
+		android:orientation="vertical"
+		android:paddingBottom="12dp"
+		android:paddingLeft="24dp"
+		android:paddingRight="24dp"
+		android:paddingTop="12dp">
+
+		<TextView
+			android:id="@+id/textView"
+			android:layout_width="match_parent"
+			android:layout_height="wrap_content"
+			android:text="@string/agent_select_agent"
+			android:textAppearance="?android:textAppearanceLarge"/>
+	</LinearLayout>
+
+	<LinearLayout
+		android:layout_width="match_parent"
+		android:layout_height="match_parent"
+		android:orientation="vertical"
+		android:paddingBottom="16dp"
+		android:paddingLeft="24dp"
+		android:paddingRight="24dp"
+		android:paddingTop="24dp">
+
+		<TextView
+			android:id="@+id/textViewInfo"
+			android:layout_width="match_parent"
+			android:layout_height="wrap_content"
+			android:paddingBottom="24dp"
+			android:text="@string/agent_select_agent_description"/>
+
+		<android.support.v7.widget.RecyclerView
+			android:id="@+id/agent_recycler"
+			android:layout_width="match_parent"
+			android:layout_height="match_parent"
+			tools:listitem="@layout/agent_selection_item"/>
+	</LinearLayout>
+
+	<LinearLayout
+		android:layout_width="match_parent"
+		android:layout_height="wrap_content"
+		android:gravity="end"
+		android:orientation="horizontal"
+		android:padding="8dp">
+
+		<Button
+			android:id="@+id/button_cancel"
+			style="@style/Widget.AppCompat.Button.ButtonBar.AlertDialog"
+			android:layout_width="wrap_content"
+			android:layout_height="wrap_content"
+			android:layout_weight="1"
+			android:text="@android:string/cancel"/>
+
+		<Button
+			android:id="@+id/button_select"
+			style="@style/Widget.AppCompat.Button.ButtonBar.AlertDialog"
+			android:layout_width="wrap_content"
+			android:layout_height="wrap_content"
+			android:layout_weight="1"
+			android:text="Select"/>
+	</LinearLayout>
+</LinearLayout>

--- a/app/src/main/res/layout/agent_selection_item.xml
+++ b/app/src/main/res/layout/agent_selection_item.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+	xmlns:app="http://schemas.android.com/apk/res-auto"
+	android:layout_width="match_parent"
+	android:layout_height="wrap_content"
+	android:paddingTop="12dp"
+	android:paddingBottom="12dp"
+	android:gravity="center_vertical"
+	android:orientation="horizontal">
+
+	<ImageView
+		android:id="@+id/agentIcon"
+		android:layout_width="24dp"
+		android:layout_height="24dp"
+		android:layout_marginEnd="8dp"
+		android:layout_marginRight="8dp"
+		app:srcCompat="?android:attr/colorBackgroundFloating"/>
+
+	<TextView
+		android:id="@+id/agentName"
+		android:layout_width="match_parent"
+		android:layout_height="wrap_content"
+		android:text="agentName"
+		android:paddingBottom="2dp"
+		android:textAppearance="?android:textAppearanceMedium"/>
+</LinearLayout>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -282,4 +282,15 @@
   <string name="key_type_ed25519">Ed25519</string>
   <string name="key_type_unknown">Schlüsseltyp unbekannt</string>
   <string name="key_attribute_encrypted">(verschlüsselt)</string>
+  <string name="agent_selected_agent_key">Agent: %1$s\nSchlüssel: %2$s</string>
+  <string name="agent_no_ssh_agents_installed">Kein SSH-Agent installiert</string>
+  <string name="agent_selection_cancelled">Agent Auswahl abgebrochen</string>
+  <string name="agent_key_selection_successful">Schlüssel Auswahl erfolgreich</string>
+  <string name="agent_key_selection_cancelled">Schlüssel Auswahl abgebrochen</string>
+  <string name="agent_key_selection_failed">Schlüssel Auswahl fehlgeschlagen: %1$s</string>
+  <string name="agent_unknown">Unbekannt</string>
+  <string name="agent_attempting_to_authenticate">Versuche Authentifizierung über SSH-Agent</string>
+  <string name="agent_could_not_be_found">Der SSH-Agent kann nicht gefunden werden</string>
+  <string name="agent_calling_ssh_agent">Calling ssh-agent: %1$s</string>
+  <string name="agent_failed_to_authenticate_via_ssh_agent">Authentifizierung über SSH-Agent fehlgeschlagen</string>
 </resources>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -96,11 +96,13 @@
 	</string-array>
 
 	<string-array name="list_pubkeyids" translatable="false">
+		<item>@string/list_pubkeyids_agent</item>
 		<item>@string/list_pubkeyids_none</item>
 		<item>@string/list_pubkeyids_any</item>
 	</string-array>
 
 	<string-array name="list_pubkeyids_value" translatable="false">
+		<item>-3</item>
 		<item>-2</item>
 		<item>-1</item>
 	</string-array>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -25,6 +25,7 @@
 
 	<!-- Summary of what the ConnectBot service does; displayed in the Android running apps list -->
 	<string name="service_desc">"Maintains SSH connections and loaded pubkeys"</string>
+	<string name="agent_service_desc">"Manages communication with key agents"</string>
 
 	<!-- Window title for the Host List -->
 	<string name="title_hosts_list">"Hosts"</string>
@@ -322,6 +323,8 @@
 	<!-- Preference selection to indicate never to use special shortcut keys. -->
 	<string name="list_keymode_none">"Disable"</string>
 
+	<!-- Preference to use an external agent to authenticate to this host. -->
+	<string name="list_pubkeyids_agent">"Use external agent"</string>
 	<!-- Preference to not use pubkeys to authenticate to this host. -->
 	<string name="list_pubkeyids_none">"Do not use keys"</string>
 	<!-- Preference to use any pubkey to authenticate to this host. -->
@@ -673,4 +676,22 @@
 	     Added to the end of a key description to indicate that the key is encrypted (i.e,
 	     password protected). -->
 	<string name="key_attribute_encrypted">(encrypted)</string>
+	<string name="agent_selected_agent_key">Agent: %1$s\nKey: %2$s</string>
+	<string name="agent_no_ssh_agents_installed">No SSH-Agents installed</string>
+	<string name="agent_selection_cancelled">Agent selection cancelled</string>
+	<string name="agent_key_selection_successful">Agent key selection successful</string>
+	<string name="agent_key_selection_cancelled">Agent key selection cancelled</string>
+	<string name="agent_key_selection_failed">Agent key selection failed: %1$s</string>
+	<string name="agent_select_agent_description">These are the installed agents. Please select one:</string>
+	<string name="agent_select_agent">Select Agent</string>
+	<string name="agent_error_decoding_key">Error decoding public key</string>
+	<string name="agent_key_algorithm_not_supported">Key algorithm not supported</string>
+	<string name="agent_internal_error">Internal error: %1$s</string>
+	<string name="agent_unknown_result_code">Unknown result code</string>
+	<string name="agent_pending_intent_result_null">PendingIntent result is null</string>
+	<string name="agent_unknown">Unknown</string>
+	<string name="agent_attempting_to_authenticate">Attempting to authenticate via ssh-agent</string>
+	<string name="agent_could_not_be_found">The ssh-agent couldn\'t be found</string>
+	<string name="agent_calling_ssh_agent">Calling ssh-agent: %1$s</string>
+	<string name="agent_failed_to_authenticate_via_ssh_agent">Failed to authenticate via ssh-agent</string>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -108,4 +108,12 @@
 		<item name="colorAccent">@color/accent</item>
 	</style>
 
+	<style name="Theme.AppCompat.Transparent" parent="Theme.AppCompat.NoActionBar">
+		<item name="android:windowNoTitle">true</item>
+		<item name="android:windowBackground">@android:color/transparent</item>
+		<item name="android:colorBackgroundCacheHint">@null</item>
+		<item name="android:windowIsTranslucent">true</item>
+		<item name="android:windowFullscreen">true</item>
+	</style>
+
 </resources>


### PR DESCRIPTION
This implements support for external authentication via [sshauthentication-api](https://github.com/open-keychain/open-keychain/tree/master/sshauthentication-api) (e.g. [OpenKeychain](https://github.com/open-keychain/open-keychain))

This requires [sshlib #34](https://github.com/connectbot/sshlib/pull/34) and [sshlib #35](https://github.com/connectbot/sshlib/pull/35).