### PR TITLE
Fix Proguard configuration

### DIFF
--- a/app/proguard.cfg
+++ b/app/proguard.cfg
@@ -42,8 +42,9 @@
 }
 
 -keep class org.connectbot.**
--keep public class com.trilead.ssh2.compression.*
--keep public class com.trilead.ssh2.crypto.*
+-keepattributes InnerClasses
+-keep public class com.trilead.ssh2.compression.**
+-keep public class com.trilead.ssh2.crypto.**
 
 # All the classes are referenced indirectly.
 -keep class org.conscrypt.** { *; }


### PR DESCRIPTION
The latest SSH library uses inner classes for some of the encryption
modes, so Proguard strips them out since they're only referenced via
reflection.

This fixes #637.