### PR TITLE
Add Android-side text entry feature

### DIFF
--- a/app/src/main/res/layout/dia_text_entry.xml
+++ b/app/src/main/res/layout/dia_text_entry.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <TextView
+        android:id="@+id/text_entry_instructions"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/text_entry_instructions"
+        android:textAppearance="?android:attr/textAppearanceMedium"
+        android:layout_marginBottom="8dp" />
+
+    <EditText
+        android:id="@+id/text_entry_field"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:inputType="textMultiLine"
+        android:minLines="3"
+        android:gravity="top|start"
+        android:scrollbars="vertical"
+        android:hint="@string/text_entry_hint" />
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -676,4 +676,10 @@
 	<string name="notification_requirement_explanation">Notification permission is required to display running sessions in the background</string>
 	<string name="continue_anyway">Continue without</string>
 	<string name="allow">Allow</string>
+
+	<!-- Text entry feature strings -->
+	<string name="text_entry_instructions">Enter text to send to the terminal</string>
+	<string name="text_entry_hint">Type text here</string>
+	<string name="console_menu_text_entry">Text Entry</string>
+	<string name="button_send">Send</string>
 </resources>


### PR DESCRIPTION
Got typos?

During most of my phone use I have long since stopped caring about typos, but over SSH I find that my typo rate is a lot worse and the worse the typo then the more the typo matters.

If you often make elaborate typos with ConnectBot and the Android virtual keyboard, then you might want to try this "text entry" feature. It's a simple enough idea: where you would normally type into the virtual keyboard tied to an SSH session, instead type into an Android native text entry field element. Here you can use the virtual keyboard as you normally would including any glide typing or dictation or other features. When you're done, you can submit your input all at once through the active SSH session.

An alternative to merging this pull request or using this feature is to instead simply open another Android app and type your text input there. Once you are done, copy your text and then paste it into an active ConnectBot session. For me this tends to be faster than typing directly into a ConnectBot session. It also allows long-form input, speech-to-text dictation, and other modern niceties.