### PR TITLE
Update to sshlib 2.2.8

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -183,7 +183,7 @@ tasks.withType(JavaCompile) {
 
 // Dependencies must be below the android block to allow productFlavor specific deps.
 dependencies {
-    implementation 'org.connectbot:sshlib:2.2.7'
+    implementation 'org.connectbot:sshlib:2.2.8'
     googleImplementation 'com.google.android.gms:play-services-base:16.0.1'
     ossImplementation 'org.conscrypt:conscrypt-android:1.4.0'
 


### PR DESCRIPTION
sshlib 2.2.7 was using StandardCharsets which only was supported in API
19 and later.

Fixes #654 