### PR TITLE
Fix Kotlin vs Java "split" difference

### DIFF
--- a/app/src/main/java/org/connectbot/ui/screens/portforwardlist/PortForwardListViewModel.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/portforwardlist/PortForwardListViewModel.kt
@@ -70,7 +70,7 @@ class PortForwardListViewModel(
             try {
                 withContext(Dispatchers.IO) {
                     // Parse destination in "host:port" format
-                    val destSplit = destination.split(":", limit = -1)
+                    val destSplit = destination.split(":")
                     val destAddr = destSplit.firstOrNull()
                     val destPort = if (destSplit.size > 1) {
                         destSplit.last().toIntOrNull() ?: 0
@@ -108,7 +108,7 @@ class PortForwardListViewModel(
             try {
                 withContext(Dispatchers.IO) {
                     // Parse destination in "host:port" format
-                    val destSplit = destination.split(":", limit = -1)
+                    val destSplit = destination.split(":")
                     val destAddr = destSplit.firstOrNull()
                     val destPort = if (destSplit.size > 1) {
                         destSplit.last().toIntOrNull() ?: 0


### PR DESCRIPTION
In Java you have to specify -1 as the limit to say you want a result even if it does not find the delimiter. Kotlin does that as the default.