### PR TITLE
GitHub Actions: checkout with history on push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,15 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - name: Checkout
+      - name: Checkout (with history)
+        if: ${{ github.event_name == 'push' }}
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Checkout (without history)
+        if: ${{ github.event_name != 'push' }}
         uses: actions/checkout@v3
 
       - name: Set up JDK


### PR DESCRIPTION
In order to use "git describe" we need to checkout the history.