### PR TITLE
Remove an outdated plugin

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,7 +10,6 @@ buildscript {
 plugins {
     id 'com.android.application' version '4.2.1'
     id 'com.github.ben-manes.versions' version '0.38.0'
-    id 'info.vividcode.android.sdk-manager' version '0.9.0'
     id 'net.ltgt.errorprone' version '2.0.1'
     id 'com.gladed.androidgitversion' version '0.4.14'
     id 'com.github.kt3k.coveralls' version '2.12.0'


### PR DESCRIPTION
The less plugin are included the less future problems you will run into. 
To remove this is quite easy, because it's not used https://github.com/nobuoka/vc-gradle-android-sdk-manager#usage-version-09x 