### PR TITLE
fix click failure for emulated keys when using Android > 12 

### DIFF
--- a/app/src/main/res/layout/inc_keyboard.xml
+++ b/app/src/main/res/layout/inc_keyboard.xml
@@ -34,7 +34,8 @@
 		android:layout_height="match_parent"
 		android:layout_weight="1"
 		android:padding="0dp"
-		android:scrollbars="none">
+		android:scrollbars="none"
+		android:overScrollMode="never">
 
 		<LinearLayout
 			android:layout_width="0dp"


### PR DESCRIPTION
When scrolling emulated keys to their maximum position to the left or right on Android 12 or later, clicking the keys does not initate a response. This seems to be connected to the overscroll stretch effect introduced with Android 12 ([https://developer.android.com/about/versions/12/behavior-changes-all#overscroll)](https://developer.android.com/about/versions/12/behavior-changes-all#overscroll). 
Setting
`android:overScrollMode="never"`
for the corresponding `HorizontalScrollView` fixes that.
