### PR TITLE
provide method to delete known host entries for ssh hosts

### DIFF
--- a/app/src/main/java/org/connectbot/HostListActivity.java
+++ b/app/src/main/java/org/connectbot/HostListActivity.java
@@ -499,6 +499,36 @@ public class HostListActivity extends AppCompatListActivity implements OnHostSta
 					return true;
 				}
 			});
+			MenuItem deleteFromKnownHosts =menu.add(R.string.list_host_reset_knownhost);
+			deleteFromKnownHosts.setOnMenuItemClickListener(new OnMenuItemClickListener() {
+				@Override
+				public boolean onMenuItemClick(MenuItem item) {
+					// prompt user to make sure they really want this
+					new androidx.appcompat.app.AlertDialog.Builder(
+							HostListActivity.this, R.style.AlertDialogTheme)
+							.setMessage(getString(R.string.reset_hostkey_message, host.getNickname()))
+							.setPositiveButton(R.string.reset_pos, new DialogInterface.OnClickListener() {
+								@Override
+								public void onClick(DialogInterface dialog, int which) {
+									// make sure we disconnect
+									if (bridge != null)
+										bridge.dispatchDisconnect(true);
+									List<String> hostKeyAlgos=
+											hostdb.getHostKeyAlgorithmsForHost(
+											host.getHostname(),host.getPort());
+									for (String algo:hostKeyAlgos) {
+										hostdb.removeKnownHost(host.getHostname(), host.getPort(),
+											algo,(new byte[0]));
+									}
+								}
+							})
+							.setNegativeButton(R.string.delete_neg, null).create().show();
+
+					return true;
+				}
+			});
+			if (!(host.getProtocol().equals("ssh")))
+				deleteFromKnownHosts.setEnabled(false);
 		}
 	}
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -185,6 +185,8 @@
   <string name="list_host_edit">Host editieren</string>
   <string name="list_host_portforwards">Port-Weiterleitungen editieren</string>
   <string name="list_host_delete">Host löschen</string>
+  <string name="list_host_reset_knownhost">"Known host keys zurücksetzen"</string>
+
   <string name="list_host_empty">Benutzen Sie die quick-connect box\nunten um sich mit einem Host zu verbinden.</string>
   <string name="list_rotation_default">Vorgabe</string>
   <string name="list_rotation_land">Querformat erzwingen</string>
@@ -200,6 +202,9 @@
   <string name="delete_message">Soll \'%1$s\' wirklich gelöscht werden?</string>
   <string name="delete_pos">Ja, löschen</string>
   <string name="delete_neg">Abbrechen</string>
+  <string name="reset_hostkey_message">
+		"Möchten Sie bekannte Hostschlüssel für \'%1$s\' wirklich zurücksetzen? Dies ist nur notwendig, wenn Schlüssel auf dem Server geändert wurde."</string>
+  <string name="reset_pos">"Ja, zurücksetzen"</string>
   <string name="disconnect_all_message">Möchtest du wirklich alle Verbindungen beenden?</string>
   <string name="disconnect_all_pos">Ja, Verbindungen beenden.</string>
   <string name="disconnect_all_neg">Abbrechen</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -441,6 +441,9 @@
 	<string name="list_host_edit">"Edit host"</string>
 	<string name="list_host_portforwards">"Edit port forwards"</string>
 	<string name="list_host_delete">"Delete host"</string>
+	<!-- Reset host key text -->
+	<string name="list_host_reset_knownhost">"Reset known host keys"</string>
+
 	<!-- Note that the '\n' splits the lines so it's actually "quick-connect box below to connect" -->
 	<string name="list_host_empty">"No hosts created yet."</string>
 
@@ -470,6 +473,11 @@
 	<string name="delete_message">"Are you sure you want to delete '%1$s'?"</string>
 	<string name="delete_pos">"Yes, delete"</string>
 	<string name="delete_neg">"Cancel"</string>
+
+	<!-- Reset host key message -->
+	<string name="reset_hostkey_message">
+		"Are you sure you want to reset known host keys for '%1$s'? This is only necessary if keys were changed on the server."</string>
+	<string name="reset_pos">"Yes, reset"</string>
 
 	<string name="disconnect_all_message">"Are you sure you want to disconnect from all connected hosts?"</string>
 	<string name="disconnect_all_pos">"Yes, disconnect"</string>


### PR DESCRIPTION
to be used if the server key or algorithm was changed
A new menu entry is added in the HostList - when executed,
all known keys in the database for the corresponding host are
deleted.
resolves #477
resolves #586