### PR TITLE
MinSdk 21 to solve multidex

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -41,7 +41,7 @@ android {
 		versionName androidGitVersion.name()
 		versionCode androidGitVersion.code()
 
-		minSdkVersion 14
+		minSdkVersion 21
 		targetSdkVersion 31
 
 		vectorDrawables.useSupportLibrary = true


### PR DESCRIPTION
I run into multidex issues. With minSdk 21 you reach 98% of all Android devices. 
Devices < 21 can still use recent version.