### PR TITLE
Use proguard for debug configs

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -1,3 +1,5 @@
+project(ConnectBot)
+
 cmake_minimum_required (VERSION 3.4.1)
 
 add_library (com_google_ase_Exec SHARED "src/main/cpp/com_google_ase_Exec.cpp")

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -33,7 +33,7 @@ androidGitVersion {
 }
 
 android {
-	compileSdkVersion 31
+	compileSdkVersion 33
 
 	defaultConfig {
 		applicationId "org.connectbot"
@@ -236,9 +236,9 @@ dependencies {
 	ossImplementation 'org.conscrypt:conscrypt-android:2.5.2'
 
 	implementation "androidx.recyclerview:recyclerview:1.2.1"
-	implementation 'androidx.appcompat:appcompat:1.4.2'
+	implementation 'androidx.appcompat:appcompat:1.6.1'
 	implementation "androidx.preference:preference:1.2.0"
-	implementation "com.google.android.material:material:1.6.1"
+	implementation "com.google.android.material:material:1.8.0"
 
 	androidTestUtil "androidx.test:orchestrator:$testRunnerVersion"
 	androidTestUtil "com.linkedin.testbutler:test-butler-app:2.2.1"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -241,7 +241,6 @@ dependencies {
 	implementation "com.google.android.material:material:1.8.0"
 
 	androidTestUtil "androidx.test:orchestrator:$testRunnerVersion"
-	androidTestUtil "com.linkedin.testbutler:test-butler-app:2.2.1"
 	androidTestImplementation "androidx.test:core:1.5.0"
 	androidTestImplementation "androidx.test:rules:$testRunnerVersion"
 	androidTestImplementation "androidx.test.espresso:espresso-core:$espressoVersion"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -83,6 +83,10 @@ android {
 		}
 
 		debug {
+			// This is necessary to avoid using multiDex
+			proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard.cfg', 'proguard-debug.cfg'
+			minifyEnabled true
+
 			applicationIdSuffix ".debug"
 			testCoverageEnabled true
 		}

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -259,6 +259,5 @@ dependencies {
 	testImplementation 'org.robolectric:robolectric:4.8.2'
 
 	errorprone "com.google.errorprone:error_prone_core:2.18.0"
-	errorproneJavac "com.google.errorprone:javac:9+181-r4173-1"
 }
 

--- a/app/proguard-debug.cfg
+++ b/app/proguard-debug.cfg
@@ -1,0 +1,1 @@
+-keepattributes SourceFile,LineNumberTable

--- a/app/proguard-debug.cfg
+++ b/app/proguard-debug.cfg
@@ -1,1 +1,9 @@
 -keepattributes SourceFile,LineNumberTable
+
+-keepclassmembers class * {
+    @org.connectbot.annotation.KeepForTesting <methods>;
+}
+
+-keep class com.google.common.util.concurrent.ListenableFuture {
+	void addListener(java.lang.Runnable, java.util.concurrent.Executor);
+}

--- a/app/src/main/java/org/connectbot/GeneratePubkeyActivity.java
+++ b/app/src/main/java/org/connectbot/GeneratePubkeyActivity.java
@@ -24,6 +24,7 @@ import java.security.PublicKey;
 import java.security.SecureRandom;
 import java.security.Security;
 
+import org.connectbot.annotation.KeepForTesting;
 import org.connectbot.bean.PubkeyBean;
 import org.connectbot.util.EntropyDialog;
 import org.connectbot.util.EntropyView;
@@ -39,7 +40,6 @@ import android.app.Dialog;
 import android.app.ProgressDialog;
 import android.graphics.PorterDuff;
 import android.os.Bundle;
-import androidx.annotation.VisibleForTesting;
 import androidx.appcompat.app.AppCompatActivity;
 import android.text.Editable;
 import android.text.TextWatcher;
@@ -275,7 +275,7 @@ public class GeneratePubkeyActivity extends AppCompatActivity implements OnEntro
 		entropyDialog.show();
 	}
 
-	@VisibleForTesting
+	@KeepForTesting
 	void setListener(OnKeyGeneratedListener listener) {
 		this.listener = listener;
 	}

--- a/app/src/main/java/org/connectbot/annotation/KeepForTesting.java
+++ b/app/src/main/java/org/connectbot/annotation/KeepForTesting.java
@@ -1,0 +1,11 @@
+package org.connectbot.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(value = RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface KeepForTesting {
+}

--- a/app/src/main/java/org/connectbot/util/EntropyView.java
+++ b/app/src/main/java/org/connectbot/util/EntropyView.java
@@ -20,6 +20,7 @@ package org.connectbot.util;
 import java.util.ArrayList;
 
 import org.connectbot.R;
+import org.connectbot.annotation.KeepForTesting;
 
 import android.content.Context;
 import android.graphics.Canvas;
@@ -27,7 +28,6 @@ import android.graphics.Color;
 import android.graphics.Paint;
 import android.graphics.Typeface;
 import android.graphics.Paint.FontMetrics;
-import androidx.annotation.VisibleForTesting;
 import android.util.AttributeSet;
 import android.view.MotionEvent;
 import android.view.View;
@@ -170,7 +170,7 @@ public class EntropyView extends View {
 		return true;
 	}
 
-	@VisibleForTesting
+	@KeepForTesting
 	public void notifyListeners() {
 		for (OnEntropyGatheredListener listener : listeners) {
 			listener.onEntropyGathered(mEntropy);

--- a/app/src/main/java/org/connectbot/util/HostDatabase.java
+++ b/app/src/main/java/org/connectbot/util/HostDatabase.java
@@ -26,6 +26,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import org.connectbot.annotation.KeepForTesting;
 import org.connectbot.bean.HostBean;
 import org.connectbot.bean.PortForwardBean;
 import org.connectbot.data.ColorStorage;
@@ -36,7 +37,6 @@ import android.content.Context;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteException;
-import androidx.annotation.VisibleForTesting;
 import android.util.Log;
 
 import com.trilead.ssh2.KnownHosts;
@@ -248,7 +248,7 @@ public class HostDatabase extends RobustSQLiteOpenHelper implements HostStorage,
 	}
 
 	@Override
-	@VisibleForTesting
+	@KeepForTesting
 	public void resetDatabase() {
 		try {
 			mDb.beginTransaction();
@@ -267,7 +267,7 @@ public class HostDatabase extends RobustSQLiteOpenHelper implements HostStorage,
 		}
 	}
 
-	@VisibleForTesting
+	@KeepForTesting
 	public static void resetInMemoryInstance(Context context) {
 		get(context).resetDatabase();
 	}

--- a/app/src/main/java/org/connectbot/util/PubkeyDatabase.java
+++ b/app/src/main/java/org/connectbot/util/PubkeyDatabase.java
@@ -20,6 +20,7 @@ package org.connectbot.util;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.connectbot.annotation.KeepForTesting;
 import org.connectbot.bean.PubkeyBean;
 
 import android.content.ContentValues;
@@ -27,7 +28,6 @@ import android.content.Context;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteException;
-import androidx.annotation.VisibleForTesting;
 
 /**
  * Public Key Encryption database. Contains private and public key pairs
@@ -289,7 +289,7 @@ public class PubkeyDatabase extends RobustSQLiteOpenHelper {
 	}
 
 
-	@VisibleForTesting
+	@KeepForTesting
 	public void resetDatabase() {
 		try {
 			mDb.beginTransaction();
@@ -304,7 +304,7 @@ public class PubkeyDatabase extends RobustSQLiteOpenHelper {
 		}
 	}
 
-	@VisibleForTesting
+	@KeepForTesting
 	public static void resetInMemoryInstance(Context context) {
 		get(context).resetDatabase();
 	}


### PR DESCRIPTION
This is necessary to keep the classes.dex under the method limit. Newer dependencies have bloated up the tree and so we must rely on Proguard to strip everything out that is not needed.