### PR TITLE
Do not drop connections if Android reports no connectivity

### DIFF
--- a/app/src/main/java/org/connectbot/service/ConnectivityReceiver.java
+++ b/app/src/main/java/org/connectbot/service/ConnectivityReceiver.java
@@ -79,22 +79,14 @@ public class ConnectivityReceiver extends BroadcastReceiver {
 			return;
 		}
 
-		boolean noConnectivity = intent.getBooleanExtra(ConnectivityManager.EXTRA_NO_CONNECTIVITY, false);
-		boolean isFailover = intent.getBooleanExtra(ConnectivityManager.EXTRA_IS_FAILOVER, false);
+		NetworkInfo info = (NetworkInfo) intent.getExtras()
+				.get(ConnectivityManager.EXTRA_NETWORK_INFO);
 
-		Log.d(TAG, "onReceived() called; noConnectivity? " + noConnectivity + "; isFailover? " + isFailover);
+		Log.d(TAG, "onReceived() called; getState() " + info.getState().toString());
 
-		if (noConnectivity && !isFailover && mIsConnected) {
-			mIsConnected = false;
-			mTerminalManager.onConnectivityLost();
-		} else if (!mIsConnected) {
-			NetworkInfo info = (NetworkInfo) intent.getExtras()
-					.get(ConnectivityManager.EXTRA_NETWORK_INFO);
-
-			mIsConnected = (info.getState() == State.CONNECTED);
-			if (mIsConnected) {
-				mTerminalManager.onConnectivityRestored();
-			}
+		mIsConnected = (info.getState() == State.CONNECTED);
+		if (mIsConnected) {
+			mTerminalManager.onConnectivityRestored();
 		}
 	}
 

--- a/app/src/main/java/org/connectbot/service/TerminalManager.java
+++ b/app/src/main/java/org/connectbot/service/TerminalManager.java
@@ -660,20 +660,6 @@ public class TerminalManager extends Service implements BridgeDisconnectedListen
 		public byte[] openSSHPubkey;
 	}
 
-	/**
-	 * Called when connectivity to the network is lost and it doesn't appear
-	 * we'll be getting a different connection any time soon.
-	 */
-	public void onConnectivityLost() {
-		final Thread t = new Thread() {
-			@Override
-			public void run() {
-				disconnectAll(false, true);
-			}
-		};
-		t.setName("Disconnector");
-		t.start();
-	}
 
 	/**
 	 * Called when connectivity to the network is restored.


### PR DESCRIPTION
Android (netd) kills TCP connections if addresses go away since
Android 5.x (Lollipop). Actively killing connection is unecessary
and in some situations even harmful, e.g. when using localhost
connections or if a VPN is present which will reconnect on its
own.

Fixes #623 and #599.