### PR TITLE
Send post login string as SSH command when no shell session is requested.

### DIFF
--- a/app/src/main/java/org/connectbot/transport/AbsTransport.java
+++ b/app/src/main/java/org/connectbot/transport/AbsTransport.java
@@ -101,6 +101,13 @@ public abstract class AbsTransport {
 	public abstract void write(int c) throws IOException;
 
 	/**
+	 * Send a command to the transport for noninteractive execution.
+	 * @param command The command to send
+	 * @throws IOException when there is a problem sending the command after connection
+	 */
+	public abstract void sendCommand(final String command) throws IOException;
+
+	/**
 	 * Flushes the write commands to the transport.
 	 * @throws IOException when there is a problem writing after connection
 	 */

--- a/app/src/main/java/org/connectbot/transport/Local.java
+++ b/app/src/main/java/org/connectbot/transport/Local.java
@@ -174,6 +174,11 @@ public class Local extends AbsTransport {
 			os.write(c);
 	}
 
+	@Override
+	public void sendCommand(String command) throws IOException {
+		this.write(command.getBytes(host.getEncoding()));
+	}
+
 	public static Uri getUri(String input) {
 		Uri uri = Uri.parse(DEFAULT_URI);
 

--- a/app/src/main/java/org/connectbot/transport/Telnet.java
+++ b/app/src/main/java/org/connectbot/transport/Telnet.java
@@ -241,6 +241,11 @@ public class Telnet extends AbsTransport {
 	}
 
 	@Override
+	public void sendCommand(String command) throws IOException {
+		this.write(command.getBytes(host.getEncoding()));
+	}
+
+	@Override
 	public void setDimensions(int columns, int rows, int width, int height) {
 		try {
 			handler.setWindowSize(columns, rows);


### PR DESCRIPTION
There is currently no way for ConnectBot to send a command to a SSH server without allocating a PTY. The "post login string" is only ever sent if a PTY is requested and allocated, and then it is simply sent as an input to the PTY. Issue #1128 describes a similar, if not identical issue.

This is especially limiting if a remote SSH server only permits executing commands. Probably the most common example is OpenSSHd's `ForceCommand` option: It requires any command (or a shell) to be started before ForceCommand takes effect. ConnectBot, however, won't start a shell unless PTY allocation succeeds.

This PR adds the following feature: If establishing a session is disabled, but a post login string is provided, the post login string is executed as a command through SSH, rather than being piped into a shell. The local and telnet transports' behavior is unchanged.