### PR TITLE
Generated version should roll with git

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -49,6 +49,7 @@ coveralls.jacocoReportPath = 'build/reports/coverage/google/debug/report.xml'
 
 androidGitVersion {
     prefix = "v"
+    codeFormat = 'MMNNPPBBB'
 }
 
 android {


### PR DESCRIPTION
Adding BBB lets us count the number of changes since the last time ConnectBot was tagged. This will fix alpha uploading to the Play Store.