### PR TITLE
Update SDK, API, tools, plugins, libraries, etc. to latest in AS 3.1 (and support multiwindow on CB)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ build/
 
 # Android gradle native build
 \.externalNativeBuild/
+.idea/

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -172,9 +172,9 @@ dependencies {
     ossCompile 'org.conscrypt:conscrypt-android:1.0.0.RC14'
 
     testCompile 'junit:junit:4.12'
-    testCompile 'org.mockito:mockito-core:1.10.19'
-    testCompile 'org.assertj:assertj-core:1.7.0'
-    testCompile('org.robolectric:robolectric:3.2.2') {
+    testCompile 'org.mockito:mockito-core:2.8.9'
+    testCompile 'org.assertj:assertj-core:3.9.0'
+    testCompile('org.robolectric:robolectric:3.6.1') {
         exclude group: 'commons-logging', module: 'commons-logging'
         exclude group: 'org.apache.httpcomponents', module: 'httpclient'
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,12 +1,13 @@
 buildscript {
     repositories {
+        google()
         jcenter()
     }
 
     dependencies {
         classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.6.3'
-        classpath 'com.android.tools.build:gradle:2.3.0'
-        classpath 'com.github.gfx.ribbonizer:plugin:0.5.0'
+        classpath 'com.android.tools.build:gradle:3.1.0-alpha08'
+        classpath 'com.github.gfx.ribbonizer:plugin:0.6.0'
         classpath 'com.trickyandroid:jacoco-everywhere:0.2.1'
         if (rootProject.hasProperty('jacocoVersion')) {
             classpath "org.jacoco:org.jacoco.core:${rootProject.jacocoVersion}"
@@ -19,7 +20,7 @@ plugins {
 }
 
 ext {
-    supportLibraryVersion = '25.3.0'
+    supportLibraryVersion = '27.0.2'
     testRunnerVersion = '0.5'
     espressoVersion = '2.2.2'
 }
@@ -33,6 +34,8 @@ apply from: '../config/quality.gradle'
 apply from: '../config/translations.gradle'
 
 repositories {
+    google()
+    jcenter()
     maven {
         url 'https://oss.jfrog.org/artifactory/oss-snapshot-local/'
     }
@@ -44,8 +47,8 @@ def preDexEnabled = "true".equals(System.getProperty("pre-dex", "true"))
 coveralls.jacocoReportPath = 'build/reports/coverage/google/debug/report.xml'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 27
+    buildToolsVersion "27.0.3"
 
     dexOptions {
         // Skip pre-dexing when running on a CI or when disabled via -Dpre-dex=false
@@ -57,8 +60,8 @@ android {
         versionName "1.9.2"
         versionCode 19200
 
-        minSdkVersion 9
-        targetSdkVersion 23
+        minSdkVersion 14
+        targetSdkVersion 27
 
         vectorDrawables.useSupportLibrary = true
 
@@ -164,9 +167,9 @@ android {
 
 // Dependencies must be below the android block to allow productFlavor specific deps.
 dependencies {
-    compile 'org.connectbot:sshlib:2.2.5-SNAPSHOT'
-    googleCompile 'com.google.android.gms:play-services-base:10.0.1'
-    ossCompile 'org.conscrypt:conscrypt-android:1.0.0.RC2'
+    compile 'org.connectbot:sshlib:2.2.5'
+    googleCompile 'com.google.android.gms:play-services-base:11.8.0'
+    ossCompile 'org.conscrypt:conscrypt-android:1.0.0.RC14'
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:1.10.19'
@@ -196,7 +199,7 @@ android.applicationVariants.all { variant ->
         ext.env = System.getenv()
         def buildNumber = getGitDescription()
         if (buildNumber != null) {
-            File valuesFile = file("${buildDir}/intermediates/res/merged/${variant.dirName}/values/values.xml")
+            File valuesFile = file("${buildDir}/intermediates/incremental/${variant.mergeResources.name}/merged.dir/values/values.xml")
             String content = valuesFile.getText('UTF-8')
             content = content.replaceAll(/\(working copy\)/, buildNumber)
             valuesFile.write(content, 'UTF-8')

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,9 +5,9 @@ buildscript {
     }
 
     dependencies {
-        classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.6.3'
-        classpath 'com.android.tools.build:gradle:3.1.0-alpha08'
-        classpath 'com.github.gfx.ribbonizer:plugin:0.6.0'
+        classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.8.2'
+        classpath 'com.android.tools.build:gradle:3.1.0-alpha09'
+        classpath 'com.github.gfx.ribbonizer:plugin:1.0.0'
         classpath 'com.trickyandroid:jacoco-everywhere:0.2.1'
         if (rootProject.hasProperty('jacocoVersion')) {
             classpath "org.jacoco:org.jacoco.core:${rootProject.jacocoVersion}"
@@ -85,25 +85,25 @@ android {
     }
 
     dependencies {
-        compile "com.android.support:recyclerview-v7:$supportLibraryVersion"
-        compile "com.android.support:support-v4:$supportLibraryVersion"
-        compile "com.android.support:appcompat-v7:$supportLibraryVersion"
-        compile "com.takisoft.fix:preference-v7:$supportLibraryVersion.0"
-        compile "com.android.support:design:$supportLibraryVersion"
+        implementation "com.android.support:recyclerview-v7:$supportLibraryVersion"
+        implementation "com.android.support:support-v4:$supportLibraryVersion"
+        implementation "com.android.support:appcompat-v7:$supportLibraryVersion"
+        implementation "com.takisoft.fix:preference-v7:$supportLibraryVersion.0"
+        implementation "com.android.support:design:$supportLibraryVersion"
 
-        androidTestCompile("com.android.support.test:runner:$testRunnerVersion") {
+        androidTestImplementation("com.android.support.test:runner:$testRunnerVersion") {
             exclude module: "support-annotations"
         }
-        androidTestCompile("com.android.support.test:rules:$testRunnerVersion") {
+        androidTestImplementation("com.android.support.test:rules:$testRunnerVersion") {
             exclude module: "support-annotations"
         }
-        androidTestCompile("com.android.support.test.espresso:espresso-core:$espressoVersion") {
+        androidTestImplementation("com.android.support.test.espresso:espresso-core:$espressoVersion") {
             exclude module: "support-annotations"
         }
-        androidTestCompile("com.android.support.test.espresso:espresso-intents:$espressoVersion") {
+        androidTestImplementation("com.android.support.test.espresso:espresso-intents:$espressoVersion") {
             exclude module: "support-annotations"
         }
-        androidTestCompile("com.android.support.test.espresso:espresso-contrib:$espressoVersion") {
+        androidTestImplementation("com.android.support.test.espresso:espresso-contrib:$espressoVersion") {
             exclude group: 'com.android.support'
         }
     }
@@ -170,14 +170,14 @@ android {
 
 // Dependencies must be below the android block to allow productFlavor specific deps.
 dependencies {
-    compile 'org.connectbot:sshlib:2.2.5'
-    googleCompile 'com.google.android.gms:play-services-base:11.8.0'
-    ossCompile 'org.conscrypt:conscrypt-android:1.0.0.RC14'
+    implementation 'org.connectbot:sshlib:2.2.5'
+    googleImplementation 'com.google.android.gms:play-services-base:11.8.0'
+    ossImplementation 'org.conscrypt:conscrypt-android:1.0.0.RC14'
 
-    testCompile 'junit:junit:4.12'
-    testCompile 'org.mockito:mockito-core:2.8.9'
-    testCompile 'org.assertj:assertj-core:3.9.0'
-    testCompile('org.robolectric:robolectric:3.6.1') {
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.mockito:mockito-core:2.13.0'
+    testImplementation 'org.assertj:assertj-core:3.9.0'
+    testImplementation('org.robolectric:robolectric:3.6.1') {
         exclude group: 'commons-logging', module: 'commons-logging'
         exclude group: 'org.apache.httpcomponents', module: 'httpclient'
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -107,7 +107,10 @@ android {
             exclude group: 'com.android.support'
         }
     }
-
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
     buildTypes {
         release {
             minifyEnabled true

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -29,7 +29,13 @@
 
 	<uses-feature android:name="android.hardware.touchscreen" android:required="false"/>
 
-	<supports-screens />
+	<supports-screens
+		android:anyDensity="true"
+		android:largeScreens="true"
+		android:normalScreens="true"
+		android:resizeable="true"
+		android:smallScreens="true"
+		android:xlargeScreens="true" />
 
 	<application
 		android:allowBackup="true"
@@ -41,10 +47,15 @@
 		android:supportsRtl="true"
 		android:theme="@style/AppTheme">
 
+		<meta-data
+			android:name="android.max_aspect"
+			android:value="2.1" />
+
 		<activity
 			android:name=".HostListActivity"
 			android:label="@string/app_name"
-			android:launchMode="singleTop">
+			android:launchMode="singleTop"
+			android:resizeableActivity="true">
 			<intent-filter>
 				<action android:name="android.intent.action.MAIN"/>
 				<category android:name="android.intent.category.LAUNCHER"/>

--- a/app/src/main/java/org/connectbot/TerminalView.java
+++ b/app/src/main/java/org/connectbot/TerminalView.java
@@ -496,7 +496,7 @@ public class TerminalView extends FrameLayout implements FontSizeChangedListener
 			// draw any highlighted area
 			if (terminalTextViewOverlay == null && bridge.isSelectingForCopy()) {
 				SelectionArea area = bridge.getSelectionArea();
-				canvas.save(Canvas.CLIP_SAVE_FLAG);
+				canvas.save(Canvas.ALL_SAVE_FLAG);
 				canvas.clipRect(
 					area.getLeft() * bridge.charWidth,
 					area.getTop() * bridge.charHeight,

--- a/app/src/main/java/org/connectbot/service/ConnectionNotifier.java
+++ b/app/src/main/java/org/connectbot/service/ConnectionNotifier.java
@@ -29,6 +29,7 @@ import org.connectbot.util.PreferenceConstants;
 
 import android.annotation.TargetApi;
 import android.app.Notification;
+import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.app.Service;
@@ -36,6 +37,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.res.Resources;
 import android.graphics.Color;
+import android.os.Build;
 import android.support.v4.app.NotificationCompat;
 
 /**
@@ -48,6 +50,9 @@ public abstract class ConnectionNotifier {
 	private static final int ACTIVITY_NOTIFICATION = 2;
 	private static final int ONLINE_DISCONNECT_NOTIFICATION = 3;
 
+	private String id = "my_connectbot_channel";
+	NotificationChannel nc;
+
 	public static ConnectionNotifier getInstance() {
 		if (PreferenceConstants.PRE_ECLAIR)
 			return PreEclair.Holder.sInstance;
@@ -59,17 +64,23 @@ public abstract class ConnectionNotifier {
 		return (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
 	}
 
-	protected NotificationCompat.Builder newNotificationBuilder(Context context) {
+	protected NotificationCompat.Builder newNotificationBuilder(Context context, String id) {
 		NotificationCompat.Builder builder =
-				new NotificationCompat.Builder(context)
+				new NotificationCompat.Builder(context, id)
 				.setSmallIcon(R.drawable.notification_icon)
 				.setWhen(System.currentTimeMillis());
+
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+			nc = new NotificationChannel(id, context.getString(R.string.app_name),
+					NotificationManager.IMPORTANCE_DEFAULT);
+			getNotificationManager(context).createNotificationChannel(nc);
+		}
 
 		return builder;
 	}
 
 	protected Notification newActivityNotification(Context context, HostBean host) {
-		NotificationCompat.Builder builder = newNotificationBuilder(context);
+		NotificationCompat.Builder builder = newNotificationBuilder(context, id);
 
 		Resources res = context.getResources();
 
@@ -105,7 +116,7 @@ public abstract class ConnectionNotifier {
 	}
 
 	protected Notification newRunningNotification(Context context) {
-		NotificationCompat.Builder builder = newNotificationBuilder(context);
+		NotificationCompat.Builder builder = newNotificationBuilder(context, id);
 
 		builder.setOngoing(true);
 		builder.setWhen(0);

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@
 
 allprojects {
     repositories {
+        google()
         jcenter()
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
 jacocoVersion=0.7.7.201606060606
+android.enableD8=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.5-rc-1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.5-all.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.5-rc-1-all.zip


### PR DESCRIPTION
So last night I was using ConnectBot on my Chromebook and got a little annoyed that I couldn't resize it, so figured I'd add that to the manifest and build it-- which lead to me updating the build to the latest stuff in Android Studio 3.1.  To do so I had to add a pretty generic NotificationChannel (feel free to change/move it somewhere else if you want) and some other minor tweaks.  Also the minimum supported API in google-services is now 14, so that's true of the app too.

Don't know if this breaks any tests that weren't breaking before, but anyhoo, I have resizable windows on my Chromebook now so I'm happy.  YMMV.  Lots of tracked .idea files (and other files) changed automatically during the build, but as there's no reason I can tell to track this in the repo, I also added .idea to .gitignore.  Android Studio/lint also recommended lots of other changes (formatting, code simplification, etc.) but I only include the bare minimum needed for the build to complete and hopefully didn't leave anything out.  Obviously someone will have to verify it builds for them too :)

I'm guessing that build daemon thing will break as there are new license things for 27.0.x that need to be agreed to.

This should also clear a path for downloadable font integration re: #565.