### PR TITLE
Allow underscores in the hostmask

### DIFF
--- a/app/src/main/java/org/connectbot/transport/SSH.java
+++ b/app/src/main/java/org/connectbot/transport/SSH.java
@@ -108,7 +108,7 @@ public class SSH extends AbsTransport implements ConnectionMonitor, InteractiveC
 	private final static int AUTH_TRIES = 20;
 
 	private static final Pattern hostmask = Pattern.compile(
-			"^(.+)@(([0-9a-z.-_]+)|(\\[[a-f:0-9]+\\]))(:(\\d+))?$", Pattern.CASE_INSENSITIVE);
+			"^(.+)@(([0-9a-z._-]+)|(\\[[a-f:0-9]+\\]))(:(\\d+))?$", Pattern.CASE_INSENSITIVE);
 
 	private boolean compression = false;
 	private volatile boolean authenticated = false;

--- a/app/src/main/java/org/connectbot/transport/SSH.java
+++ b/app/src/main/java/org/connectbot/transport/SSH.java
@@ -108,7 +108,7 @@ public class SSH extends AbsTransport implements ConnectionMonitor, InteractiveC
 	private final static int AUTH_TRIES = 20;
 
 	private static final Pattern hostmask = Pattern.compile(
-			"^(.+)@(([0-9a-z.-]+)|(\\[[a-f:0-9]+\\]))(:(\\d+))?$", Pattern.CASE_INSENSITIVE);
+			"^(.+)@(([0-9a-z.-_]+)|(\\[[a-f:0-9]+\\]))(:(\\d+))?$", Pattern.CASE_INSENSITIVE);
 
 	private boolean compression = false;
 	private volatile boolean authenticated = false;

--- a/app/src/main/java/org/connectbot/transport/Telnet.java
+++ b/app/src/main/java/org/connectbot/transport/Telnet.java
@@ -68,7 +68,7 @@ public class Telnet extends AbsTransport {
 
 	static final Pattern hostmask;
 	static {
-		hostmask = Pattern.compile("^([0-9a-z.-_]+)(:(\\d+))?$", Pattern.CASE_INSENSITIVE);
+		hostmask = Pattern.compile("^([0-9a-z._-]+)(:(\\d+))?$", Pattern.CASE_INSENSITIVE);
 	}
 
 	public Telnet() {

--- a/app/src/main/java/org/connectbot/transport/Telnet.java
+++ b/app/src/main/java/org/connectbot/transport/Telnet.java
@@ -68,7 +68,7 @@ public class Telnet extends AbsTransport {
 
 	static final Pattern hostmask;
 	static {
-		hostmask = Pattern.compile("^([0-9a-z.-]+)(:(\\d+))?$", Pattern.CASE_INSENSITIVE);
+		hostmask = Pattern.compile("^([0-9a-z.-_]+)(:(\\d+))?$", Pattern.CASE_INSENSITIVE);
 	}
 
 	public Telnet() {


### PR DESCRIPTION
While the "rules" may say that _ is not allowed in host and/or
domainnames, the real worl reality is that they are widely used
and not breaking anything.  So embracing the robustness principle
and accepting the world as it is rather than how it should be, allow
the use of _ in host/domainnames.

Fixes: #188