### PR TITLE
Compress mapping files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,7 @@ jobs:
           cp ./app/build/outputs/native-debug-symbols/ossRelease/native-debug-symbols.zip ConnectBot-${GITHUB_TAG}-oss.native-debug-symbols.zip
           cp ./app/build/outputs/mapping/googleRelease/mapping.txt ConnectBot-${GITHUB_TAG}-google.mapping.txt
           cp ./app/build/outputs/mapping/ossRelease/mapping.txt ConnectBot-${GITHUB_TAG}-oss.mapping.txt
+          zstd *.mapping.txt
   
       - name: Store artifacts for upload
         if: ${{ github.event_name == 'push' }}
@@ -139,7 +140,7 @@ jobs:
             ConnectBot-*-unsigned.apk
             ConnectBot-*-unsigned.aab
             ConnectBot-*.native-debug-symbols.zip
-            ConnectBot-*.mapping.txt
+            ConnectBot-*.mapping.txt.zst
 
   upload:
     name: Upload to GitHub releases


### PR DESCRIPTION
These are pretty much 1:1 mappings currently, so we can compress these pretty well. Use zstd to save some space on the CI infrastructure and GitHub since they're not usually needed by end users.