### PR TITLE
Monochrome icon

### DIFF
--- a/app/src/main/res/drawable/ic_launcher_monochrome.xml
+++ b/app/src/main/res/drawable/ic_launcher_monochrome.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+  <path
+      android:pathData="M38.839,39.124l15.232,15.232 -15.232,15.232 -3.839,-3.839L46.395,54.356 34.995,42.963Z"
+      android:fillColor="#fff"/>
+  <path
+      android:pathData="M54,66L73,66L73,70L54,70Z"
+      android:fillColor="#fff"/>
+</vector>

--- a/app/src/main/res/mipmap-anydpi-v26/icon.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/icon.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@drawable/ic_launcher_background"/>
     <foreground android:drawable="@drawable/ic_launcher_foreground"/>
+    <monochrome android:drawable="@drawable/ic_launcher_monochrome"/>
 </adaptive-icon>


### PR DESCRIPTION
Adds support for themed icons (Android 13 feature).
The monochrome icon consists only of the white parts of ic_launcher_foreground (in other words, I removed the shadow and blue bar).
Seems to work fine on my device with LineageOS 20 and Trebuchet.