### PR TITLE
Fix accidental size bloat

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -237,8 +237,8 @@ dependencies {
 	testImplementation 'org.robolectric:robolectric:4.10.3'
 
 	// Needed for robolectric tests
-	compileOnly 'org.conscrypt:conscrypt-openjdk-uber:2.5.2'
-	runtimeOnly 'org.conscrypt:conscrypt-android:2.5.2'
+	testCompileOnly 'org.conscrypt:conscrypt-openjdk-uber:2.5.2'
+	testRuntimeOnly 'org.conscrypt:conscrypt-android:2.5.2'
 	testImplementation 'org.conscrypt:conscrypt-openjdk-uber:2.5.2'
 
 	errorprone "com.google.errorprone:error_prone_core:2.21.1"


### PR DESCRIPTION
A change for robolectric tests accidentally included the Conscrypt library into the Google Play Store release which made the app unneccessarily large. In the Play Store version, Play Services provides the crypto library update.