### PR TITLE
Fix an off-by-one error in ESC [ G handling

### DIFF
--- a/app/src/main/java/de/mud/terminal/vt320.java
+++ b/app/src/main/java/de/mud/terminal/vt320.java
@@ -2713,7 +2713,7 @@ public void setScreenSize(int c, int r, boolean broadcast) {
               debug("ESC [" + DCEvars[0] + " ; " + DCEvars[1] + " r");
             break;
           case 'G':  /* CUP  / cursor absolute column */
-            C = DCEvars[0];
+            C = DCEvars[0] - 1;
             if (C < 0)
               C = 0;
             else if (C >= width)


### PR DESCRIPTION
There's an off-by-one error in the terminal emulator's handling of the ESC [ G (Cursor Horizontal Absolute) sequence.

I believe this also solves issue #702.