### PR TITLE
Fix themed app icon

### DIFF
--- a/app/src/main/res/mipmap-anydpi-v26/icon_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/icon_round.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@drawable/ic_launcher_background"/>
     <foreground android:drawable="@drawable/ic_launcher_foreground"/>
+    <monochrome android:drawable="@drawable/ic_launcher_monochrome"/>
 </adaptive-icon>


### PR DESCRIPTION
Previously, the monochrome version of the icon wasn't referenced correctly from within `icon_round.xml` leading to the themed icon not working correctly in some launchers.