### PR TITLE
Only run translation workflows on main repo

### DIFF
--- a/.github/workflows/export-po-files.yml
+++ b/.github/workflows/export-po-files.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   copy:
     name: Copy to po-files
+    if: github.repository_owner == 'connectbot'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/translations-import.yml
+++ b/.github/workflows/translations-import.yml
@@ -13,7 +13,9 @@ on:
 
 jobs:
   import:
+    name: Import translations from Launchpad
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'connectbot'
 
     env:
       BAZAAR_URI: lp:~kennyr/connectbot/po-output


### PR DESCRIPTION
This will prevent forks from getting spammed by the job that can only run on the main repository.