### PR TITLE
Fix last connection time race condition

### DIFF
--- a/app/src/main/java/org/connectbot/util/HostDatabase.java
+++ b/app/src/main/java/org/connectbot/util/HostDatabase.java
@@ -406,6 +406,7 @@ public class HostDatabase extends RobustSQLiteOpenHelper implements HostStorage,
 	@Override
 	public void touchHost(HostBean host) {
 		long now = System.currentTimeMillis() / 1000;
+		host.setLastConnect(now);
 
 		ContentValues values = new ContentValues();
 		values.put(FIELD_HOST_LASTCONNECT, now);


### PR DESCRIPTION
Last connection time is stored in a host instance and in the db. If
not updated in the host instance before updated in the db, saveHost,
called in the connection thread, will overwrite the value in the db,
just updated from touchHost, with the old host instance value.

Fixes #594.