### PR TITLE
Pin GitHub Actions to use macOS 13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   build:
     name: Build and test
-    runs-on: macos-latest
+    runs-on: macos-13 # emulator never starts on macOS 14 https://github.com/ReactiveCircus/android-emulator-runner/issues/392#issuecomment-2106167725
 
     steps:
       - name: Checkout (with history)


### PR DESCRIPTION
`macos-latest` uses macOS 14 now which appears to have an issue starting the Android emulator.

See https://github.com/ReactiveCircus/android-emulator-runner/issues/392#issuecomment-2106167725