### PR TITLE
Fix null pointer exception when exiting terminal.

### DIFF
--- a/app/src/main/java/org/connectbot/ConsoleActivity.java
+++ b/app/src/main/java/org/connectbot/ConsoleActivity.java
@@ -402,7 +402,17 @@ public class ConsoleActivity extends AppCompatActivity implements BridgeDisconne
 		// If we just closed the last bridge, go back to the previous activity.
 		if (pager.getChildCount() == 0) {
 			finish();
+			unregisterMenuListeners();
 		}
+	}
+
+	private void unregisterMenuListeners() {
+		portForward.setOnMenuItemClickListener(null);
+		disconnect.setOnMenuItemClickListener(null);
+		paste.setOnMenuItemClickListener(null);
+		portForward.setOnMenuItemClickListener(null);
+		resize.setOnMenuItemClickListener(null);
+		urlscan.setOnMenuItemClickListener(null);
 	}
 
 	protected View findCurrentView(int id) {


### PR DESCRIPTION
When finish is called, remove the click listeners from the menu.  Based on event timing, these click listeners may be invoked after the activity is paused or destroyed.

This should fix issue #1015 .

@seg-ha could you test if this fixes issue #765 ?