### PR TITLE
Add support for specifying IP version

### DIFF
--- a/app/src/main/java/org/connectbot/HostEditorFragment.java
+++ b/app/src/main/java/org/connectbot/HostEditorFragment.java
@@ -92,6 +92,10 @@ public class HostEditorFragment extends Fragment {
 	private TypedArray mDelKeyNames;
 	private TypedArray mDelKeyValues;
 
+	// Likewise, but for IP version.
+	private TypedArray mIpVersionNames;
+	private TypedArray mIpVersionValues;
+
 	// A map from Charset display name to Charset value (i.e., unique ID for the Charset).
 	private Map<String, String> mCharsetData;
 
@@ -117,6 +121,8 @@ public class HostEditorFragment extends Fragment {
 	private TextView mPubkeyText;
 	private View mDelKeyItem;
 	private TextView mDelKeyText;
+	private View mIpVersionItem;
+	private TextView mIpVersionText;
 	private View mEncodingItem;
 	private TextView mEncodingText;
 	private CheckableMenuItem mUseSshAuthSwitch;
@@ -384,6 +390,39 @@ public class HostEditorFragment extends Fragment {
 			}
 		}
 
+		mIpVersionItem = view.findViewById(R.id.ipversion_item);
+		mIpVersionItem.setOnClickListener(new View.OnClickListener() {
+			@Override
+			public void onClick(View v) {
+				PopupMenu menu = new PopupMenu(getActivity(), v);
+				for (int i = 0; i < mIpVersionNames.length(); i++) {
+					menu.getMenu().add(mIpVersionNames.getText(i));
+				}
+				menu.setOnMenuItemClickListener(new PopupMenu.OnMenuItemClickListener() {
+					@Override
+					public boolean onMenuItemClick(MenuItem item) {
+						for (int i = 0; i < mIpVersionNames.length(); i++) {
+							if (mIpVersionNames.getText(i).toString().equals(item.getTitle().toString())) {
+								mHost.setIpVersion(mIpVersionValues.getText(i).toString());
+								mIpVersionText.setText(mIpVersionNames.getText(i));
+								return true;
+							}
+						}
+						return false;
+					}
+				});
+				menu.show();
+			}
+		});
+
+		mIpVersionText = view.findViewById(R.id.ipversion_text);
+		for (int i = 0; i < mIpVersionValues.length(); i++) {
+			if (mIpVersionValues.getText(i).toString().equals(mHost.getIpVersion())) {
+				mIpVersionText.setText(mIpVersionNames.getText(i));
+				break;
+			}
+		}
+
 		mEncodingItem = view.findViewById(R.id.encoding_item);
 		mEncodingItem.setOnClickListener(new View.OnClickListener() {
 			@Override
@@ -581,6 +620,8 @@ public class HostEditorFragment extends Fragment {
 		mColorValues = getResources().obtainTypedArray(R.array.list_color_values);
 		mDelKeyNames = getResources().obtainTypedArray(R.array.list_delkey);
 		mDelKeyValues = getResources().obtainTypedArray(R.array.list_delkey_values);
+		mIpVersionNames = getResources().obtainTypedArray(R.array.list_ipversion);
+		mIpVersionValues = getResources().obtainTypedArray(R.array.list_ipversion_values);
 	}
 
 	@Override
@@ -591,6 +632,8 @@ public class HostEditorFragment extends Fragment {
 		mColorValues.recycle();
 		mDelKeyNames.recycle();
 		mDelKeyValues.recycle();
+		mIpVersionNames.recycle();
+		mIpVersionValues.recycle();
 	}
 
 	@Override
@@ -669,7 +712,7 @@ public class HostEditorFragment extends Fragment {
 	/**
 	 * Handles a change in the host caused by the user adjusting the values of one of the widgets
 	 * in this fragment. If the change has resulted in a valid host, the new value is sent back
-	 * to the listener; however, if the change ha resulted in an invalid host, the listener is
+	 * to the listener; however, if the change has resulted in an invalid host, the listener is
 	 * notified.
 	 */
 	private void handleHostChange() {

--- a/app/src/main/java/org/connectbot/bean/HostBean.java
+++ b/app/src/main/java/org/connectbot/bean/HostBean.java
@@ -51,6 +51,7 @@ public class HostBean extends AbstractBean {
 	private long pubkeyId = HostDatabase.PUBKEYID_ANY;
 	private boolean wantSession = true;
 	private String delKey = HostDatabase.DELKEY_DEL;
+	private String ipVersion = HostDatabase.IPVERSION_IPV4IPV6;
 	private int fontSize = DEFAULT_FONT_SIZE;
 	private boolean compression = false;
 	private String encoding = HostDatabase.ENCODING_DEFAULT;
@@ -161,6 +162,8 @@ public class HostBean extends AbstractBean {
 	public String getDelKey() {
 		return delKey;
 	}
+	public void setIpVersion(String ipVersion) { this.ipVersion = ipVersion; }
+	public String getIpVersion() { return ipVersion; }
 	public void setFontSize(int fontSize) {
 		this.fontSize = fontSize;
 	}
@@ -225,6 +228,7 @@ public class HostBean extends AbstractBean {
 		values.put(HostDatabase.FIELD_HOST_PUBKEYID, pubkeyId);
 		values.put(HostDatabase.FIELD_HOST_WANTSESSION, Boolean.toString(wantSession));
 		values.put(HostDatabase.FIELD_HOST_DELKEY, delKey);
+		values.put(HostDatabase.FIELD_HOST_IPVERSION, ipVersion);
 		values.put(HostDatabase.FIELD_HOST_FONTSIZE, fontSize);
 		values.put(HostDatabase.FIELD_HOST_COMPRESSION, Boolean.toString(compression));
 		values.put(HostDatabase.FIELD_HOST_ENCODING, encoding);
@@ -249,6 +253,7 @@ public class HostBean extends AbstractBean {
 		host.setPubkeyId(values.getAsLong(HostDatabase.FIELD_HOST_PUBKEYID));
 		host.setWantSession(Boolean.valueOf(values.getAsString(HostDatabase.FIELD_HOST_WANTSESSION)));
 		host.setDelKey(values.getAsString(HostDatabase.FIELD_HOST_DELKEY));
+		host.setIpVersion(values.getAsString(HostDatabase.FIELD_HOST_IPVERSION));
 		host.setFontSize(values.getAsInteger(HostDatabase.FIELD_HOST_FONTSIZE));
 		host.setCompression(Boolean.valueOf(values.getAsString(HostDatabase.FIELD_HOST_COMPRESSION)));
 		host.setEncoding(values.getAsString(HostDatabase.FIELD_HOST_ENCODING));

--- a/app/src/main/java/org/connectbot/transport/SSH.java
+++ b/app/src/main/java/org/connectbot/transport/SSH.java
@@ -456,7 +456,17 @@ public class SSH extends AbsTransport implements ConnectionMonitor, InteractiveC
 			Logger.enabled = true;
 			Logger.logger = logger;
 			*/
-			ConnectionInfo connectionInfo = connection.connect(new HostKeyVerifier());
+			Connection.IpVersion ipVersion;
+			String hostIpVersion = host.getIpVersion();
+			if (hostIpVersion.equals(HostDatabase.IPVERSION_IPV4ONLY)) {
+				ipVersion = Connection.IpVersion.IPV4_ONLY;
+			}
+			else if (hostIpVersion.equals(HostDatabase.IPVERSION_IPV6ONLY)) {
+				ipVersion = Connection.IpVersion.IPV6_ONLY;
+			} else { // Assumes (hostIpVersion.equals(HostDatabase.IPVERSION_IPV4IPV6))
+				ipVersion = Connection.IpVersion.IPV4_AND_IPV6;
+			}
+			ConnectionInfo connectionInfo = connection.connect(new HostKeyVerifier(), ipVersion);
 			connected = true;
 
 			bridge.outputLine(manager.res.getString(R.string.terminal_kex_algorithm,


### PR DESCRIPTION
Added UI and code to support specifying IP version to be used for connections. Defaults to both IPv4 and IPv6. Depends on a similar change in connectbot/sshlib.