### PR TITLE
Add WiFi hotspot port forwarding with bind address selection

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,6 +21,7 @@
 	<uses-sdk />
 
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+	<uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
 	<uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 	<uses-permission android:name="android.permission.INTERNET" />
 	<uses-permission android:name="android.permission.VIBRATE" />

--- a/app/src/main/java/org/connectbot/service/AccessPointReceiver.java
+++ b/app/src/main/java/org/connectbot/service/AccessPointReceiver.java
@@ -1,0 +1,86 @@
+/*
+ * ConnectBot: simple, powerful, open-source SSH client for Android
+ * Copyright 2007 Kenny Root, Jeffrey Sharkey
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.connectbot.service;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.util.Log;
+
+/**
+ * BroadcastReceiver to monitor WiFi hotspot state changes for faster response times.
+ * This provides immediate notification when the hotspot state changes, complementing
+ * the polling timer fallback for devices that don't reliably send these broadcasts.
+ *
+ * @author ConnectBot Team
+ */
+public class AccessPointReceiver extends BroadcastReceiver {
+	private static final String TAG = "CB.AccessPointReceiver";
+
+	// WiFi AP state change action (may not be reliable on all devices)
+	private static final String WIFI_AP_STATE_CHANGED_ACTION = "android.net.wifi.WIFI_AP_STATE_CHANGED";
+
+	final private TerminalManager mTerminalManager;
+
+	public AccessPointReceiver(TerminalManager manager) {
+		mTerminalManager = manager;
+
+		// Register for WiFi AP state changes
+		// Note: This action is not officially part of the Android API and may not work on all devices
+		// That's why we keep the polling timer as a reliable fallback
+		final IntentFilter filter = new IntentFilter();
+		filter.addAction(WIFI_AP_STATE_CHANGED_ACTION);
+		
+		try {
+			manager.registerReceiver(this, filter);
+			Log.d(TAG, "AccessPointReceiver registered for WIFI_AP_STATE_CHANGED");
+		} catch (Exception e) {
+			// Some devices might not support this broadcast
+			Log.w(TAG, "Failed to register for WIFI_AP_STATE_CHANGED: " + e.getMessage());
+		}
+	}
+
+	@Override
+	public void onReceive(Context context, Intent intent) {
+		final String action = intent.getAction();
+
+		if (!WIFI_AP_STATE_CHANGED_ACTION.equals(action)) {
+			Log.w(TAG, "onReceive() called with unexpected action: " + action);
+			return;
+		}
+
+		Log.d(TAG, "WiFi AP state change detected via broadcast - triggering immediate check");
+		
+		// Trigger immediate AP state check for faster response
+		// The existing checkAccessPointStateChange() method handles all the logic
+		mTerminalManager.checkAccessPointStateChange();
+	}
+
+	/**
+	 * Cleanup and unregister the receiver
+	 */
+	public void cleanup() {
+		try {
+			mTerminalManager.unregisterReceiver(this);
+			Log.d(TAG, "AccessPointReceiver unregistered");
+		} catch (Exception e) {
+			// Receiver might not have been registered successfully
+			Log.w(TAG, "Failed to unregister AccessPointReceiver: " + e.getMessage());
+		}
+	}
+}

--- a/app/src/main/java/org/connectbot/service/ConnectionNotifier.java
+++ b/app/src/main/java/org/connectbot/service/ConnectionNotifier.java
@@ -126,6 +126,10 @@ public class ConnectionNotifier {
 	}
 
 	private Notification newRunningNotification(Context context) {
+		return newRunningNotification(context, null, false);
+	}
+	
+	private Notification newRunningNotification(Context context, String apIP, boolean hasApForwards) {
 		NotificationCompat.Builder builder = newNotificationBuilder(context, NOTIFICATION_CHANNEL);
 
 		Resources res = context.getResources();
@@ -142,12 +146,26 @@ public class ConnectionNotifier {
 				disconnectIntent,
 				pendingIntentFlags);
 
+		String contentText = res.getString(R.string.app_is_running);
+		
+		// Add AP forwarding information if relevant
+		if (hasApForwards) {
+			if (apIP != null) {
+				contentText = res.getString(R.string.app_is_running) + "\n" + 
+					res.getString(R.string.notification_access_point_text, apIP);
+			} else {
+				contentText = res.getString(R.string.app_is_running) + "\n" + 
+					res.getString(R.string.notification_ap_disabled_text);
+			}
+		}
+
 		builder.setOngoing(true)
 				.setWhen(0)
 				.setSilent(true)
 				.setContentIntent(pendingIntent)
 				.setContentTitle(res.getString(R.string.app_name))
-				.setContentText(res.getString(R.string.app_is_running))
+				.setContentText(contentText)
+				.setStyle(new NotificationCompat.BigTextStyle().bigText(contentText))
 				.addAction(
 						android.R.drawable.ic_menu_close_clear_cancel,
 						res.getString(R.string.list_host_disconnect),
@@ -161,17 +179,26 @@ public class ConnectionNotifier {
 	}
 
 	void showRunningNotification(Service context) {
+		showRunningNotification(context, null, false);
+	}
+	
+	void showRunningNotification(Service context, String apIP, boolean hasApForwards) {
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-			showRunningNotificationWithType(context);
+			showRunningNotificationWithType(context, apIP, hasApForwards);
 			return;
 		}
 
-		context.startForeground(ONLINE_NOTIFICATION, newRunningNotification(context));
+		context.startForeground(ONLINE_NOTIFICATION, newRunningNotification(context, apIP, hasApForwards));
 	}
 
 	@RequiresApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
 	void showRunningNotificationWithType(Service context) {
-		context.startForeground(ConnectionNotifier.ONLINE_NOTIFICATION, newRunningNotification(context),
+		showRunningNotificationWithType(context, null, false);
+	}
+	
+	@RequiresApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+	void showRunningNotificationWithType(Service context, String apIP, boolean hasApForwards) {
+		context.startForeground(ConnectionNotifier.ONLINE_NOTIFICATION, newRunningNotification(context, apIP, hasApForwards),
 				ServiceInfo.FOREGROUND_SERVICE_TYPE_REMOTE_MESSAGING);
 	}
 

--- a/app/src/main/java/org/connectbot/service/TerminalBridge.java
+++ b/app/src/main/java/org/connectbot/service/TerminalBridge.java
@@ -954,7 +954,15 @@ public class TerminalBridge implements VDUDisplay {
 			return false;
 		}
 
-		return transport.enablePortForward(portForward);
+		boolean result = transport.enablePortForward(portForward);
+		
+		// Notify listeners when port forward state changes so UI can update
+		// Only notify if the state actually changed
+		if (manager != null && result) {
+			manager.notifyHostStatusChanged();
+		}
+		
+		return result;
 	}
 
 	/**
@@ -969,7 +977,15 @@ public class TerminalBridge implements VDUDisplay {
 			return false;
 		}
 
-		return transport.disablePortForward(portForward);
+		boolean result = transport.disablePortForward(portForward);
+		
+		// Notify listeners when port forward state changes so UI can update
+		// Only notify if the state actually changed
+		if (manager != null && result) {
+			manager.notifyHostStatusChanged();
+		}
+		
+		return result;
 	}
 
 	/**

--- a/app/src/main/java/org/connectbot/service/TerminalManager.java
+++ b/app/src/main/java/org/connectbot/service/TerminalManager.java
@@ -31,11 +31,13 @@ import java.util.TimerTask;
 
 import org.connectbot.R;
 import org.connectbot.bean.HostBean;
+import org.connectbot.bean.PortForwardBean;
 import org.connectbot.bean.PubkeyBean;
 import org.connectbot.data.ColorStorage;
 import org.connectbot.data.HostStorage;
 import org.connectbot.transport.TransportFactory;
 import org.connectbot.util.HostDatabase;
+import org.connectbot.util.NetworkUtils;
 import org.connectbot.util.PreferenceConstants;
 import org.connectbot.util.ProviderLoader;
 import org.connectbot.util.ProviderLoaderListener;
@@ -94,17 +96,22 @@ public class TerminalManager extends Service implements BridgeDisconnectedListen
 	final private IBinder binder = new TerminalBinder();
 
 	private ConnectivityReceiver connectivityManager;
+	private AccessPointReceiver accessPointReceiver;
 
 	private MediaPlayer mediaPlayer;
 
 	private Timer pubkeyTimer;
 
 	private Timer idleTimer;
+	
+	private Timer apStateTimer;
+	private boolean apMonitoringActive = false;
 	private final long IDLE_TIMEOUT = 300000; // 5 minutes
 
 	private Vibrator vibrator;
 	private volatile boolean wantKeyVibration;
 	public static final long VIBRATE_DURATION = 30;
+
 
 	private boolean wantBellVibration;
 
@@ -116,6 +123,43 @@ public class TerminalManager extends Service implements BridgeDisconnectedListen
 
 	public boolean hardKeyboardHidden;
 
+	/**
+	 * Create a thread-safe copy of the bridges list for iteration.
+	 * This helper prevents ConcurrentModificationException when iterating
+	 * bridges from background threads while the list may be modified.
+	 *
+	 * @return array of bridges (empty array if no bridges, never null)
+	 */
+	private TerminalBridge[] getBridgesCopy() {
+		synchronized (bridges) {
+			return bridges.toArray(new TerminalBridge[bridges.size()]);
+		}
+	}
+
+	/**
+	 * Thread-safe check if there are any active bridges.
+	 * This is more efficient than getBridgesCopy() when only checking existence.
+	 *
+	 * @return true if there are active bridges
+	 */
+	private boolean hasBridges() {
+		synchronized (bridges) {
+			return !bridges.isEmpty();
+		}
+	}
+
+	/**
+	 * Get the number of active bridges in a thread-safe manner.
+	 * Primarily used for logging and debugging.
+	 *
+	 * @return number of active bridges
+	 */
+	private int getBridgeCount() {
+		synchronized (bridges) {
+			return bridges.size();
+		}
+	}
+
 	@Override
 	public void onCreate() {
 		Log.i(TAG, "Starting service");
@@ -126,6 +170,7 @@ public class TerminalManager extends Service implements BridgeDisconnectedListen
 		res = getResources();
 
 		pubkeyTimer = new Timer("pubkeyTimer", true);
+		apStateTimer = new Timer("apStateTimer", true);
 
 		hostdb = HostDatabase.get(this);
 		colordb = HostDatabase.get(this);
@@ -150,12 +195,15 @@ public class TerminalManager extends Service implements BridgeDisconnectedListen
 		wantBellVibration = prefs.getBoolean(PreferenceConstants.BELL_VIBRATE, true);
 		enableMediaPlayer();
 
+		updateAccessPointMonitoring();
+
 		hardKeyboardHidden = (res.getConfiguration().hardKeyboardHidden ==
 			Configuration.HARDKEYBOARDHIDDEN_YES);
 
 		final boolean lockingWifi = prefs.getBoolean(PreferenceConstants.WIFI_LOCK, true);
 
 		connectivityManager = new ConnectivityReceiver(this, lockingWifi);
+		accessPointReceiver = new AccessPointReceiver(this);
 
 		ProviderLoader.load(this, this);
 	}
@@ -178,9 +226,14 @@ public class TerminalManager extends Service implements BridgeDisconnectedListen
 				idleTimer.cancel();
 			if (pubkeyTimer != null)
 				pubkeyTimer.cancel();
+			if (apStateTimer != null) {
+				apStateTimer.cancel();
+				apMonitoringActive = false;
+			}
 		}
 
 		connectivityManager.cleanup();
+		accessPointReceiver.cleanup();
 
 		ConnectionNotifier.getInstance().hideRunningNotification(this);
 
@@ -191,21 +244,11 @@ public class TerminalManager extends Service implements BridgeDisconnectedListen
 	 * Disconnect all currently connected bridges.
 	 */
 	public void disconnectAll(final boolean immediate, final boolean excludeLocal) {
-		TerminalBridge[] tmpBridges = null;
-
-		synchronized (bridges) {
-			if (bridges.size() > 0) {
-				tmpBridges = bridges.toArray(new TerminalBridge[bridges.size()]);
-			}
-		}
-
-		if (tmpBridges != null) {
-			// disconnect and dispose of any existing bridges
-			for (TerminalBridge tmpBridge : tmpBridges) {
-				if (excludeLocal && !tmpBridge.isUsingNetwork())
-					continue;
-				tmpBridge.dispatchDisconnect(immediate);
-			}
+		// disconnect and dispose of any existing bridges
+		for (TerminalBridge tmpBridge : getBridgesCopy()) {
+			if (excludeLocal && !tmpBridge.isUsingNetwork())
+				continue;
+			tmpBridge.dispatchDisconnect(immediate);
 		}
 	}
 
@@ -238,8 +281,10 @@ public class TerminalManager extends Service implements BridgeDisconnectedListen
 		}
 
 		if (prefs.getBoolean(PreferenceConstants.CONNECTION_PERSIST, true)) {
-			ConnectionNotifier.getInstance().showRunningNotification(this);
+			updateRunningNotificationWithApInfo();
 		}
+		
+		updateAccessPointMonitoring();
 
 		// also update database with new connected time
 		touchHost(host);
@@ -352,7 +397,12 @@ public class TerminalManager extends Service implements BridgeDisconnectedListen
 
 		if (shouldHideRunningNotification) {
 			ConnectionNotifier.getInstance().hideRunningNotification(this);
+		} else {
+			// Update notification in case this bridge had AP forwards
+			updateRunningNotificationWithApInfo();
 		}
+		
+		updateAccessPointMonitoring();
 	}
 
 	public boolean isKeyLoaded(String nickname) {
@@ -447,7 +497,7 @@ public class TerminalManager extends Service implements BridgeDisconnectedListen
 	}
 
 	protected void stopNow() {
-		if (bridges.size() == 0) {
+		if (!hasBridges()) {
 			stopSelf();
 		}
 	}
@@ -481,7 +531,7 @@ public class TerminalManager extends Service implements BridgeDisconnectedListen
 
 	@Override
 	public IBinder onBind(Intent intent) {
-		Log.i(TAG, "Someone bound to TerminalManager with " + bridges.size() + " bridges active");
+		Log.i(TAG, "Someone bound to TerminalManager with " + getBridgeCount() + " bridges active");
 		keepServiceAlive();
 		setResizeAllowed(true);
 		return binder;
@@ -507,23 +557,25 @@ public class TerminalManager extends Service implements BridgeDisconnectedListen
 	@Override
 	public void onRebind(Intent intent) {
 		super.onRebind(intent);
-		Log.i(TAG, "Someone rebound to TerminalManager with " + bridges.size() + " bridges active");
+		Log.i(TAG, "Someone rebound to TerminalManager with " + getBridgeCount() + " bridges active");
 		keepServiceAlive();
 		setResizeAllowed(true);
 	}
 
 	@Override
 	public boolean onUnbind(Intent intent) {
-		Log.i(TAG, "Someone unbound from TerminalManager with " + bridges.size() + " bridges active");
+		Log.i(TAG, "Someone unbound from TerminalManager with " + getBridgeCount() + " bridges active");
 
 		setResizeAllowed(true);
 
-		if (bridges.isEmpty()) {
+		// Get snapshot once to avoid TOCTOU race between hasBridges() and getBridgesCopy()
+		TerminalBridge[] bridgesCopy = getBridgesCopy();
+		if (bridgesCopy.length == 0) {
 			stopWithDelay();
 		} else {
 			// tell each bridge to forget about their previous prompt handler
-			for (TerminalBridge bridge : bridges) {
-				bridge.promptHelper.setListener(null);
+			for (TerminalBridge bridge : bridgesCopy) {
+				bridge.promptHelper.clearListener();
 			}
 		}
 
@@ -733,9 +785,142 @@ public class TerminalManager extends Service implements BridgeDisconnectedListen
 		hostStatusChangedListeners.remove(listener);
 	}
 
-	private void notifyHostStatusChanged() {
+	public void notifyHostStatusChanged() {
 		for (OnHostStatusChangedListener listener : hostStatusChangedListeners) {
 			listener.onHostStatusChanged();
+		}
+	}
+	
+	/**
+	 * Update access point notification state based on current port forwards
+	 * Called when port forwards are enabled/disabled
+	 */
+	public void updateAccessPointNotification() {
+		updateRunningNotificationWithApInfo();
+		updateAccessPointMonitoring();
+	}
+	
+	/**
+	 * Check for AP state changes and update notification if needed
+	 * Should be called periodically to keep notification in sync with AP state
+	 */
+	public void checkAccessPointStateChange() {
+		if (NetworkUtils.hasAccessPointStateChanged(this)) {
+			Log.d(TAG, "AP state changed, updating notification");
+			
+			// Check if AP became available - if so, retry failed AP port forwards
+			String currentApIP = NetworkUtils.getAccessPointIP(this);
+			if (currentApIP != null) {
+				Log.d(TAG, "AP is now available, retrying failed AP port forwards");
+				retryFailedAccessPointForwards();
+			}
+			
+			updateRunningNotificationWithApInfo();
+			
+			// Notify host status listeners so UI can update (like port forwarding display in host list)
+			notifyHostStatusChanged();
+		}
+	}
+	
+	/**
+	 * Update access point monitoring state based on current needs
+	 * Starts monitoring if there are active connections with AP port forwards
+	 * Stops monitoring if there are no connections or no AP forwards configured
+	 *
+	 * Note: Android does not provide reliable broadcast intents for WiFi hotspot state changes.
+	 * The WIFI_AP_STATE_CHANGED intent is not documented in the public API and may not work
+	 * consistently across all devices and Android versions. Therefore, we use periodic polling
+	 * to detect AP state changes for reliable cross-device compatibility.
+	 */
+	private void updateAccessPointMonitoring() {
+		boolean shouldMonitor = hasBridges() && hasActiveAccessPointForwards();
+
+		if (shouldMonitor && !apMonitoringActive) {
+			// Start monitoring - hybrid approach: broadcast receiver for fast response + timer for reliability
+			Log.d(TAG, "Starting AP state monitoring (hybrid: broadcast + 10s polling)");
+			apStateTimer.schedule(new ApStateMonitorTask(), 0, 10000);  // 10s polling
+			apMonitoringActive = true;
+		} else if (!shouldMonitor && apMonitoringActive) {
+			// Stop monitoring
+			Log.d(TAG, "Stopping AP state monitoring");
+			apStateTimer.cancel();
+			apStateTimer = new Timer("apStateTimer", true);
+			apMonitoringActive = false;
+		}
+	}
+	
+	/**
+	 * Timer task to monitor access point state changes every 10 seconds.
+	 * This provides a reliable fallback for AP state monitoring that works on all devices.
+	 * Combined with AccessPointReceiver for immediate response on devices that support broadcasts.
+	 * Only runs when monitoring is active (connections exist with AP port forwards).
+	 */
+	private class ApStateMonitorTask extends TimerTask {
+		@Override
+		public void run() {
+			Log.d(TAG, "ApStateMonitorTask running - checking for AP state changes");
+			checkAccessPointStateChange();
+		}
+	}
+	
+	/**
+	 * Update the running notification to include AP information when relevant
+	 */
+	private void updateRunningNotificationWithApInfo() {
+		// Only update if we have active connections (running notification is showing)
+		if (!hasBridges()) {
+			return;
+		}
+
+		boolean hasActiveForwards = hasActiveAccessPointForwards();
+		String apIP = null;
+
+		if (hasActiveForwards) {
+			apIP = NetworkUtils.getAccessPointIP(this);
+		}
+
+		Log.d(TAG, "Updating running notification: hasApForwards=" + hasActiveForwards + ", apIP=" + apIP);
+		ConnectionNotifier.getInstance().showRunningNotification(this, apIP, hasActiveForwards);
+	}
+	
+	/**
+	 * Check if there are any configured access point port forwards
+	 * @return true if any access point forwards are configured (enabled or failed to enable)
+	 */
+	private boolean hasActiveAccessPointForwards() {
+		// Check all active terminal bridges for access point forwards
+		for (TerminalBridge bridge : getBridgesCopy()) {
+			if (bridge != null) {
+				List<PortForwardBean> forwards = bridge.getPortForwards();
+				for (PortForwardBean forward : forwards) {
+					// Count both enabled forwards and those configured for AP (even if failed to bind)
+					if (NetworkUtils.BIND_ACCESS_POINT.equals(forward.getBindAddress())) {
+						return true; // Found at least one
+					}
+				}
+			}
+		}
+
+		return false;
+	}
+	
+	/**
+	 * Retry failed access point port forwards when AP becomes available
+	 */
+	private void retryFailedAccessPointForwards() {
+		// Check all active terminal bridges for failed AP forwards
+		for (TerminalBridge bridge : getBridgesCopy()) {
+			if (bridge != null) {
+				List<PortForwardBean> forwards = bridge.getPortForwards();
+				for (PortForwardBean forward : forwards) {
+					// Look for AP forwards that are not enabled (likely failed due to no AP)
+					if (NetworkUtils.BIND_ACCESS_POINT.equals(forward.getBindAddress()) && !forward.isEnabled()) {
+						Log.d(TAG, "Retrying failed AP port forward: " + forward.getNickname());
+						// Ask the bridge to retry enabling this forward
+						bridge.enablePortForward(forward);
+					}
+				}
+			}
 		}
 	}
 }

--- a/app/src/main/java/org/connectbot/util/HostDatabase.java
+++ b/app/src/main/java/org/connectbot/util/HostDatabase.java
@@ -52,7 +52,7 @@ public class HostDatabase extends RobustSQLiteOpenHelper implements HostStorage,
 	public final static String TAG = "CB.HostDatabase";
 
 	public final static String DB_NAME = "hosts";
-	public final static int DB_VERSION = 26;
+	public final static int DB_VERSION = 27;
 
 	public final static String TABLE_HOSTS = "hosts";
 	public final static String FIELD_HOST_NICKNAME = "nickname";
@@ -86,6 +86,7 @@ public class HostDatabase extends RobustSQLiteOpenHelper implements HostStorage,
 	public final static String FIELD_PORTFORWARD_SOURCEPORT = "sourceport";
 	public final static String FIELD_PORTFORWARD_DESTADDR = "destaddr";
 	public final static String FIELD_PORTFORWARD_DESTPORT = "destport";
+	public final static String FIELD_PORTFORWARD_BINDADDR = "bindaddr";
 
 	public final static String TABLE_COLORS = "colors";
 	public final static String FIELD_COLOR_SCHEME = "scheme";
@@ -244,6 +245,7 @@ public class HostDatabase extends RobustSQLiteOpenHelper implements HostStorage,
 				+ FIELD_PORTFORWARD_SOURCEPORT + " INTEGER NOT NULL DEFAULT 8080, "
 				+ FIELD_PORTFORWARD_DESTADDR + " TEXT, "
 				+ FIELD_PORTFORWARD_DESTPORT + " INTEGER, "
+				+ FIELD_PORTFORWARD_BINDADDR + " TEXT DEFAULT 'localhost', "
 				+ "FOREIGN KEY (" + FIELD_PORTFORWARD_HOSTID + ") REFERENCES " + TABLE_HOSTS + "(_id) ON DELETE CASCADE)");
 
 		db.execSQL("CREATE INDEX " + TABLE_PORTFORWARDS + FIELD_PORTFORWARD_HOSTID + "index ON "
@@ -310,7 +312,8 @@ public class HostDatabase extends RobustSQLiteOpenHelper implements HostStorage,
 					+ FIELD_PORTFORWARD_TYPE + " TEXT NOT NULL DEFAULT '" + PORTFORWARD_LOCAL + "', "
 					+ FIELD_PORTFORWARD_SOURCEPORT + " INTEGER NOT NULL DEFAULT 8080, "
 					+ FIELD_PORTFORWARD_DESTADDR + " TEXT, "
-					+ FIELD_PORTFORWARD_DESTPORT + " INTEGER)");
+					+ FIELD_PORTFORWARD_DESTPORT + " INTEGER, "
+					+ FIELD_PORTFORWARD_BINDADDR + " TEXT DEFAULT 'localhost')");
 			// fall through
 		case 12:
 			db.execSQL("ALTER TABLE " + TABLE_HOSTS
@@ -471,6 +474,11 @@ public class HostDatabase extends RobustSQLiteOpenHelper implements HostStorage,
 				// Re-enable foreign keys (will be automatically enabled on next connection via onConfigure)
 				db.execSQL("PRAGMA foreign_keys = ON");
 			}
+			// fall through
+		case 26:
+			// Add bind address column to port forwards table
+			db.execSQL("ALTER TABLE " + TABLE_PORTFORWARDS
+					+ " ADD COLUMN " + FIELD_PORTFORWARD_BINDADDR + " TEXT DEFAULT 'localhost'");
 		}
 	}
 
@@ -839,7 +847,7 @@ public class HostDatabase extends RobustSQLiteOpenHelper implements HostStorage,
 
 		Cursor c = mDb.query(TABLE_PORTFORWARDS, new String[] {
 						"_id", FIELD_PORTFORWARD_NICKNAME, FIELD_PORTFORWARD_TYPE, FIELD_PORTFORWARD_SOURCEPORT,
-						FIELD_PORTFORWARD_DESTADDR, FIELD_PORTFORWARD_DESTPORT},
+						FIELD_PORTFORWARD_DESTADDR, FIELD_PORTFORWARD_DESTPORT, FIELD_PORTFORWARD_BINDADDR},
 				FIELD_PORTFORWARD_HOSTID + " = ?", new String[] {String.valueOf(host.getId())},
 				null, null, null);
 
@@ -851,7 +859,8 @@ public class HostDatabase extends RobustSQLiteOpenHelper implements HostStorage,
 					c.getString(2),
 					c.getInt(3),
 					c.getString(4),
-					c.getInt(5));
+					c.getInt(5),
+					c.getString(6));
 			portForwards.add(pfb);
 		}
 

--- a/app/src/main/java/org/connectbot/util/NetworkUtils.java
+++ b/app/src/main/java/org/connectbot/util/NetworkUtils.java
@@ -1,0 +1,349 @@
+/*
+ * ConnectBot: simple, powerful, open-source SSH client for Android
+ * Copyright 2007 Kenny Root, Jeffrey Sharkey
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.connectbot.util;
+
+import android.content.Context;
+import android.net.ConnectivityManager;
+import android.net.Network;
+import android.net.NetworkCapabilities;
+import android.net.NetworkInfo;
+import android.util.Log;
+
+import java.net.InetAddress;
+import java.net.InterfaceAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Utility class for network-related operations, specifically for detecting
+ * WiFi hotspot IP addresses for port forwarding bind address selection.
+ *
+ * @author ConnectBot Team
+ */
+public class NetworkUtils {
+	public final static String TAG = "CB.NetworkUtils";
+
+	// Bind address constants
+	public static final String BIND_LOCALHOST = "localhost";
+	public static final String BIND_ALL_INTERFACES = "0.0.0.0";
+	public static final String BIND_ACCESS_POINT = "access_point";
+
+	// Common AP interface name patterns
+	private static final String[] AP_INTERFACE_PATTERNS = {
+		"ap", "wlan1", "p2p", "hotspot", "softap", "wifi_ap"
+	};
+
+	// Cellular interface name patterns for security filtering
+	private static final String[] CELLULAR_INTERFACE_PATTERNS = {
+		"rmnet", "ccmni", "pdp", "ppp", "cellular", "mobile", "radio", "baseband"
+	};
+
+	/**
+	 * Interface for listening to network changes
+	 */
+	public interface NetworkChangeListener {
+		void onAccessPointIPChanged(String newIP);
+		void onAccessPointDisconnected();
+	}
+
+	private static String lastKnownApIP = null;
+
+	/**
+	 * Get the current WiFi access point IP address
+	 * Read-only method - does not update internal state to avoid masking changes
+	 * from the background monitor task
+	 * @param context Android context
+	 * @return IP address as string, or null if not available
+	 */
+	public static String getAccessPointIP(Context context) {
+		// Only use explicitly identified AP interface IPs for security
+		// Do NOT update lastKnownApIP here - that's only for hasAccessPointStateChanged()
+		String apInterfaceIP = getHotspotInterfaceIP();
+		if (apInterfaceIP != null) {
+			Log.d(TAG, "Found AP interface IP: " + apInterfaceIP);
+			return apInterfaceIP;
+		}
+
+		Log.d(TAG, "No valid AP interface found");
+		return null;
+	}
+
+	/**
+	 * Check if the access point state has changed since last check
+	 * @param context Android context
+	 * @return true if AP state changed
+	 */
+	public static boolean hasAccessPointStateChanged(Context context) {
+		String currentApIP = getHotspotInterfaceIP(); // Don't update lastKnownApIP yet
+		boolean changed = !java.util.Objects.equals(lastKnownApIP, currentApIP);
+		if (changed) {
+			Log.d(TAG, "AP state changed: " + lastKnownApIP + " -> " + currentApIP);
+			lastKnownApIP = currentApIP; // Update only when we detect a change
+		}
+		return changed;
+	}
+
+	/**
+	 * Get the hotspot interface IP address from provided interfaces (pure logic, testable)
+	 * @param interfaces List of network interfaces to check
+	 * @return IP address string, or null if not found
+	 */
+	static String getHotspotInterfaceIP(List<NetworkInterface> interfaces) {
+		if (interfaces == null) return null;
+
+		for (NetworkInterface intf : interfaces) {
+			try {
+				if (!intf.isUp() || intf.isLoopback() || intf.isVirtual()) {
+					continue;
+				}
+
+				String name = intf.getName().toLowerCase();
+
+				// SECURITY: Block cellular interfaces using device-agnostic detection
+				if (isCellularInterface(intf)) {
+					continue;
+				}
+
+				// Look for common AP interface names
+				boolean isApInterface = false;
+				for (String pattern : AP_INTERFACE_PATTERNS) {
+					if (name.contains(pattern)) {
+						isApInterface = true;
+						break;
+					}
+				}
+				if (isApInterface) {
+
+					List<InterfaceAddress> addrs = intf.getInterfaceAddresses();
+					for (InterfaceAddress addr : addrs) {
+						InetAddress inetAddr = addr.getAddress();
+						if (!inetAddr.isLoopbackAddress() &&
+							!inetAddr.isLinkLocalAddress() &&
+							inetAddr.isSiteLocalAddress()) {
+
+							String ip = inetAddr.getHostAddress();
+							if (ip != null && !ip.contains(":")) { // IPv4 only
+
+								// Verify this looks like an AP IP (typically x.x.x.1)
+								if (isLikelyApIP(ip)) {
+									return ip;
+								}
+							}
+						}
+					}
+				}
+			} catch (Exception e) {
+				// Skip this interface if there's an error checking it
+				continue;
+			}
+		}
+
+		// No fallback - only use explicitly named AP interfaces for security
+		return null;
+	}
+
+	/**
+	 * Get the hotspot interface IP address when phone is acting as WiFi AP
+	 * @return IP address string, or null if not found
+	 */
+	private static String getHotspotInterfaceIP() {
+		try {
+			List<NetworkInterface> interfaces = Collections.list(NetworkInterface.getNetworkInterfaces());
+			String result = getHotspotInterfaceIP(interfaces);
+			if (result != null) {
+				Log.d(TAG, "Found AP interface with IP: " + result);
+			} else {
+				Log.d(TAG, "No hotspot interface IP found");
+			}
+			return result;
+		} catch (SocketException e) {
+			Log.e(TAG, "Error getting hotspot interface IP", e);
+			return null;
+		}
+	}
+
+	/**
+	 * Check if an IP address looks like an access point IP
+	 * @param ip the IP address to check
+	 * @return true if it looks like an AP IP
+	 */
+	private static boolean isLikelyApIP(String ip) {
+		if (ip == null) return false;
+
+		// Accept private IP ranges that could be AP addresses
+		// Since we've already filtered out cellular interfaces by their
+		// network characteristics, we can be permissive with IP ranges
+		return ip.startsWith("192.168.") ||
+			ip.startsWith("10.") ||
+			ip.matches("172\\.(1[6-9]|2[0-9]|3[0-1])\\..*");
+	}
+
+
+	/**
+	 * Check if an interface is a cellular interface
+	 * Uses only interface name patterns for reliable detection
+	 * @param intf the network interface to check
+	 * @return true if this appears to be a cellular interface
+	 */
+	private static boolean isCellularInterface(NetworkInterface intf) {
+		if (intf == null) return false;
+
+		String name = intf.getName().toLowerCase();
+
+		// Only use interface name patterns for detection
+		// This is the most reliable method across all devices
+		for (String pattern : CELLULAR_INTERFACE_PATTERNS) {
+			if (name.contains(pattern)) {
+				Log.d(TAG, "Interface " + name + " identified as cellular by name pattern: " + pattern);
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Check if WiFi is currently connected
+	 * @param context Android context
+	 * @return true if WiFi is connected
+	 */
+	public static boolean isWifiConnected(Context context) {
+		ConnectivityManager cm = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
+		if (cm == null) {
+			return false;
+		}
+
+		try {
+			// API 23+
+			if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M) {
+				Network activeNetwork = cm.getActiveNetwork();
+				if (activeNetwork == null) {
+					return false;
+				}
+				NetworkCapabilities caps = cm.getNetworkCapabilities(activeNetwork);
+				return caps != null && caps.hasTransport(NetworkCapabilities.TRANSPORT_WIFI);
+			} else {
+				// Legacy API
+				NetworkInfo networkInfo = cm.getActiveNetworkInfo();
+				return networkInfo != null &&
+					networkInfo.isConnected() &&
+					networkInfo.getType() == ConnectivityManager.TYPE_WIFI;
+			}
+		} catch (Exception e) {
+			Log.e(TAG, "Error checking WiFi connection", e);
+			return false;
+		}
+	}
+
+	/**
+	 * Check if access point is available for binding
+	 * @param context Android context
+	 * @return true if access point IP is available
+	 */
+	public static boolean isAccessPointAvailable(Context context) {
+		return getAccessPointIP(context) != null;
+	}
+
+	/**
+	 * Get display name for bind address type (pure logic, testable)
+	 * @param bindAddress the bind address string
+	 * @param apIP the current AP IP (null if unavailable)
+	 * @return human readable name
+	 */
+	public static String getBindAddressDisplayName(String bindAddress, String apIP) {
+		if (BIND_ALL_INTERFACES.equals(bindAddress)) {
+			return "all interfaces";
+		} else if (BIND_ACCESS_POINT.equals(bindAddress)) {
+			if (apIP != null) {
+				return "WiFi hotspot (" + apIP + ")";
+			} else {
+				return "WiFi hotspot (unavailable)";
+			}
+		} else {
+			return "localhost";
+		}
+	}
+
+	/**
+	 * Get display name for bind address type
+	 * @param bindAddress the bind address string
+	 * @param context Android context for hotspot IP resolution
+	 * @return human readable name
+	 */
+	public static String getBindAddressDisplayName(String bindAddress, Context context) {
+		String apIP = (context != null) ? getAccessPointIP(context) : null;
+		return getBindAddressDisplayName(bindAddress, apIP);
+	}
+
+	/**
+	 * Get simple bind address display for compact UI (pure logic, testable)
+	 * @param bindAddress the bind address string
+	 * @param apIP the current AP IP (null if unavailable)
+	 * @return simple address display (actual IP or short form)
+	 */
+	public static String getSimpleBindAddressDisplay(String bindAddress, String apIP) {
+		if (BIND_ALL_INTERFACES.equals(bindAddress)) {
+			return BIND_ALL_INTERFACES;
+		} else if (BIND_ACCESS_POINT.equals(bindAddress)) {
+			return apIP != null ? apIP : "AP";
+		} else {
+			return "localhost";
+		}
+	}
+
+	/**
+	 * Get simple bind address display for compact UI (shows actual IPs)
+	 * @param bindAddress the bind address string
+	 * @param context Android context for hotspot IP resolution
+	 * @return simple address display (actual IP or short form)
+	 */
+	public static String getSimpleBindAddressDisplay(String bindAddress, Context context) {
+		String apIP = (context != null) ? getAccessPointIP(context) : null;
+		return getSimpleBindAddressDisplay(bindAddress, apIP);
+	}
+
+	/**
+	 * Resolve bind address string to actual IP address (pure logic, testable)
+	 * @param bindAddress the bind address type
+	 * @param apIP the current AP IP (null if unavailable)
+	 * @return IP address string, or null if access_point is requested but unavailable
+	 */
+	public static String resolveBindAddress(String bindAddress, String apIP) {
+		if (BIND_ALL_INTERFACES.equals(bindAddress)) {
+			return BIND_ALL_INTERFACES;
+		} else if (BIND_ACCESS_POINT.equals(bindAddress)) {
+			// Return null if AP is not available - do not fall back to localhost for security
+			return apIP;
+		} else {
+			return "127.0.0.1";
+		}
+	}
+
+	/**
+	 * Resolve bind address string to actual IP address
+	 * @param bindAddress the bind address type
+	 * @param context Android context
+	 * @return IP address string, or null if access_point is requested but unavailable
+	 */
+	public static String resolveBindAddress(String bindAddress, Context context) {
+		String apIP = (context != null) ? getAccessPointIP(context) : null;
+		return resolveBindAddress(bindAddress, apIP);
+	}
+}

--- a/app/src/main/res/layout/act_hostlist.xml
+++ b/app/src/main/res/layout/act_hostlist.xml
@@ -26,6 +26,7 @@
 	android:orientation="vertical"
 	>
 
+
 	<!-- paddingBottom is calculated with FloatingActionButton's height (56dp) and
 	     margins (16dp): 56dp + (2 x 16dp) = 88dp. -->
 	<androidx.recyclerview.widget.RecyclerView

--- a/app/src/main/res/layout/dia_portforward.xml
+++ b/app/src/main/res/layout/dia_portforward.xml
@@ -108,5 +108,57 @@
 				android:inputType="textEmailAddress"
 				/>
 		</TableRow>
+
+		<TableRow>
+
+			<TextView
+				android:id="@+id/bind_address_label"
+				android:gravity="end|center_vertical"
+				android:paddingEnd="10dip"
+				android:paddingRight="10dip"
+				android:text="@string/prompt_bind_address"
+				android:textAppearance="?android:attr/textAppearanceMedium"/>
+
+			<RadioGroup
+				android:id="@+id/bind_address_group"
+				android:layout_width="fill_parent"
+				android:layout_height="wrap_content"
+				android:layout_weight="1"
+				android:orientation="vertical">
+
+				<RadioButton
+					android:id="@+id/bind_localhost"
+					android:layout_width="wrap_content"
+					android:layout_height="wrap_content"
+					android:text="@string/bind_localhost"
+					android:checked="true" />
+
+				<RadioButton
+					android:id="@+id/bind_all_interfaces"
+					android:layout_width="wrap_content"
+					android:layout_height="wrap_content"
+					android:text="@string/bind_all_interfaces" />
+
+				<RadioButton
+					android:id="@+id/bind_access_point"
+					android:layout_width="wrap_content"
+					android:layout_height="wrap_content"
+					android:text="@string/bind_access_point" />
+
+			</RadioGroup>
+		</TableRow>
+
+		<TableRow android:id="@+id/security_warning_row" android:visibility="gone">
+			<TextView />
+			<TextView
+				android:layout_width="fill_parent"
+				android:layout_height="wrap_content"
+				android:layout_weight="1"
+				android:text="@string/security_warning_network_exposure"
+				android:textAppearance="?android:attr/textAppearanceSmall"
+				android:textColor="#ffcc00"
+				android:padding="5dip" />
+		</TableRow>
+
 	</TableLayout>
 </ScrollView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -153,6 +153,25 @@
 	<string name="prompt_again">"(again)"</string>
 	<!-- Label for the user to select port forward type. -->
 	<string name="prompt_type">"Type:"</string>
+	<!-- Label for the user to select port forward bind address. -->
+	<string name="prompt_bind_address">"Bind to:"</string>
+	<!-- Option to bind port forward to localhost only -->
+	<string name="bind_localhost">"Localhost only"</string>
+	<!-- Option to bind port forward to all network interfaces -->
+	<string name="bind_all_interfaces">"All interfaces (0.0.0.0)"</string>
+	<!-- Option to bind port forward to WiFi hotspot only -->
+	<string name="bind_access_point">"WiFi hotspot only"</string>
+	<!-- General label for WiFi hotspot interface -->
+	<string name="wifi_hotspot">"WiFi hotspot"</string>
+	<!-- Security warning shown when user selects network-exposed binding -->
+	<string name="security_warning_network_exposure">"⚠️ This will expose the forwarded port to other devices on the network"</string>
+	<!-- Notification title when hotspot port forwarding is active -->
+	<string name="notification_access_point_title">"Port forwarding active"</string>
+	<!-- Notification text showing current hotspot IP -->
+	<string name="notification_access_point_text">"Hotspot IP: %s"</string>
+	<!-- Warning notification when AP forwards are configured but AP is disabled -->
+	<string name="notification_ap_disabled_title">"Hotspot required"</string>
+	<string name="notification_ap_disabled_text">"Port forwards configured for WiFi hotspot, but hotspot is disabled"</string>
 	<!-- Hint given below the password input box that lets them know that they are allowed to leave the field blank. -->
 	<string name="prompt_password_can_be_blank">"Note: password can be blank"</string>
 	<!-- Prompt for the size of the private key in bits. -->

--- a/app/src/test/java/org/connectbot/util/NetworkUtilsTest.java
+++ b/app/src/test/java/org/connectbot/util/NetworkUtilsTest.java
@@ -1,0 +1,430 @@
+/*
+ * ConnectBot: simple, powerful, open-source SSH client for Android
+ * Copyright 2007 Kenny Root, Jeffrey Sharkey
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.connectbot.util;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.Test;
+
+import java.net.InetAddress;
+import java.net.InterfaceAddress;
+import java.net.NetworkInterface;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Tests for NetworkUtils functionality, focusing on methods that can be tested
+ * without Android Context dependencies.
+ */
+public class NetworkUtilsTest {
+
+	@Test
+	public void testBindAddressConstants() {
+		assertEquals("localhost", NetworkUtils.BIND_LOCALHOST);
+		assertEquals("0.0.0.0", NetworkUtils.BIND_ALL_INTERFACES);
+		assertEquals("access_point", NetworkUtils.BIND_ACCESS_POINT);
+	}
+
+	@Test
+	public void testGetBindAddressDisplayName() {
+		// Test with null AP IP (unavailable)
+		assertEquals("all interfaces",
+			NetworkUtils.getBindAddressDisplayName("0.0.0.0", (String)null));
+		assertEquals("localhost",
+			NetworkUtils.getBindAddressDisplayName("localhost", (String)null));
+		assertEquals("localhost",
+			NetworkUtils.getBindAddressDisplayName("anything_else", (String)null));
+		assertEquals("WiFi hotspot (unavailable)",
+			NetworkUtils.getBindAddressDisplayName("access_point", (String)null));
+
+		// Test with valid AP IP
+		assertEquals("WiFi hotspot (192.168.1.1)",
+			NetworkUtils.getBindAddressDisplayName("access_point", "192.168.1.1"));
+	}
+
+	@Test
+	public void testGetSimpleBindAddressDisplay() {
+		// Test with null AP IP (unavailable)
+		assertEquals("0.0.0.0",
+			NetworkUtils.getSimpleBindAddressDisplay("0.0.0.0", (String)null));
+		assertEquals("localhost",
+			NetworkUtils.getSimpleBindAddressDisplay("localhost", (String)null));
+		assertEquals("localhost",
+			NetworkUtils.getSimpleBindAddressDisplay("anything_else", (String)null));
+		assertEquals("AP",
+			NetworkUtils.getSimpleBindAddressDisplay("access_point", (String)null));
+
+		// Test with valid AP IP
+		assertEquals("192.168.1.1",
+			NetworkUtils.getSimpleBindAddressDisplay("access_point", "192.168.1.1"));
+	}
+
+	@Test
+	public void testResolveBindAddress() {
+		// Test with null AP IP (unavailable)
+		assertEquals("0.0.0.0",
+			NetworkUtils.resolveBindAddress("0.0.0.0", (String)null));
+		assertEquals("127.0.0.1",
+			NetworkUtils.resolveBindAddress("localhost", (String)null));
+		assertEquals("127.0.0.1",
+			NetworkUtils.resolveBindAddress("anything_else", (String)null));
+		// access_point with null AP IP should return null
+		assertNull(NetworkUtils.resolveBindAddress("access_point", (String)null));
+
+		// Test with valid AP IP
+		assertEquals("192.168.1.1",
+			NetworkUtils.resolveBindAddress("access_point", "192.168.1.1"));
+	}
+
+	@Test
+	public void testBindAddressConstantsEdgeCases() {
+		// Test edge cases with constants using pure logic methods
+		assertEquals("localhost", NetworkUtils.getBindAddressDisplayName(NetworkUtils.BIND_LOCALHOST, (String)null));
+		assertEquals("all interfaces", NetworkUtils.getBindAddressDisplayName(NetworkUtils.BIND_ALL_INTERFACES, (String)null));
+		assertEquals("WiFi hotspot (unavailable)", NetworkUtils.getBindAddressDisplayName(NetworkUtils.BIND_ACCESS_POINT, (String)null));
+
+		// Test that constants are non-null and non-empty
+		assertNotNull(NetworkUtils.BIND_LOCALHOST);
+		assertNotNull(NetworkUtils.BIND_ALL_INTERFACES);
+		assertNotNull(NetworkUtils.BIND_ACCESS_POINT);
+		assertFalse(NetworkUtils.BIND_LOCALHOST.isEmpty());
+		assertFalse(NetworkUtils.BIND_ALL_INTERFACES.isEmpty());
+		assertFalse(NetworkUtils.BIND_ACCESS_POINT.isEmpty());
+	}
+
+	@Test
+	public void testNullInputHandling() {
+		// Test methods handle null inputs gracefully using pure logic methods
+		assertEquals("localhost", NetworkUtils.getBindAddressDisplayName(null, (String)null));
+		assertEquals("localhost", NetworkUtils.getSimpleBindAddressDisplay(null, (String)null));
+		assertEquals("127.0.0.1", NetworkUtils.resolveBindAddress(null, (String)null));
+
+		// Test empty strings
+		assertEquals("localhost", NetworkUtils.getBindAddressDisplayName("", (String)null));
+		assertEquals("localhost", NetworkUtils.getSimpleBindAddressDisplay("", (String)null));
+		assertEquals("127.0.0.1", NetworkUtils.resolveBindAddress("", (String)null));
+	}
+
+	@Test
+	public void testGetHotspotInterfaceIP_NullInput() {
+		// Test null input
+		assertNull(NetworkUtils.getHotspotInterfaceIP(null));
+
+		// Test empty list
+		assertNull(NetworkUtils.getHotspotInterfaceIP(Collections.emptyList()));
+	}
+
+	@Test
+	public void testGetHotspotInterfaceIP_ValidApInterface() throws Exception {
+		// Create mock NetworkInterface for AP
+		NetworkInterface mockIntf = mock(NetworkInterface.class);
+		when(mockIntf.isUp()).thenReturn(true);
+		when(mockIntf.isLoopback()).thenReturn(false);
+		when(mockIntf.isVirtual()).thenReturn(false);
+		when(mockIntf.getName()).thenReturn("ap0");
+
+		// Create mock InetAddress and InterfaceAddress
+		InetAddress mockInetAddr = mock(InetAddress.class);
+		when(mockInetAddr.isLoopbackAddress()).thenReturn(false);
+		when(mockInetAddr.isLinkLocalAddress()).thenReturn(false);
+		when(mockInetAddr.isSiteLocalAddress()).thenReturn(true);
+		when(mockInetAddr.getHostAddress()).thenReturn("192.168.1.1");
+
+		InterfaceAddress mockIfaceAddr = mock(InterfaceAddress.class);
+		when(mockIfaceAddr.getAddress()).thenReturn(mockInetAddr);
+
+		when(mockIntf.getInterfaceAddresses()).thenReturn(Arrays.asList(mockIfaceAddr));
+
+		List<NetworkInterface> interfaces = Arrays.asList(mockIntf);
+		String result = NetworkUtils.getHotspotInterfaceIP(interfaces);
+
+		assertEquals("192.168.1.1", result);
+	}
+
+	@Test
+	public void testGetHotspotInterfaceIP_NoApInterface() throws Exception {
+		// Create mock NetworkInterface for non-AP interface
+		NetworkInterface mockIntf = mock(NetworkInterface.class);
+		when(mockIntf.isUp()).thenReturn(true);
+		when(mockIntf.isLoopback()).thenReturn(false);
+		when(mockIntf.isVirtual()).thenReturn(false);
+		when(mockIntf.getName()).thenReturn("wlan0"); // Not an AP interface
+
+		List<NetworkInterface> interfaces = Arrays.asList(mockIntf);
+		String result = NetworkUtils.getHotspotInterfaceIP(interfaces);
+
+		assertNull(result);
+	}
+
+	@Test
+	public void testGetHotspotInterfaceIP_InterfaceDown() throws Exception {
+		// Create mock NetworkInterface that's down
+		NetworkInterface mockIntf = mock(NetworkInterface.class);
+		when(mockIntf.isUp()).thenReturn(false); // Interface is down
+		when(mockIntf.getName()).thenReturn("ap0");
+
+		List<NetworkInterface> interfaces = Arrays.asList(mockIntf);
+		String result = NetworkUtils.getHotspotInterfaceIP(interfaces);
+
+		assertNull(result);
+	}
+
+	@Test
+	public void testGetHotspotInterfaceIP_IPv6Filtered() throws Exception {
+		// Create mock NetworkInterface for AP with IPv6 address
+		NetworkInterface mockIntf = mock(NetworkInterface.class);
+		when(mockIntf.isUp()).thenReturn(true);
+		when(mockIntf.isLoopback()).thenReturn(false);
+		when(mockIntf.isVirtual()).thenReturn(false);
+		when(mockIntf.getName()).thenReturn("ap0");
+
+		// Create mock InetAddress with IPv6 (contains colon)
+		InetAddress mockInetAddr = mock(InetAddress.class);
+		when(mockInetAddr.isLoopbackAddress()).thenReturn(false);
+		when(mockInetAddr.isLinkLocalAddress()).thenReturn(false);
+		when(mockInetAddr.isSiteLocalAddress()).thenReturn(true);
+		when(mockInetAddr.getHostAddress()).thenReturn("2001:db8::1"); // IPv6
+
+		InterfaceAddress mockIfaceAddr = mock(InterfaceAddress.class);
+		when(mockIfaceAddr.getAddress()).thenReturn(mockInetAddr);
+
+		when(mockIntf.getInterfaceAddresses()).thenReturn(Arrays.asList(mockIfaceAddr));
+
+		List<NetworkInterface> interfaces = Arrays.asList(mockIntf);
+		String result = NetworkUtils.getHotspotInterfaceIP(interfaces);
+
+		assertNull(result); // IPv6 should be filtered out
+	}
+
+	@Test
+	public void testGetHotspotInterfaceIP_PublicIPFiltered() throws Exception {
+		// Create mock NetworkInterface for AP with public IP
+		NetworkInterface mockIntf = mock(NetworkInterface.class);
+		when(mockIntf.isUp()).thenReturn(true);
+		when(mockIntf.isLoopback()).thenReturn(false);
+		when(mockIntf.isVirtual()).thenReturn(false);
+		when(mockIntf.getName()).thenReturn("ap0");
+
+		// Create mock InetAddress with public IP
+		InetAddress mockInetAddr = mock(InetAddress.class);
+		when(mockInetAddr.isLoopbackAddress()).thenReturn(false);
+		when(mockInetAddr.isLinkLocalAddress()).thenReturn(false);
+		when(mockInetAddr.isSiteLocalAddress()).thenReturn(true);
+		when(mockInetAddr.getHostAddress()).thenReturn("8.8.8.8"); // Public IP
+
+		InterfaceAddress mockIfaceAddr = mock(InterfaceAddress.class);
+		when(mockIfaceAddr.getAddress()).thenReturn(mockInetAddr);
+
+		when(mockIntf.getInterfaceAddresses()).thenReturn(Arrays.asList(mockIfaceAddr));
+
+		List<NetworkInterface> interfaces = Arrays.asList(mockIntf);
+		String result = NetworkUtils.getHotspotInterfaceIP(interfaces);
+
+		assertNull(result); // Public IP should be filtered out by isLikelyApIP
+	}
+
+	@Test
+	public void testGetHotspotInterfaceIP_AllApPatterns() throws Exception {
+		// Test all AP interface patterns: "ap", "wlan1", "p2p", "hotspot", "softap", "wifi_ap"
+		String[] apPatterns = {"ap0", "wlan1", "p2p0", "hotspot0", "softap0", "wifi_ap0"};
+
+		for (String interfaceName : apPatterns) {
+			NetworkInterface mockIntf = mock(NetworkInterface.class);
+			when(mockIntf.isUp()).thenReturn(true);
+			when(mockIntf.isLoopback()).thenReturn(false);
+			when(mockIntf.isVirtual()).thenReturn(false);
+			when(mockIntf.getName()).thenReturn(interfaceName);
+
+			InetAddress mockInetAddr = mock(InetAddress.class);
+			when(mockInetAddr.isLoopbackAddress()).thenReturn(false);
+			when(mockInetAddr.isLinkLocalAddress()).thenReturn(false);
+			when(mockInetAddr.isSiteLocalAddress()).thenReturn(true);
+			when(mockInetAddr.getHostAddress()).thenReturn("192.168.1.1");
+
+			InterfaceAddress mockIfaceAddr = mock(InterfaceAddress.class);
+			when(mockIfaceAddr.getAddress()).thenReturn(mockInetAddr);
+			when(mockIntf.getInterfaceAddresses()).thenReturn(Arrays.asList(mockIfaceAddr));
+
+			List<NetworkInterface> interfaces = Arrays.asList(mockIntf);
+			String result = NetworkUtils.getHotspotInterfaceIP(interfaces);
+
+			assertEquals("AP pattern " + interfaceName + " should be detected", "192.168.1.1", result);
+		}
+	}
+
+	@Test
+	public void testGetHotspotInterfaceIP_CellularInterfacesFiltered() throws Exception {
+		// Test that cellular interfaces are filtered out (security feature)
+		String[] cellularNames = {"rmnet0", "ccmni0", "pdp_ip0", "ppp0", "cellular0", "mobile0", "radio0", "baseband0"};
+
+		for (String cellularName : cellularNames) {
+			NetworkInterface mockIntf = mock(NetworkInterface.class);
+			when(mockIntf.isUp()).thenReturn(true);
+			when(mockIntf.isLoopback()).thenReturn(false);
+			when(mockIntf.isVirtual()).thenReturn(false);
+			when(mockIntf.getName()).thenReturn(cellularName);
+
+			// Even if it has AP-like IP, should be filtered out by cellular detection
+			InetAddress mockInetAddr = mock(InetAddress.class);
+			when(mockInetAddr.isLoopbackAddress()).thenReturn(false);
+			when(mockInetAddr.isLinkLocalAddress()).thenReturn(false);
+			when(mockInetAddr.isSiteLocalAddress()).thenReturn(true);
+			when(mockInetAddr.getHostAddress()).thenReturn("192.168.1.1");
+
+			InterfaceAddress mockIfaceAddr = mock(InterfaceAddress.class);
+			when(mockIfaceAddr.getAddress()).thenReturn(mockInetAddr);
+			when(mockIntf.getInterfaceAddresses()).thenReturn(Arrays.asList(mockIfaceAddr));
+
+			List<NetworkInterface> interfaces = Arrays.asList(mockIntf);
+			String result = NetworkUtils.getHotspotInterfaceIP(interfaces);
+
+			assertNull("Cellular interface " + cellularName + " should be filtered out", result);
+		}
+	}
+
+	@Test
+	public void testGetHotspotInterfaceIP_AllPrivateIPRanges() throws Exception {
+		// Test all supported private IP ranges: 192.168.x, 10.x, 172.16-31.x
+		String[] validPrivateIPs = {
+			"192.168.1.1",    // 192.168.x.x range
+			"192.168.0.1",
+			"10.0.0.1",       // 10.x.x.x range
+			"10.255.255.1",
+			"172.16.0.1",     // 172.16-31.x.x range
+			"172.31.255.1"
+		};
+
+		for (String ip : validPrivateIPs) {
+			NetworkInterface mockIntf = mock(NetworkInterface.class);
+			when(mockIntf.isUp()).thenReturn(true);
+			when(mockIntf.isLoopback()).thenReturn(false);
+			when(mockIntf.isVirtual()).thenReturn(false);
+			when(mockIntf.getName()).thenReturn("ap0");
+
+			InetAddress mockInetAddr = mock(InetAddress.class);
+			when(mockInetAddr.isLoopbackAddress()).thenReturn(false);
+			when(mockInetAddr.isLinkLocalAddress()).thenReturn(false);
+			when(mockInetAddr.isSiteLocalAddress()).thenReturn(true);
+			when(mockInetAddr.getHostAddress()).thenReturn(ip);
+
+			InterfaceAddress mockIfaceAddr = mock(InterfaceAddress.class);
+			when(mockIfaceAddr.getAddress()).thenReturn(mockInetAddr);
+			when(mockIntf.getInterfaceAddresses()).thenReturn(Arrays.asList(mockIfaceAddr));
+
+			List<NetworkInterface> interfaces = Arrays.asList(mockIntf);
+			String result = NetworkUtils.getHotspotInterfaceIP(interfaces);
+
+			assertEquals("Private IP " + ip + " should be accepted", ip, result);
+		}
+	}
+
+	@Test
+	public void testGetHotspotInterfaceIP_InvalidPrivateIPRanges() throws Exception {
+		// Test IPs that should be rejected by isLikelyApIP
+		String[] invalidPrivateIPs = {
+			"172.15.255.255", // Just below 172.16-31 range
+			"172.32.0.0",     // Just above 172.16-31 range
+			"172.0.0.1",      // Way below range
+			"127.0.0.1",      // Loopback
+			"169.254.1.1",    // Link-local
+			"8.8.8.8"         // Public IP
+		};
+
+		for (String ip : invalidPrivateIPs) {
+			NetworkInterface mockIntf = mock(NetworkInterface.class);
+			when(mockIntf.isUp()).thenReturn(true);
+			when(mockIntf.isLoopback()).thenReturn(false);
+			when(mockIntf.isVirtual()).thenReturn(false);
+			when(mockIntf.getName()).thenReturn("ap0");
+
+			InetAddress mockInetAddr = mock(InetAddress.class);
+			when(mockInetAddr.isLoopbackAddress()).thenReturn(false);
+			when(mockInetAddr.isLinkLocalAddress()).thenReturn(false);
+			when(mockInetAddr.isSiteLocalAddress()).thenReturn(true);
+			when(mockInetAddr.getHostAddress()).thenReturn(ip);
+
+			InterfaceAddress mockIfaceAddr = mock(InterfaceAddress.class);
+			when(mockIfaceAddr.getAddress()).thenReturn(mockInetAddr);
+			when(mockIntf.getInterfaceAddresses()).thenReturn(Arrays.asList(mockIfaceAddr));
+
+			List<NetworkInterface> interfaces = Arrays.asList(mockIntf);
+			String result = NetworkUtils.getHotspotInterfaceIP(interfaces);
+
+			assertNull("Invalid private IP " + ip + " should be rejected", result);
+		}
+	}
+
+	@Test
+	public void testGetHotspotInterfaceIP_MultipleInterfaces() throws Exception {
+		// Test realistic scenario: cellular first, then WiFi client, then AP
+		NetworkInterface cellularIntf = mock(NetworkInterface.class);
+		when(cellularIntf.isUp()).thenReturn(true);
+		when(cellularIntf.isLoopback()).thenReturn(false);
+		when(cellularIntf.isVirtual()).thenReturn(false);
+		when(cellularIntf.getName()).thenReturn("rmnet0"); // Should be filtered
+
+		NetworkInterface wifiClientIntf = mock(NetworkInterface.class);
+		when(wifiClientIntf.isUp()).thenReturn(true);
+		when(wifiClientIntf.isLoopback()).thenReturn(false);
+		when(wifiClientIntf.isVirtual()).thenReturn(false);
+		when(wifiClientIntf.getName()).thenReturn("wlan0"); // Not AP pattern
+
+		NetworkInterface apIntf = mock(NetworkInterface.class);
+		when(apIntf.isUp()).thenReturn(true);
+		when(apIntf.isLoopback()).thenReturn(false);
+		when(apIntf.isVirtual()).thenReturn(false);
+		when(apIntf.getName()).thenReturn("ap0"); // AP pattern
+
+		InetAddress mockInetAddr = mock(InetAddress.class);
+		when(mockInetAddr.isLoopbackAddress()).thenReturn(false);
+		when(mockInetAddr.isLinkLocalAddress()).thenReturn(false);
+		when(mockInetAddr.isSiteLocalAddress()).thenReturn(true);
+		when(mockInetAddr.getHostAddress()).thenReturn("192.168.43.1");
+
+		InterfaceAddress mockIfaceAddr = mock(InterfaceAddress.class);
+		when(mockIfaceAddr.getAddress()).thenReturn(mockInetAddr);
+		when(apIntf.getInterfaceAddresses()).thenReturn(Arrays.asList(mockIfaceAddr));
+
+		// Other interfaces return empty address lists
+		when(cellularIntf.getInterfaceAddresses()).thenReturn(Collections.emptyList());
+		when(wifiClientIntf.getInterfaceAddresses()).thenReturn(Collections.emptyList());
+
+		List<NetworkInterface> interfaces = Arrays.asList(cellularIntf, wifiClientIntf, apIntf);
+		String result = NetworkUtils.getHotspotInterfaceIP(interfaces);
+
+		assertEquals("Should find AP interface despite cellular and client interfaces", "192.168.43.1", result);
+	}
+
+	@Test
+	public void testGetHotspotInterfaceIP_InterfaceWithNoAddresses() throws Exception {
+		// Test interface that matches AP pattern but has no addresses
+		NetworkInterface mockIntf = mock(NetworkInterface.class);
+		when(mockIntf.isUp()).thenReturn(true);
+		when(mockIntf.isLoopback()).thenReturn(false);
+		when(mockIntf.isVirtual()).thenReturn(false);
+		when(mockIntf.getName()).thenReturn("ap0");
+		when(mockIntf.getInterfaceAddresses()).thenReturn(Collections.emptyList());
+
+		List<NetworkInterface> interfaces = Arrays.asList(mockIntf);
+		String result = NetworkUtils.getHotspotInterfaceIP(interfaces);
+
+		assertNull("Interface with no addresses should return null", result);
+	}
+}


### PR DESCRIPTION
* Add WiFi hotspot port forwarding with bind address selection

This adds support for binding port forwards to specific network interfaces, particularly targeting WiFi hotspot scenarios where users want to forward ports only on the hotspot interface.

Features:
- Three bind address options: localhost, all interfaces (0.0.0.0), WiFi hotspot only
- Automatic WiFi hotspot IP detection using interface name patterns
- Port forwarding information displayed directly in host list entries
- Icon tap for quick connect/disconnect without switching to console view

Technical implementation:
- Database schema upgrade (v25→v26) to add bindaddr column
- New NetworkUtils class for WiFi/cellular interface detection
- Graceful handling of devices that don't support AP broadcasts