### PR TITLE
Fix text selection for certain font sizes

### DIFF
--- a/app/src/main/java/org/connectbot/TerminalView.java
+++ b/app/src/main/java/org/connectbot/TerminalView.java
@@ -48,6 +48,7 @@ import android.net.Uri;
 import android.os.AsyncTask;
 import android.preference.PreferenceManager;
 import android.text.ClipboardManager;
+import android.util.TypedValue;
 import android.view.GestureDetector;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
@@ -212,7 +213,7 @@ public class TerminalView extends FrameLayout implements FontSizeChangedListener
 		bridge.addFontSizeChangedListener(this);
 		bridge.parentChanged(this);
 
-		onFontSizeChanged(bridge.getFontSize());
+		onFontSizeChanged(0); // the argument is unused
 
 		gestureDetector = new GestureDetector(context, new GestureDetector.SimpleOnGestureListener() {
 			// Only used for pre-Honeycomb devices.
@@ -372,14 +373,15 @@ public class TerminalView extends FrameLayout implements FontSizeChangedListener
 	}
 
 	@Override
-	public void onFontSizeChanged(final float size) {
+	public void onFontSizeChanged(final float unusedSizeDp) {
 		scaleCursors();
 
 		((Activity) context).runOnUiThread(new Runnable() {
 			@Override
 			public void run() {
 				if (terminalTextViewOverlay != null) {
-					terminalTextViewOverlay.setTextSize(size);
+					// Use the bridge text size in pixels to have exactly the same text size.
+					terminalTextViewOverlay.setTextSize(TypedValue.COMPLEX_UNIT_PX, bridge.getTextSizePx());
 
 					// For the TextView to line up with the bitmap text, lineHeight must be equal to
 					// the bridge's charHeight. See TextView.getLineHeight(), which has been reversed to

--- a/app/src/main/java/org/connectbot/service/TerminalBridge.java
+++ b/app/src/main/java/org/connectbot/service/TerminalBridge.java
@@ -557,8 +557,11 @@ public class TerminalBridge implements VDUDisplay {
 		forcedSize = false;
 	}
 
-	public float getFontSize() {
-		return fontSizeDp;
+	/**
+	 * @return current text size in pixels
+	 */
+	public float getTextSizePx() {
+		return defaultPaint.getTextSize();
 	}
 
 	/**


### PR DESCRIPTION
For certain font sizes (e.g. for 13 points), the overlay was using slightly smaller font than the terminal bridge. It appears that the overlay (i.e. TextView) is always rounding down the pixel size, whereas TerminalBridge is rounding to the closest integer.

Copy the pixel size from the bridge to the overlay to ensure perfect alignment between the two.

Remove TerminalBridge#setFontSize(), it's not used anymore. Add TerminalBridge#setFontSizePx() instead.