### PR TITLE
Fix German F11 label in emulated keys

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -264,7 +264,7 @@
   <string name="button_key_f8">F8</string>
   <string name="button_key_f9">F9</string>
   <string name="button_key_f10">F10</string>
-  <string name="button_key_f11">F10</string>
+  <string name="button_key_f11">F11</string>
   <string name="button_key_f12">F12</string>
   <string name="protocol_spinner_label">Protokoll</string>
   <string name="expand">Aufklappen</string>


### PR DESCRIPTION
Fixes #607