### PR TITLE
Add startForeground service type

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -33,7 +33,7 @@ androidGitVersion {
 
 android {
 	namespace "org.connectbot"
-	compileSdk 33
+	compileSdk 34
 
 	defaultConfig {
 		applicationId "org.connectbot"
@@ -41,7 +41,7 @@ android {
 		versionCode androidGitVersion.code()
 
 		minSdkVersion 14
-		targetSdkVersion 33
+		targetSdkVersion 34
 
 		vectorDrawables.useSupportLibrary = true
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,6 +27,7 @@
 	<uses-permission android:name="android.permission.WAKE_LOCK" />
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 	<uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+	<uses-permission android:name="android.permission.FOREGROUND_SERVICE_REMOTE_MESSAGING" />
 
 	<uses-feature android:name="android.hardware.touchscreen" android:required="false"/>
 
@@ -167,7 +168,8 @@
 		<service
 			android:name="org.connectbot.service.TerminalManager"
 			android:configChanges="keyboardHidden|orientation"
-			android:description="@string/service_desc"/>
+			android:description="@string/service_desc"
+			android:foregroundServiceType="remoteMessaging"/>
 
 		<activity
 			android:name=".ConsoleActivity"

--- a/app/src/main/java/org/connectbot/util/PreferenceConstants.java
+++ b/app/src/main/java/org/connectbot/util/PreferenceConstants.java
@@ -17,8 +17,6 @@
 
 package org.connectbot.util;
 
-import android.os.Build;
-
 /**
  * @author Kenny Root
  *

--- a/app/src/main/java/org/connectbot/util/PreferenceConstants.java
+++ b/app/src/main/java/org/connectbot/util/PreferenceConstants.java
@@ -27,9 +27,6 @@ public final class PreferenceConstants {
 	private PreferenceConstants() {
 	}
 
-	public static final boolean PRE_ECLAIR = Build.VERSION.SDK_INT < 5;
-	public static final boolean PRE_FROYO = Build.VERSION.SDK_INT < 8;
-
 	public static final String MEMKEYS = "memkeys";
 
 	public static final String SCROLLBACK = "scrollback";


### PR DESCRIPTION
Remote messaging seems to be close to what we are doing with long-lived TCP connections sending messages to the remote server and receiving them back.

Make sure that the initial foreground notification is silent when we first start up since the default seems to have changed.