### PR TITLE
Append duplicate marker on end of dupe nicknames

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -933,6 +933,10 @@
 	<string name="migration_retry">Retry</string>
 	<!-- Help text shown after migration failure -->
 	<string name="migration_failed_help">If the problem persists, please contact support or check the application logs</string>
+	<!-- Title for warnings section shown during database migration -->
+	<string name="migration_warnings_title">Migration Warnings</string>
+	<!-- Button text to copy migration warnings to clipboard for reporting issues -->
+	<string name="migration_copy_warnings">Copy Warnings</string>
 	<!-- Shown in the alert dialog when a user chooses the 'disconnect' item to disconnect from a SSH or Telnet host. -->
 	<string name="disconnect_host_alert">Are you sure you want to disconnect from \'%1$s\'?</string>
 	<!-- Shown in the alert dialog when a user chooses the 'delete host' item to delete a host. -->


### PR DESCRIPTION
During migration if there are hosts or pubkey with non-unique names then we will just append (1), (2), etc to the end instead of failing.

Fix #1632 