### PR TITLE
New preference settings to work around issues with Hacker's Keyboard

### DIFF
--- a/app/src/main/java/org/connectbot/util/PreferenceConstants.java
+++ b/app/src/main/java/org/connectbot/util/PreferenceConstants.java
@@ -82,7 +82,9 @@ public final class PreferenceConstants {
 	public static final String SHIFT_FKEYS = "shiftfkeys";
 	public static final String CTRL_FKEYS = "ctrlfkeys";
 	public static final String VOLUME_FONT = "volumefont";
+	public static final String CTRL_FONT = "ctrlfont";
 	public static final String STICKY_MODIFIERS = "stickymodifiers";
+	public static final String STICKY_NON_LOCKING = "stickynonlocking";
 	public static final String YES = "yes";
 	public static final String NO = "no";
 	public static final String ALT = "alt";

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -255,6 +255,11 @@
 	<!-- Summary for the volume keys control font size preference -->
 	<string name="pref_volumefont_summary">"Font size can also be changed in per-host settings"</string>
 
+	<!-- Name for the ctrl-+/- keys control font size preference -->
+	<string name="pref_ctrlfont_title">"Ctrl-plus/minus keys change font size"</string>
+	<!-- Summary for the ctrl-+/- keys control font size preference -->
+	<string name="pref_ctrlfont_summary">"Font size can also be changed in per-host settings"</string>
+
 	<!-- Name for the memorize keys preference -->
 	<string name="pref_memkeys_title">"Remember keys in memory"</string>
 	<!-- Summary for the memorize keys preference -->
@@ -274,6 +279,11 @@
 	<string name="pref_stickymodifiers_title">"Sticky modifiers"</string>
 	<!-- Summary for the sticky modifiers preference -->
 	<string name="pref_stickymodifiers_summary">"Modifier keys remain enabled until another key is pressed"</string>
+
+	<!-- Name for the sticky non locking preference -->
+	<string name="pref_stickynonlocking_title">"Sticky modifiers do not lock"</string>
+	<!-- Summary for the sticky non locking preference -->
+	<string name="pref_stickynonlocking_summary">"This setting is a workaround for Hacker's Keyboard"</string>
 
 	<!-- Sticky modifier preference value description for when only the Alt key should be a sticky modifier. -->
 	<string name="only_alt">"Only alt"</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -111,6 +111,13 @@
 			/>
 
 		<SwitchPreferenceCompat
+			android:key="ctrlfont"
+			android:title="@string/pref_ctrlfont_title"
+			android:summary="@string/pref_ctrlfont_summary"
+			android:defaultValue="true"
+			/>
+
+		<SwitchPreferenceCompat
 			android:key="keepalive"
 			android:title="@string/pref_keepalive_title"
 			android:summary="@string/pref_keepalive_summary"
@@ -148,6 +155,13 @@
 			android:entries="@array/list_stickymodifiers"
 			android:entryValues="@array/list_stickymodifiers_values"
 			android:defaultValue="no"
+			/>
+
+		<SwitchPreferenceCompat
+			android:key="stickynonlocking"
+			android:title="@string/pref_stickynonlocking_title"
+			android:summary="@string/pref_stickynonlocking_summary"
+			android:defaultValue="false"
 			/>
 
 		<ListPreference


### PR DESCRIPTION
I am using Hacker's Keyboard and Connectbot version 1.9.8-oss, both installed from F-Droid.

For most control characters, Hacker's Keyboard sends (optional) key-down and key-up events for the control key, followed by key-down and key-up events for the alphabetic character, the latter having the META_CTRL_LEFT_ON flag set, as expected. 
Unfortunately, pressing ctrl-shift-minus in order to send ctrl-underscore causes Hacker's keyboard to send the keycode for the minus key with only the META_SHIFT flag set, and not META_CTRL. This is undoubtedly a bug in Hacker's Keyboard, but that project seems to have been abandoned by its owner. The effect in Connectbot is to send a plain underscore (0x5f) to the server, and not ctrl-underscore (0x1f).

A potential workaround would be to turn on 'meta keys are sticky' in Connectbot, so that the preceding control key-down is remembered. However, that has two weird effects: 
1. control-shift-minus now causes the volume setting to be reduced, and sends nothing to the server 
2. the combination of control keycode followed by a keycode with META_CTRL set, as sent by (e.g.) ctrl-Q, confuses the logic that is evidently trying to interpret pressing control twice to mean control-lock. The effect is that every subsequent character is interpreted as a control character until the control key is pressed again.

None of this happened with version 1.9.6-oss as it received characters from Hacker's keyboard as multi-character IME input (KEYCODE_UNKNOWN) and passed them on to the server unexamined. 

This patch adds two preference settings, which between them solve the problems introduced by the 'meta keys are sticky' workaround: 
1. setting the volume by ctrl-plus/minus can be disabled 
2. pressing the control key twice no longer locks it 
The latter setting does not apply to the control key on the special keyboard, which continues to work as before. 