### PR TITLE
Fix edit pubkey text

### DIFF
--- a/app/src/main/java/org/connectbot/ui/screens/pubkeylist/PubkeyListScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/pubkeylist/PubkeyListScreen.kt
@@ -290,7 +290,7 @@ private fun PubkeyListItem(
                     // Edit key
                     DropdownMenuItem(
                         text = {
-                            Text(stringResource(R.string.list_host_edit))
+                            Text(stringResource(R.string.list_pubkey_edit))
                         },
                         onClick = {
                             showMenu = false

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -949,4 +949,6 @@
 	<string name="disconnect_host_alert">Are you sure you want to disconnect from \'%1$s\'?</string>
 	<!-- Shown in the alert dialog when a user chooses the 'delete host' item to delete a host. -->
 	<string name="delete_host_confirm">Are you sure you want to delete host \'%1$s\'?</string>
+	<!-- Menu selection to edit a pubkey details (e.g., nickname) -->
+	<string name="list_pubkey_edit">Edit pubkey</string>
 </resources>


### PR DESCRIPTION
Accidentally copied edit host without changing the string resource.

Fixes #1637 