### PR TITLE
Update AGP to 7.2.2

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,7 +7,7 @@ buildscript {
 }
 
 plugins {
-	id 'com.android.application' version '7.1.3'
+	id 'com.android.application' version '7.2.2'
 	id 'com.github.ben-manes.versions' version '0.45.0'
 	id 'net.ltgt.errorprone' version '3.0.1'
 	id 'com.gladed.androidgitversion' version '0.4.14'


### PR DESCRIPTION
We can not go any farther because of a bug in 7.3.x and 7.4.x that duplicates resources when used with easylauncher.