### PR TITLE
Fix Persistent notification no longer working

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,6 +26,7 @@
 	<uses-permission android:name="android.permission.VIBRATE" />
 	<uses-permission android:name="android.permission.WAKE_LOCK" />
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+	<uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
 	<uses-feature android:name="android.hardware.touchscreen" android:required="false"/>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -673,4 +673,7 @@
 	     Added to the end of a key description to indicate that the key is encrypted (i.e,
 	     password protected). -->
 	<string name="key_attribute_encrypted">(encrypted)</string>
+	<string name="notification_requirement_explanation">Notification permission is required to display running sessions in the background</string>
+	<string name="continue_anyway">Continue without</string>
+	<string name="allow">Allow</string>
 </resources>


### PR DESCRIPTION
Add Android 13 POST_NOTIFICATIONS runtime permission

Request the permission after clicking on a Host and before starting the Console (only on Android 13+ devices).

Resolves [1352](https://github.com/connectbot/connectbot/issues/1352)