### PR TITLE
Support the ESC from the hardware keyboard

### DIFF
--- a/app/src/main/java/org/connectbot/service/TerminalKeyListener.java
+++ b/app/src/main/java/org/connectbot/service/TerminalKeyListener.java
@@ -147,6 +147,8 @@ public class TerminalKeyListener implements OnKeyListener, OnSharedPreferenceCha
 					interpretAsHardKeyboard;
 			final boolean controlNumbersAreFKeys = controlNumbersAreFKeysOnSoftKeyboard &&
 					!interpretAsHardKeyboard;
+			final boolean backKeyAsEscKey = interpretAsHardKeyboard &&
+					prefs.getBoolean(PreferenceConstants.BACKKEY_AS_ESCKEY, false);
 
 			// Ignore all key-up events except for the special keys
 			if (event.getAction() == KeyEvent.ACTION_UP) {
@@ -376,7 +378,7 @@ public class TerminalKeyListener implements OnKeyListener, OnSharedPreferenceCha
 			}
 
 			// If hardware keyboard pressed the BACK key, it works as the ESC key
-			if (keyCode == KEYCODE_BACK && interpretAsHardKeyboard
+			if (backKeyAsEscKey && keyCode == KEYCODE_BACK
 					&& ((event.getFlags() & KeyEvent.FLAG_VIRTUAL_HARD_KEY) != KeyEvent.FLAG_VIRTUAL_HARD_KEY)) {
 				sendEscape();
 				return true;

--- a/app/src/main/java/org/connectbot/service/TerminalKeyListener.java
+++ b/app/src/main/java/org/connectbot/service/TerminalKeyListener.java
@@ -62,6 +62,7 @@ public class TerminalKeyListener implements OnKeyListener, OnSharedPreferenceCha
 	private final static int OUR_SHIFT_MASK = OUR_SHIFT_ON | OUR_SHIFT_LOCK;
 
 	// backport constants from api level 11
+	private final static int KEYCODE_BACK = 4;
 	private final static int KEYCODE_ESCAPE = 111;
 	private final static int KEYCODE_CTRL_LEFT = 113;
 	private final static int KEYCODE_CTRL_RIGHT = 114;
@@ -78,6 +79,7 @@ public class TerminalKeyListener implements OnKeyListener, OnSharedPreferenceCha
 			| HC_META_CTRL_LEFT_ON;
 	private final static int HC_META_ALT_MASK = KeyEvent.META_ALT_ON | KeyEvent.META_ALT_LEFT_ON
 			| KeyEvent.META_ALT_RIGHT_ON;
+	private final static int FLAG_VIRTUAL_HARD_KEY = 64;
 
 	private final TerminalManager manager;
 	private final TerminalBridge bridge;
@@ -370,6 +372,13 @@ public class TerminalKeyListener implements OnKeyListener, OnSharedPreferenceCha
 					// TODO write encoding routine that doesn't allocate each time
 					bridge.transport.write(new String(Character.toChars(uchar))
 							.getBytes(encoding));
+				return true;
+			}
+
+			// If hardware keyboard pressed the BACK key, it works as the ESC key
+			if (keyCode == KEYCODE_BACK && interpretAsHardKeyboard
+					&& ((event.getFlags() & KeyEvent.FLAG_VIRTUAL_HARD_KEY) != KeyEvent.FLAG_VIRTUAL_HARD_KEY)) {
+				sendEscape();
 				return true;
 			}
 

--- a/app/src/main/java/org/connectbot/service/TerminalKeyListener.java
+++ b/app/src/main/java/org/connectbot/service/TerminalKeyListener.java
@@ -379,7 +379,7 @@ public class TerminalKeyListener implements OnKeyListener, OnSharedPreferenceCha
 
 			// If hardware keyboard pressed the BACK key, it works as the ESC key
 			if (backKeyAsEscKey && keyCode == KEYCODE_BACK
-					&& ((event.getFlags() & KeyEvent.FLAG_VIRTUAL_HARD_KEY) != KeyEvent.FLAG_VIRTUAL_HARD_KEY)) {
+					&& ((event.getFlags() & FLAG_VIRTUAL_HARD_KEY) != FLAG_VIRTUAL_HARD_KEY)) {
 				sendEscape();
 				return true;
 			}

--- a/app/src/main/java/org/connectbot/util/PreferenceConstants.java
+++ b/app/src/main/java/org/connectbot/util/PreferenceConstants.java
@@ -69,6 +69,8 @@ public final class PreferenceConstants {
 
 	public static final String BUMPY_ARROWS = "bumpyarrows";
 
+	public static final String BACKKEY_AS_ESCKEY = "backesckey";
+
 	public static final String SORT_BY_COLOR = "sortByColor";
 
 	public static final String BELL = "bell";

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -190,4 +190,6 @@
   <string name="discard_host_changes_message">호스트 URI가 유효하지 않습니다. 변경 사항을 취소 하시겠습니까?</string>
   <string name="discard_host_button">버리기</string>
   <string name="discard_host_cancel_button">계속 편집하기</string>
+  <string name="pref_backesckey_title">Back 키를 ESC 키로 사용</string>
+  <string name="pref_backesckey_summary">하드웨어 키보드에서 Back 키가 ESC 키를 보내게 합니다</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -298,6 +298,11 @@
 	<!-- Summary for the haptic feedback (bumpy arrow) preference -->
 	<string name="pref_bumpyarrows_summary">"Vibrate when sending arrow keys; useful for laggy connections"</string>
 
+	<!-- Name for the Back key as the ESC key preference -->
+	<string name="pref_backesckey_title">"The Back key as the ESC key"</string>
+	<!-- Summary for the Back key as the ESC key preference -->
+	<string name="pref_backesckey_summary">"On hardware keyboards, the Back key sends the ESC key"</string>
+
 	<!-- Category title for the Terminal Bell preferences -->
 	<string name="pref_bell_category">"Terminal bell"</string>
 

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -174,6 +174,13 @@
 			android:summary="@string/pref_bumpyarrows_summary"
 			android:defaultValue="true"
 			/>
+
+		<SwitchPreferenceCompat
+			android:key="backesckey"
+			android:title="@string/pref_backesckey_title"
+			android:summary="@string/pref_backesckey_summary"
+			android:defaultValue="false"
+			/>
 	</PreferenceCategory>
 
 	<PreferenceCategory


### PR DESCRIPTION
When I pressed the ESC key on my Bluetooth keyboard, it sent the KEYCODE_BACK code instead of the KEYCODE_ESCAPE code.
So I have added the 'The Back Key as the ESC key' preference. (and I added the Korean translation of this preference.)

When the preference is enabled, only the back key event generated from the hardware keyboard is mapped to the ESC key.
(Use the FLAG_VIRTUAL_HARD_KEY flag to know where the key event was generated)

Also, it fixed issue #433