### PR TITLE
Import&export of hosts and port forwards using Gson

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -240,6 +240,7 @@ dependencies {
 	implementation 'androidx.appcompat:appcompat:1.4.1'
 	implementation "androidx.preference:preference:1.2.0"
 	implementation "com.google.android.material:material:1.5.0"
+	implementation 'com.google.code.gson:gson:2.9.0'
 
 	androidTestUtil "androidx.test:orchestrator:$testRunnerVersion"
 	androidTestUtil "com.linkedin.testbutler:test-butler-app:2.2.1"

--- a/app/src/main/java/org/connectbot/HostListActivity.java
+++ b/app/src/main/java/org/connectbot/HostListActivity.java
@@ -317,6 +317,8 @@ public class HostListActivity extends AppCompatListActivity implements OnHostSta
 				for (HostExport.HostWithForwards hostExport: export.getHosts()) {
 					HostBean host = hostExport.getHost();
 					host.setId(-1);
+					host.setPubkeyId(HostDatabase.PUBKEYID_ANY);
+					host.setLastConnect(-1);
 					hostdb.saveHost(host);
 					for (PortForwardBean portforward : hostExport.getPortforwards()) {
 						portforward.setId(-1);

--- a/app/src/main/java/org/connectbot/bean/PortForwardBean.java
+++ b/app/src/main/java/org/connectbot/bean/PortForwardBean.java
@@ -95,6 +95,20 @@ public class PortForwardBean extends AbstractBean {
 	}
 
 	/**
+	 * @param hostId the hostId to set
+	 */
+	public void setHostId(long hostId) {
+		this.hostId = hostId;
+	}
+
+	/**
+	 * @return the hostId
+	 */
+	public long getHostId() {
+		return hostId;
+	}
+
+	/**
 	 * @param nickname the nickname to set
 	 */
 	public void setNickname(String nickname) {

--- a/app/src/main/java/org/connectbot/util/HostExport.java
+++ b/app/src/main/java/org/connectbot/util/HostExport.java
@@ -1,0 +1,48 @@
+package org.connectbot.util;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.connectbot.bean.HostBean;
+import org.connectbot.bean.PortForwardBean;
+
+import kotlin.collections.ArrayDeque;
+
+public class HostExport {
+	private List<HostWithForwards> hosts;
+
+	public HostExport() {
+		this.hosts = new ArrayList<>();
+	}
+	public HostExport(List<HostWithForwards> hosts) {
+		this.hosts = hosts;
+	}
+
+	public List<HostWithForwards> getHosts() {
+		return hosts;
+	}
+
+	public void addHost(HostBean host, List<PortForwardBean> portForwards) {
+		HostWithForwards hostExport = new HostWithForwards(host, portForwards);
+		hosts.add(hostExport);
+	}
+
+	public class HostWithForwards {
+		HostBean host;
+		List<PortForwardBean> portforwards;
+
+		public HostWithForwards (HostBean host, List<PortForwardBean> portforwards) {
+			this.host = host;
+			this.portforwards = portforwards;
+		}
+
+		public HostBean getHost() {
+			return host;
+		}
+
+		public List<PortForwardBean> getPortforwards() {
+			return portforwards;
+		}
+
+	}
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -435,11 +435,14 @@
 	<!-- Selection choice to sort hosts by nickname. -->
 	<string name="list_menu_sortname">"Sort by name"</string>
 	<string name="list_menu_disconnect">"Disconnect All"</string>
+	<string name="list_menu_import">"Import Host(s) from Clipboard"</string>
+	<string name="list_menu_export">"Export Host(s) to Clipboard"</string>
 	<string name="list_menu_settings">"Settings"</string>
 
 	<string name="list_host_disconnect">"Disconnect"</string>
 	<string name="list_host_edit">"Edit host"</string>
 	<string name="list_host_portforwards">"Edit port forwards"</string>
+	<string name="list_host_export">"Export to Clipboard"</string>
 	<string name="list_host_delete">"Delete host"</string>
 	<!-- Note that the '\n' splits the lines so it's actually "quick-connect box below to connect" -->
 	<string name="list_host_empty">"No hosts created yet."</string>


### PR DESCRIPTION
Fixes #527 and #922.

The hosts and port forwards are exported to the clipboard in json format. This does not include any keys.

The class `HostExport` is a crude workaround. Currently there is no Object-Oriented data structure that maps port forwards to hosts. If someone is willing to refactor the existing code, this class could be removed. This workaround was the simplest way I found to serialize all hosts with their respective port forwards.