### PR TITLE
Fix export key

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -229,6 +229,7 @@ dependencies {
     implementation(libs.sshlib)
     implementation(libs.termlib)
     implementation("com.google.crypto.tink:tink:1.19.0") // For Ed25519 key derivation
+    implementation("org.connectbot:jbcrypt:1.0.2") // For bcrypt_pbkdf in OpenSSH encrypted keys
     implementation(libs.androidx.media3.common.ktx)
     implementation(libs.androidx.navigation.testing)
     implementation(libs.androidx.ui)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -228,6 +228,7 @@ tasks.withType<DependencyUpdatesTask>().configureEach {
 dependencies {
     implementation(libs.sshlib)
     implementation(libs.termlib)
+    implementation("com.google.crypto.tink:tink:1.19.0") // For Ed25519 key derivation
     implementation(libs.androidx.media3.common.ktx)
     implementation(libs.androidx.navigation.testing)
     implementation(libs.androidx.ui)

--- a/app/src/main/java/org/connectbot/ui/screens/pubkeylist/PubkeyListScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/pubkeylist/PubkeyListScreen.kt
@@ -172,7 +172,8 @@ fun PubkeyListScreen(
         onDeletePubkey = viewModel::deletePubkey,
         onToggleKeyLoaded = viewModel::toggleKeyLoaded,
         onCopyPublicKey = viewModel::copyPublicKey,
-        onCopyPrivateKey = viewModel::copyPrivateKey,
+        onCopyPrivateKeyOpenSSH = viewModel::copyPrivateKeyOpenSSH,
+        onCopyPrivateKeyPem = viewModel::copyPrivateKeyPem,
         onImportKey = {
             filePickerLauncher.launch(arrayOf("*/*"))
         },
@@ -191,7 +192,8 @@ fun PubkeyListScreenContent(
     onDeletePubkey: (Pubkey) -> Unit,
     onToggleKeyLoaded: (Pubkey, (Pubkey, (String) -> Unit) -> Unit) -> Unit,
     onCopyPublicKey: (Pubkey) -> Unit,
-    onCopyPrivateKey: (Pubkey) -> Unit,
+    onCopyPrivateKeyOpenSSH: (Pubkey) -> Unit,
+    onCopyPrivateKeyPem: (Pubkey) -> Unit,
     onImportKey: () -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -283,7 +285,8 @@ fun PubkeyListScreenContent(
                                 onDelete = { onDeletePubkey(pubkey) },
                                 onToggleLoaded = { onToggleKeyLoaded(pubkey, it) },
                                 onCopyPublicKey = { onCopyPublicKey(pubkey) },
-                                onCopyPrivateKey = { onCopyPrivateKey(pubkey) },
+                                onCopyPrivateKeyOpenSSH = { onCopyPrivateKeyOpenSSH(pubkey) },
+                                onCopyPrivateKeyPem = { onCopyPrivateKeyPem(pubkey) },
                                 onEdit = { onNavigateToEdit(pubkey) },
                                 onClick = { onToggleKeyLoaded(pubkey, it) }
                             )
@@ -302,7 +305,8 @@ private fun PubkeyListItem(
     onDelete: () -> Unit,
     onToggleLoaded: ((Pubkey, (String) -> Unit) -> Unit) -> Unit,
     onCopyPublicKey: () -> Unit,
-    onCopyPrivateKey: () -> Unit,
+    onCopyPrivateKeyOpenSSH: () -> Unit,
+    onCopyPrivateKeyPem: () -> Unit,
     onEdit: () -> Unit,
     onClick: ((Pubkey, (String) -> Unit) -> Unit) -> Unit,
     modifier: Modifier = Modifier
@@ -397,18 +401,40 @@ private fun PubkeyListItem(
                         enabled = !isImported
                     )
 
-                    // Copy private key (not available for Keystore keys)
+                    // Copy private key in OpenSSH format (not available for Keystore keys)
                     DropdownMenuItem(
-                        text = { Text(stringResource(R.string.pubkey_copy_private)) },
+                        text = {
+                            Text(stringResource(
+                                if (isImported)
+                                    R.string.pubkey_copy_private
+                                else
+                                    R.string.pubkey_copy_private_openssh
+                            ))
+                        },
                         onClick = {
                             showMenu = false
-                            onCopyPrivateKey()
+                            onCopyPrivateKeyOpenSSH()
                         },
                         leadingIcon = {
                             Icon(Icons.Default.ContentCopy, null)
                         },
                         enabled = !pubkey.isBiometric && (!pubkey.encrypted || isImported)
                     )
+
+                    // Copy private key in PEM format (for non-imported keys)
+                    if (!isImported) {
+                        DropdownMenuItem(
+                            text = { Text(stringResource(R.string.pubkey_copy_private_pem)) },
+                            onClick = {
+                                showMenu = false
+                                onCopyPrivateKeyPem()
+                            },
+                            leadingIcon = {
+                                Icon(Icons.Default.ContentCopy, null)
+                            },
+                            enabled = !pubkey.isBiometric && !pubkey.encrypted
+                        )
+                    }
 
                     // Delete
                     DropdownMenuItem(
@@ -553,7 +579,8 @@ private fun PubkeyListScreenEmptyPreview() {
             onDeletePubkey = {},
             onToggleKeyLoaded = { _, _ -> },
             onCopyPublicKey = {},
-            onCopyPrivateKey = {},
+            onCopyPrivateKeyOpenSSH = {},
+            onCopyPrivateKeyPem = {},
             onImportKey = {}
         )
     }
@@ -575,7 +602,8 @@ private fun PubkeyListScreenLoadingPreview() {
             onDeletePubkey = {},
             onToggleKeyLoaded = { _, _ -> },
             onCopyPublicKey = {},
-            onCopyPrivateKey = {},
+            onCopyPrivateKeyOpenSSH = {},
+            onCopyPrivateKeyPem = {},
             onImportKey = {}
         )
     }
@@ -632,7 +660,8 @@ private fun PubkeyListScreenPopulatedPreview() {
             onDeletePubkey = {},
             onToggleKeyLoaded = { _, _ -> },
             onCopyPublicKey = {},
-            onCopyPrivateKey = {},
+            onCopyPrivateKeyOpenSSH = {},
+            onCopyPrivateKeyPem = {},
             onImportKey = {}
         )
     }

--- a/app/src/main/java/org/connectbot/ui/screens/pubkeylist/PubkeyListScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/pubkeylist/PubkeyListScreen.kt
@@ -210,6 +210,9 @@ fun PubkeyListScreen(
         onCopyPrivateKeyPem = { pubkey, onPasswordRequired ->
             viewModel.copyPrivateKeyPem(pubkey, onPasswordRequired)
         },
+        onCopyPrivateKeyEncrypted = { pubkey, onPasswordRequired, onExportPassphraseRequired ->
+            viewModel.copyPrivateKeyEncrypted(pubkey, onPasswordRequired, onExportPassphraseRequired)
+        },
         onExportPrivateKeyOpenSSH = { pubkey, onPasswordRequired ->
             viewModel.requestExportPrivateKeyOpenSSH(pubkey, onPasswordRequired)
         },
@@ -239,6 +242,7 @@ fun PubkeyListScreenContent(
     onCopyPublicKey: (Pubkey) -> Unit,
     onCopyPrivateKeyOpenSSH: (Pubkey, (Pubkey, (String) -> Unit) -> Unit) -> Unit,
     onCopyPrivateKeyPem: (Pubkey, (Pubkey, (String) -> Unit) -> Unit) -> Unit,
+    onCopyPrivateKeyEncrypted: (Pubkey, (Pubkey, (String) -> Unit) -> Unit, (Pubkey, (String) -> Unit) -> Unit) -> Unit,
     onExportPrivateKeyOpenSSH: (Pubkey, (Pubkey, (String) -> Unit) -> Unit) -> Unit,
     onExportPrivateKeyPem: (Pubkey, (Pubkey, (String) -> Unit) -> Unit) -> Unit,
     onExportPrivateKeyEncrypted: (Pubkey, (Pubkey, (String) -> Unit) -> Unit, (Pubkey, (String) -> Unit) -> Unit) -> Unit,
@@ -339,6 +343,9 @@ fun PubkeyListScreenContent(
                                 onCopyPrivateKeyPem = { onPasswordRequired ->
                                     onCopyPrivateKeyPem(pubkey, onPasswordRequired)
                                 },
+                                onCopyPrivateKeyEncrypted = { onPasswordRequired, onExportPassphraseRequired ->
+                                    onCopyPrivateKeyEncrypted(pubkey, onPasswordRequired, onExportPassphraseRequired)
+                                },
                                 onExportPrivateKeyOpenSSH = { onPasswordRequired ->
                                     onExportPrivateKeyOpenSSH(pubkey, onPasswordRequired)
                                 },
@@ -368,6 +375,7 @@ private fun PubkeyListItem(
     onCopyPublicKey: () -> Unit,
     onCopyPrivateKeyOpenSSH: ((Pubkey, (String) -> Unit) -> Unit) -> Unit,
     onCopyPrivateKeyPem: ((Pubkey, (String) -> Unit) -> Unit) -> Unit,
+    onCopyPrivateKeyEncrypted: ((Pubkey, (String) -> Unit) -> Unit, (Pubkey, (String) -> Unit) -> Unit) -> Unit,
     onExportPrivateKeyOpenSSH: ((Pubkey, (String) -> Unit) -> Unit) -> Unit,
     onExportPrivateKeyPem: ((Pubkey, (String) -> Unit) -> Unit) -> Unit,
     onExportPrivateKeyEncrypted: ((Pubkey, (String) -> Unit) -> Unit, (Pubkey, (String) -> Unit) -> Unit) -> Unit,
@@ -503,6 +511,30 @@ private fun PubkeyListItem(
                             },
                             leadingIcon = {
                                 Icon(Icons.Default.ContentCopy, null)
+                            },
+                            enabled = !pubkey.isBiometric
+                        )
+                    }
+
+                    // Copy private key encrypted (for non-imported keys)
+                    if (!isImported) {
+                        DropdownMenuItem(
+                            text = { Text(stringResource(R.string.pubkey_copy_private_encrypted)) },
+                            onClick = {
+                                showMenu = false
+                                onCopyPrivateKeyEncrypted(
+                                    { _, callback ->
+                                        passwordCallback = callback
+                                        showPasswordDialog = true
+                                    },
+                                    { _, callback ->
+                                        exportPassphraseCallback = callback
+                                        showExportPassphraseDialog = true
+                                    }
+                                )
+                            },
+                            leadingIcon = {
+                                Icon(Icons.Default.Lock, null)
                             },
                             enabled = !pubkey.isBiometric
                         )
@@ -856,6 +888,7 @@ private fun PubkeyListScreenEmptyPreview() {
             onCopyPublicKey = {},
             onCopyPrivateKeyOpenSSH = { _, _ -> },
             onCopyPrivateKeyPem = { _, _ -> },
+            onCopyPrivateKeyEncrypted = { _, _, _ -> },
             onExportPrivateKeyOpenSSH = { _, _ -> },
             onExportPrivateKeyPem = { _, _ -> },
             onExportPrivateKeyEncrypted = { _, _, _ -> },
@@ -882,6 +915,7 @@ private fun PubkeyListScreenLoadingPreview() {
             onCopyPublicKey = {},
             onCopyPrivateKeyOpenSSH = { _, _ -> },
             onCopyPrivateKeyPem = { _, _ -> },
+            onCopyPrivateKeyEncrypted = { _, _, _ -> },
             onExportPrivateKeyOpenSSH = { _, _ -> },
             onExportPrivateKeyPem = { _, _ -> },
             onExportPrivateKeyEncrypted = { _, _, _ -> },
@@ -943,6 +977,7 @@ private fun PubkeyListScreenPopulatedPreview() {
             onCopyPublicKey = {},
             onCopyPrivateKeyOpenSSH = { _, _ -> },
             onCopyPrivateKeyPem = { _, _ -> },
+            onCopyPrivateKeyEncrypted = { _, _, _ -> },
             onExportPrivateKeyOpenSSH = { _, _ -> },
             onExportPrivateKeyPem = { _, _ -> },
             onExportPrivateKeyEncrypted = { _, _, _ -> },

--- a/app/src/main/java/org/connectbot/util/PubkeyUtils.kt
+++ b/app/src/main/java/org/connectbot/util/PubkeyUtils.kt
@@ -19,8 +19,8 @@ package org.connectbot.util
 import android.util.Log
 import com.trilead.ssh2.crypto.Base64
 import com.trilead.ssh2.crypto.PEMDecoder
-import com.trilead.ssh2.crypto.SimpleDERReader
 import com.google.crypto.tink.subtle.Ed25519Sign
+import com.trilead.ssh2.crypto.OpenSSHKeyEncoder
 import com.trilead.ssh2.crypto.keys.Ed25519PrivateKey
 import com.trilead.ssh2.crypto.keys.Ed25519Provider
 import com.trilead.ssh2.crypto.keys.Ed25519PublicKey
@@ -29,12 +29,9 @@ import com.trilead.ssh2.signature.ECDSASHA2Verify
 import com.trilead.ssh2.signature.Ed25519Verify
 import com.trilead.ssh2.signature.RSASHA1Verify
 import com.trilead.ssh2.signature.SSHSignature
-import com.trilead.ssh2.packets.TypesWriter
 import java.nio.ByteBuffer
 import org.connectbot.data.entity.Pubkey
-import org.keyczar.jce.EcCore
 import java.io.IOException
-import java.math.BigInteger
 import java.security.AlgorithmParameters
 import java.security.InvalidAlgorithmParameterException
 import java.security.InvalidKeyException
@@ -45,33 +42,22 @@ import java.security.NoSuchAlgorithmException
 import java.security.PrivateKey
 import java.security.PublicKey
 import java.security.SecureRandom
-import java.security.interfaces.DSAPrivateKey
 import java.security.interfaces.DSAPublicKey
-import java.security.interfaces.ECPrivateKey
 import java.security.interfaces.ECPublicKey
-import java.security.interfaces.RSAPrivateCrtKey
-import java.security.interfaces.RSAPrivateKey
 import java.security.interfaces.RSAPublicKey
-import java.security.spec.DSAPublicKeySpec
-import java.security.spec.ECPoint
-import java.security.spec.ECPublicKeySpec
 import java.security.spec.InvalidKeySpecException
 import java.security.spec.InvalidParameterSpecException
 import java.security.spec.KeySpec
 import java.security.spec.PKCS8EncodedKeySpec
-import java.security.spec.RSAPublicKeySpec
 import java.security.spec.X509EncodedKeySpec
 import java.util.Arrays
-import org.mindrot.jbcrypt.BCrypt
 import javax.crypto.Cipher
 import javax.crypto.EncryptedPrivateKeyInfo
 import javax.crypto.IllegalBlockSizeException
 import javax.crypto.NoSuchPaddingException
 import javax.crypto.SecretKeyFactory
-import javax.crypto.spec.IvParameterSpec
 import javax.crypto.spec.PBEKeySpec
 import javax.crypto.spec.PBEParameterSpec
-import javax.crypto.spec.SecretKeySpec
 
 object PubkeyUtils {
     init {
@@ -83,15 +69,6 @@ object PubkeyUtils {
     const val PKCS8_START: String = "-----BEGIN PRIVATE KEY-----"
     const val PKCS8_END: String = "-----END PRIVATE KEY-----"
 
-    // OpenSSH encrypted key constants
-    private const val OPENSSH_CIPHER_AES256_CTR = "aes256-ctr"
-    private const val OPENSSH_KDF_BCRYPT = "bcrypt"
-    private const val OPENSSH_BCRYPT_SALT_SIZE = 16
-    private const val OPENSSH_BCRYPT_ROUNDS = 16
-    private const val OPENSSH_AES_KEY_SIZE = 32  // 256 bits
-    private const val OPENSSH_AES_IV_SIZE = 16   // 128 bits
-    private const val OPENSSH_AES_BLOCK_SIZE = 16
-
     // Size in bytes of salt to use.
     private const val SALT_SIZE = 8
 
@@ -99,9 +76,9 @@ object PubkeyUtils {
     private const val ITERATIONS = 1000
 
     fun formatKey(key: Key): String {
-        val algo = key.getAlgorithm()
-        val fmt = key.getFormat()
-        val encoded = key.getEncoded()
+        val algo = key.algorithm
+        val fmt = key.format
+        val encoded = key.encoded
         return "Key[algorithm=" + algo + ", format=" + fmt +
                 ", bytes=" + encoded.size + "]"
     }
@@ -135,53 +112,9 @@ object PubkeyUtils {
         return Encryptor.decrypt(salt, ITERATIONS, secret, ciphertext)
     }
 
-    /**
-     * Derives a key and IV from a passphrase using bcrypt_pbkdf for OpenSSH encrypted keys.
-     * @param passphrase The passphrase to derive from
-     * @param salt The salt (typically 16 bytes)
-     * @param rounds Number of bcrypt rounds (typically 16)
-     * @return A byte array containing the key (32 bytes) followed by IV (16 bytes)
-     */
-    private fun deriveOpenSSHKey(passphrase: String, salt: ByteArray, rounds: Int): ByteArray {
-        val keyLength = OPENSSH_AES_KEY_SIZE + OPENSSH_AES_IV_SIZE  // 48 bytes
-        val output = ByteArray(keyLength)
-        BCrypt().pbkdf(passphrase.toByteArray(Charsets.UTF_8), salt, rounds, output)
-        return output
-    }
-
-    /**
-     * Encrypts data using AES-256-CTR for OpenSSH encrypted key format.
-     * @param data The plaintext data to encrypt
-     * @param key The 32-byte AES key
-     * @param iv The 16-byte IV
-     * @return The encrypted data
-     */
-    private fun encryptAesCtr(data: ByteArray, key: ByteArray, iv: ByteArray): ByteArray {
-        val cipher = Cipher.getInstance("AES/CTR/NoPadding")
-        val keySpec = SecretKeySpec(key, "AES")
-        val ivSpec = IvParameterSpec(iv)
-        cipher.init(Cipher.ENCRYPT_MODE, keySpec, ivSpec)
-        return cipher.doFinal(data)
-    }
-
-    /**
-     * Decrypts data using AES-256-CTR for OpenSSH encrypted key format.
-     * @param data The encrypted data
-     * @param key The 32-byte AES key
-     * @param iv The 16-byte IV
-     * @return The decrypted data
-     */
-    private fun decryptAesCtr(data: ByteArray, key: ByteArray, iv: ByteArray): ByteArray {
-        val cipher = Cipher.getInstance("AES/CTR/NoPadding")
-        val keySpec = SecretKeySpec(key, "AES")
-        val ivSpec = IvParameterSpec(iv)
-        cipher.init(Cipher.DECRYPT_MODE, keySpec, ivSpec)
-        return cipher.doFinal(data)
-    }
-
     @Throws(Exception::class)
     fun getEncodedPrivate(pk: PrivateKey, secret: String?): ByteArray {
-        val encoded = pk.getEncoded()
+        val encoded = pk.encoded
         if (secret == null || secret.isEmpty()) {
             return encoded
         }
@@ -197,28 +130,11 @@ object PubkeyUtils {
 
     @Throws(Exception::class)
     fun decodePrivate(encoded: ByteArray, keyType: String?, secret: String?): PrivateKey? {
-        if (secret != null && secret.isNotEmpty()) return decodePrivate(
+        return if (secret != null && secret.isNotEmpty()) decodePrivate(
             decrypt(encoded, secret),
             keyType
         )
-        else return decodePrivate(encoded, keyType)
-    }
-
-    @Throws(InvalidKeySpecException::class, NoSuchAlgorithmException::class)
-    fun getBitStrength(encoded: ByteArray?, keyType: String?): Int {
-        val pubKey = decodePublic(encoded, keyType)
-        if ("RSA" == keyType) {
-            return (pubKey as RSAPublicKey).getModulus().bitLength()
-        } else if ("DSA" == keyType) {
-            return 1024
-        } else if ("EC" == keyType) {
-            return (pubKey as ECPublicKey).getParams().getCurve().getField()
-                .getFieldSize()
-        } else if ("Ed25519" == keyType) {
-            return 256
-        } else {
-            return 0
-        }
+        else decodePrivate(encoded, keyType)
     }
 
     @Throws(NoSuchAlgorithmException::class, InvalidKeySpecException::class)
@@ -228,70 +144,13 @@ object PubkeyUtils {
         return kf.generatePublic(pubKeySpec)
     }
 
-    @JvmStatic
-    @Throws(NoSuchAlgorithmException::class)
-    fun getAlgorithmForOid(oid: String?): String {
-        if ("1.2.840.10045.2.1" == oid) {
-            return "EC"
-        } else if ("1.2.840.113549.1.1.1" == oid) {
-            return "RSA"
-        } else if ("1.2.840.10040.4.1" == oid) {
-            return "DSA"
-        } else if ("1.3.101.112" == oid) {
-            return "Ed25519"
-        } else {
-            throw NoSuchAlgorithmException("Unknown algorithm OID " + oid)
-        }
-    }
-
-    @JvmStatic
-    @Throws(NoSuchAlgorithmException::class)
-    fun getOidFromPkcs8Encoded(encoded: ByteArray): String? {
-        try {
-            val reader = SimpleDERReader(encoded)
-            reader.resetInput(reader.readSequenceAsByteArray())
-            reader.readInt()
-            reader.resetInput(reader.readSequenceAsByteArray())
-            return reader.readOid()
-        } catch (e: IOException) {
-            Log.w(TAG, "Could not read OID", e)
-            throw NoSuchAlgorithmException("Could not read key", e)
-        }
-    }
-
-    @JvmStatic
-    @Throws(InvalidKeySpecException::class)
-    fun getRSAPublicExponentFromPkcs8Encoded(encoded: ByteArray): BigInteger? {
-        try {
-            val reader = SimpleDERReader(encoded)
-            reader.resetInput(reader.readSequenceAsByteArray())
-            if (reader.readInt() != BigInteger.ZERO) {
-                throw InvalidKeySpecException("PKCS#8 is not version 0")
-            }
-
-            reader.readSequenceAsByteArray() // OID sequence
-            reader.resetInput(reader.readOctetString()) // RSA key bytes
-            reader.resetInput(reader.readSequenceAsByteArray()) // RSA key sequence
-
-            if (reader.readInt() != BigInteger.ZERO) {
-                throw InvalidKeySpecException("RSA key is not version 0")
-            }
-
-            reader.readInt() // modulus
-            return reader.readInt() // public exponent
-        } catch (e: IOException) {
-            Log.w(TAG, "Could not read public exponent", e)
-            throw InvalidKeySpecException("Could not read key", e)
-        }
-    }
-
     @Throws(BadPasswordException::class)
     fun convertToKeyPair(pubkey: Pubkey, password: String?): KeyPair? {
         if ("IMPORTED" == pubkey.type) {
             // load specific key using pem format
             try {
                 return PEMDecoder.decode(
-                    kotlin.text.String(pubkey.privateKey!!, charset("UTF-8")).toCharArray(),
+                    String(pubkey.privateKey!!, charset("UTF-8")).toCharArray(),
                     password
                 )
             } catch (e: Exception) {
@@ -301,7 +160,7 @@ object PubkeyUtils {
         } else {
             // load using internal generated format
             try {
-                val privKey = PubkeyUtils.decodePrivate(pubkey.privateKey!!, pubkey.type, password)
+                val privKey = decodePrivate(pubkey.privateKey!!, pubkey.type, password)
                 val pubKey = decodePublic(pubkey.publicKey, pubkey.type)
                 Log.d(TAG, "Unlocked key " + formatKey(pubKey))
 
@@ -316,7 +175,7 @@ object PubkeyUtils {
     @JvmStatic
     @Throws(NoSuchAlgorithmException::class, InvalidKeySpecException::class)
     fun recoverKeyPair(encoded: ByteArray): KeyPair {
-        val algo = getAlgorithmForOid(getOidFromPkcs8Encoded(encoded))
+        val algo = OpenSSHKeyEncoder.getAlgorithmForOid(OpenSSHKeyEncoder.getOidFromPkcs8Encoded(encoded))
 
         val privKeySpec: KeySpec = PKCS8EncodedKeySpec(encoded)
 
@@ -325,61 +184,13 @@ object PubkeyUtils {
 
         // Ed25519 requires special handling to derive the public key
         if (priv is Ed25519PrivateKey) {
-            val seed = priv.getSeed()
+            val seed = priv.seed
             val tinkKeyPair = Ed25519Sign.KeyPair.newKeyPairFromSeed(seed)
             val publicKey = Ed25519PublicKey(tinkKeyPair.publicKey)
             return KeyPair(publicKey, priv)
         }
 
-        return KeyPair(recoverPublicKey(kf, priv), priv)
-    }
-
-    @JvmStatic
-    @Throws(NoSuchAlgorithmException::class, InvalidKeySpecException::class)
-    fun recoverPublicKey(kf: KeyFactory, priv: PrivateKey?): PublicKey {
-        if (priv is RSAPrivateCrtKey) {
-            val rsaPriv = priv
-            return kf.generatePublic(
-                RSAPublicKeySpec(
-                    rsaPriv.getModulus(), rsaPriv
-                        .getPublicExponent()
-                )
-            )
-        } else if (priv is RSAPrivateKey) {
-            val publicExponent = getRSAPublicExponentFromPkcs8Encoded(priv.getEncoded())
-            val rsaPriv = priv
-            return kf.generatePublic(RSAPublicKeySpec(rsaPriv.getModulus(), publicExponent))
-        } else if (priv is DSAPrivateKey) {
-            val dsaPriv = priv
-            val params = dsaPriv.getParams()
-
-            // Calculate public key Y
-            val y = params.getG().modPow(dsaPriv.getX(), params.getP())
-
-            return kf.generatePublic(
-                DSAPublicKeySpec(
-                    y, params.getP(), params.getQ(), params
-                        .getG()
-                )
-            )
-        } else if (priv is ECPrivateKey) {
-            val ecPriv = priv
-            val params = ecPriv.getParams()
-
-            // Calculate public key Y
-            val generator = params.getGenerator()
-            val wCoords = EcCore.multiplyPointA(
-                arrayOf<BigInteger?>(
-                    generator.getAffineX(),
-                    generator.getAffineY()
-                ), ecPriv.getS(), params
-            )
-            val w = ECPoint(wCoords[0], wCoords[1])
-
-            return kf.generatePublic(ECPublicKeySpec(w, params))
-        } else {
-            throw NoSuchAlgorithmException("Key type must be RSA, DSA, or EC")
-        }
+        return KeyPair(OpenSSHKeyEncoder.recoverPublicKey(kf, priv), priv)
     }
 
     /*
@@ -390,31 +201,37 @@ object PubkeyUtils {
         var nickname = origNickname
         if (nickname == null) nickname = "connectbot@android"
 
-        if (pk is RSAPublicKey) {
-            var data = "ssh-rsa "
-            data += String(Base64.encode(RSASHA1Verify.get().encodePublicKey(pk)))
-            return "$data $nickname"
-        } else if (pk is DSAPublicKey) {
-            var data = "ssh-dss "
-            data += String(Base64.encode(DSASHA1Verify.get().encodePublicKey(pk)))
-            return "$data $nickname"
-        } else if (pk is ECPublicKey) {
-            val ecPub = pk
-            val keyType = ECDSASHA2Verify.getSshKeyType(ecPub)
-            val verifier: SSHSignature = ECDSASHA2Verify.getVerifierForKey(ecPub)
-            val keyData = String(Base64.encode(verifier.encodePublicKey(ecPub)))
-            return "$keyType $keyData $nickname"
-        } else if (pk is Ed25519PublicKey) {
-            val edPub = pk
-            return Ed25519Verify.ED25519_ID + " " + String(
-                Base64.encode(
-                    Ed25519Verify.get().encodePublicKey(edPub)
-                )
-            ) +
-                    " " + nickname
-        }
+        when (pk) {
+            is RSAPublicKey -> {
+                var data = "ssh-rsa "
+                data += String(Base64.encode(RSASHA1Verify.get().encodePublicKey(pk)))
+                return "$data $nickname"
+            }
 
-        throw InvalidKeyException("Unknown key type")
+            is DSAPublicKey -> {
+                var data = "ssh-dss "
+                data += String(Base64.encode(DSASHA1Verify.get().encodePublicKey(pk)))
+                return "$data $nickname"
+            }
+
+            is ECPublicKey -> {
+                val keyType = ECDSASHA2Verify.getSshKeyType(pk)
+                val verifier: SSHSignature = ECDSASHA2Verify.getVerifierForKey(pk)
+                val keyData = String(Base64.encode(verifier.encodePublicKey(pk)))
+                return "$keyType $keyData $nickname"
+            }
+
+            is Ed25519PublicKey -> {
+                return Ed25519Verify.ED25519_ID + " " + String(
+                    Base64.encode(
+                        Ed25519Verify.get().encodePublicKey(pk)
+                    )
+                ) +
+                        " " + nickname
+            }
+
+            else -> throw InvalidKeyException("Unknown key type")
+        }
     }
 
     /*
@@ -426,17 +243,17 @@ object PubkeyUtils {
      */
     fun extractOpenSSHPublic(pair: KeyPair): ByteArray? {
         try {
-            val pubKey = pair.getPublic()
-            if (pubKey is RSAPublicKey) {
-                return RSASHA1Verify.get().encodePublicKey(pubKey)
-            } else if (pubKey is DSAPublicKey) {
-                return DSASHA1Verify.get().encodePublicKey(pubKey)
-            } else if (pubKey is ECPublicKey) {
-                return ECDSASHA2Verify.getVerifierForKey(pubKey).encodePublicKey(pubKey)
-            } else if (pubKey is Ed25519PublicKey) {
-                return Ed25519Verify.get().encodePublicKey(pubKey)
-            } else {
-                return null
+            return when (val pubKey = pair.public) {
+                is RSAPublicKey ->
+                    RSASHA1Verify.get().encodePublicKey(pubKey)
+                is DSAPublicKey ->
+                    DSASHA1Verify.get().encodePublicKey(pubKey)
+                is ECPublicKey ->
+                    ECDSASHA2Verify.getVerifierForKey(pubKey).encodePublicKey(pubKey)
+                is Ed25519PublicKey ->
+                    Ed25519Verify.get().encodePublicKey(pubKey)
+                else ->
+                    null
             }
         } catch (_: IOException) {
             return null
@@ -456,7 +273,7 @@ object PubkeyUtils {
     fun exportPEM(key: PrivateKey, secret: String?): String {
         val sb = StringBuilder()
 
-        var data = key.getEncoded()
+        var data = key.encoded
 
         sb.append(PKCS8_START)
         sb.append('\n')
@@ -467,14 +284,14 @@ object PubkeyUtils {
             random.nextBytes(salt)
 
             val defParams = PBEParameterSpec(salt, 1)
-            val params = AlgorithmParameters.getInstance(key.getAlgorithm())
+            val params = AlgorithmParameters.getInstance(key.algorithm)
 
             params.init(defParams)
 
             val pbeSpec = PBEKeySpec(secret.toCharArray())
 
-            val keyFact = SecretKeyFactory.getInstance(key.getAlgorithm())
-            val cipher = Cipher.getInstance(key.getAlgorithm())
+            val keyFact = SecretKeyFactory.getInstance(key.algorithm)
+            val cipher = Cipher.getInstance(key.algorithm)
             cipher.init(Cipher.WRAP_MODE, keyFact.generateSecret(pbeSpec), params)
 
             val wrappedKey = cipher.wrap(key)
@@ -507,478 +324,6 @@ object PubkeyUtils {
     private const val OPENSSH_PRIVATE_KEY_START = "-----BEGIN OPENSSH PRIVATE KEY-----"
     private const val OPENSSH_PRIVATE_KEY_END = "-----END OPENSSH PRIVATE KEY-----"
     private const val OPENSSH_KEY_V1_MAGIC = "openssh-key-v1\u0000"
-    private const val ED25519_KEY_TYPE = "ssh-ed25519"
-
-    /**
-     * Exports an Ed25519 key pair in OpenSSH format (unencrypted).
-     */
-    fun exportOpenSSHEd25519(
-        privateKey: Ed25519PrivateKey,
-        publicKey: Ed25519PublicKey,
-        comment: String?
-    ): String {
-        return exportOpenSSHEd25519(privateKey, publicKey, comment, null)
-    }
-
-    /**
-     * Exports an Ed25519 key pair in OpenSSH format.
-     * This is the standard format used by ssh-keygen and compatible with other SSH tools.
-     *
-     * @param privateKey The Ed25519 private key
-     * @param publicKey The Ed25519 public key
-     * @param comment Optional comment (typically the key nickname)
-     * @param passphrase Optional passphrase for encryption. If null or empty, key is unencrypted.
-     * @return The key in OpenSSH PEM format
-     */
-    fun exportOpenSSHEd25519(
-        privateKey: Ed25519PrivateKey,
-        publicKey: Ed25519PublicKey,
-        comment: String?,
-        passphrase: String?
-    ): String {
-        val encrypted = !passphrase.isNullOrEmpty()
-        val tw = TypesWriter()
-
-        // Magic header: "openssh-key-v1\0"
-        tw.writeBytes(OPENSSH_KEY_V1_MAGIC.toByteArray(Charsets.US_ASCII))
-
-        // Generate salt for encryption if needed
-        val salt = if (encrypted) {
-            ByteArray(OPENSSH_BCRYPT_SALT_SIZE).also { SecureRandom().nextBytes(it) }
-        } else null
-
-        // Cipher name
-        tw.writeString(if (encrypted) OPENSSH_CIPHER_AES256_CTR else "none")
-
-        // KDF name
-        tw.writeString(if (encrypted) OPENSSH_KDF_BCRYPT else "none")
-
-        // KDF options
-        if (encrypted && salt != null) {
-            val kdfOptions = TypesWriter()
-            kdfOptions.writeString(salt, 0, salt.size)
-            kdfOptions.writeUINT32(OPENSSH_BCRYPT_ROUNDS)
-            tw.writeString(kdfOptions.getBytes(), 0, kdfOptions.length())
-        } else {
-            tw.writeString("")
-        }
-
-        // Number of keys: 1
-        tw.writeUINT32(1)
-
-        // Public key blob
-        val publicKeyBytes = publicKey.getAbyte()
-        val pubKeyBlob = TypesWriter()
-        pubKeyBlob.writeString(ED25519_KEY_TYPE)
-        pubKeyBlob.writeString(publicKeyBytes, 0, publicKeyBytes.size)
-        tw.writeString(pubKeyBlob.getBytes(), 0, pubKeyBlob.length())
-
-        // Private key section
-        val privateSection = TypesWriter()
-
-        // Check integers (random, must match for verification)
-        val checkInt = SecureRandom().nextInt()
-        privateSection.writeUINT32(checkInt)
-        privateSection.writeUINT32(checkInt)
-
-        // Key type
-        privateSection.writeString(ED25519_KEY_TYPE)
-
-        // Public key
-        privateSection.writeString(publicKeyBytes, 0, publicKeyBytes.size)
-
-        // Private key: 64 bytes (32-byte seed + 32-byte public key)
-        val seed = privateKey.getSeed()
-        val privateKeyData = ByteArray(64)
-        System.arraycopy(seed, 0, privateKeyData, 0, 32)
-        System.arraycopy(publicKeyBytes, 0, privateKeyData, 32, 32)
-        privateSection.writeString(privateKeyData, 0, privateKeyData.size)
-
-        // Comment
-        privateSection.writeString(comment ?: "")
-
-        // Padding to block size (16 for encrypted, 8 for unencrypted)
-        val blockSize = if (encrypted) OPENSSH_AES_BLOCK_SIZE else 8
-        var paddingNeeded = blockSize - (privateSection.length() % blockSize)
-        if (paddingNeeded == blockSize) paddingNeeded = 0
-        for (i in 1..paddingNeeded) {
-            privateSection.writeByte(i)
-        }
-
-        // Encrypt if passphrase provided
-        val privateSectionBytes = if (encrypted && salt != null && passphrase != null) {
-            val derivedKey = deriveOpenSSHKey(passphrase, salt, OPENSSH_BCRYPT_ROUNDS)
-            val key = derivedKey.copyOfRange(0, OPENSSH_AES_KEY_SIZE)
-            val iv = derivedKey.copyOfRange(OPENSSH_AES_KEY_SIZE, OPENSSH_AES_KEY_SIZE + OPENSSH_AES_IV_SIZE)
-            encryptAesCtr(privateSection.getBytes(), key, iv)
-        } else {
-            privateSection.getBytes()
-        }
-
-        // Write the private section
-        tw.writeString(privateSectionBytes, 0, privateSectionBytes.size)
-
-        return formatOpenSSHKey(tw.getBytes())
-    }
-
-    /**
-     * Exports an RSA key pair in OpenSSH format (unencrypted).
-     */
-    fun exportOpenSSHRSA(
-        privateKey: RSAPrivateCrtKey,
-        publicKey: RSAPublicKey,
-        comment: String?
-    ): String {
-        return exportOpenSSHRSA(privateKey, publicKey, comment, null)
-    }
-
-    /**
-     * Exports an RSA key pair in OpenSSH format.
-     * @param passphrase Optional passphrase for encryption. If null or empty, key is unencrypted.
-     */
-    fun exportOpenSSHRSA(
-        privateKey: RSAPrivateCrtKey,
-        publicKey: RSAPublicKey,
-        comment: String?,
-        passphrase: String?
-    ): String {
-        val encrypted = !passphrase.isNullOrEmpty()
-        val tw = TypesWriter()
-
-        // Magic header
-        tw.writeBytes(OPENSSH_KEY_V1_MAGIC.toByteArray(Charsets.US_ASCII))
-
-        // Generate salt for encryption if needed
-        val salt = if (encrypted) {
-            ByteArray(OPENSSH_BCRYPT_SALT_SIZE).also { SecureRandom().nextBytes(it) }
-        } else null
-
-        // Cipher name
-        tw.writeString(if (encrypted) OPENSSH_CIPHER_AES256_CTR else "none")
-
-        // KDF name
-        tw.writeString(if (encrypted) OPENSSH_KDF_BCRYPT else "none")
-
-        // KDF options
-        if (encrypted && salt != null) {
-            val kdfOptions = TypesWriter()
-            kdfOptions.writeString(salt, 0, salt.size)
-            kdfOptions.writeUINT32(OPENSSH_BCRYPT_ROUNDS)
-            tw.writeString(kdfOptions.getBytes(), 0, kdfOptions.length())
-        } else {
-            tw.writeString("")
-        }
-
-        // Number of keys
-        tw.writeUINT32(1)
-
-        // Public key blob: ssh-rsa, e, n
-        val pubKeyBlob = TypesWriter()
-        pubKeyBlob.writeString("ssh-rsa")
-        pubKeyBlob.writeMPInt(publicKey.publicExponent)
-        pubKeyBlob.writeMPInt(publicKey.modulus)
-        tw.writeString(pubKeyBlob.getBytes(), 0, pubKeyBlob.length())
-
-        // Private key section
-        val privateSection = TypesWriter()
-        val checkInt = SecureRandom().nextInt()
-        privateSection.writeUINT32(checkInt)
-        privateSection.writeUINT32(checkInt)
-
-        privateSection.writeString("ssh-rsa")
-        privateSection.writeMPInt(publicKey.modulus)          // n
-        privateSection.writeMPInt(publicKey.publicExponent)   // e
-        privateSection.writeMPInt(privateKey.privateExponent) // d
-        privateSection.writeMPInt(privateKey.crtCoefficient)  // iqmp (q^-1 mod p)
-        privateSection.writeMPInt(privateKey.primeP)          // p
-        privateSection.writeMPInt(privateKey.primeQ)          // q
-
-        privateSection.writeString(comment ?: "")
-
-        // Padding to block size (16 for encrypted, 8 for unencrypted)
-        val blockSize = if (encrypted) OPENSSH_AES_BLOCK_SIZE else 8
-        var paddingNeeded = blockSize - (privateSection.length() % blockSize)
-        if (paddingNeeded == blockSize) paddingNeeded = 0
-        for (i in 1..paddingNeeded) {
-            privateSection.writeByte(i)
-        }
-
-        // Encrypt if passphrase provided
-        val privateSectionBytes = if (encrypted && salt != null && passphrase != null) {
-            val derivedKey = deriveOpenSSHKey(passphrase, salt, OPENSSH_BCRYPT_ROUNDS)
-            val key = derivedKey.copyOfRange(0, OPENSSH_AES_KEY_SIZE)
-            val iv = derivedKey.copyOfRange(OPENSSH_AES_KEY_SIZE, OPENSSH_AES_KEY_SIZE + OPENSSH_AES_IV_SIZE)
-            encryptAesCtr(privateSection.getBytes(), key, iv)
-        } else {
-            privateSection.getBytes()
-        }
-
-        tw.writeString(privateSectionBytes, 0, privateSectionBytes.size)
-
-        return formatOpenSSHKey(tw.getBytes())
-    }
-
-    /**
-     * Exports a DSA key pair in OpenSSH format (unencrypted).
-     */
-    fun exportOpenSSHDSA(
-        privateKey: DSAPrivateKey,
-        publicKey: DSAPublicKey,
-        comment: String?
-    ): String {
-        return exportOpenSSHDSA(privateKey, publicKey, comment, null)
-    }
-
-    /**
-     * Exports a DSA key pair in OpenSSH format.
-     * @param passphrase Optional passphrase for encryption. If null or empty, key is unencrypted.
-     */
-    fun exportOpenSSHDSA(
-        privateKey: DSAPrivateKey,
-        publicKey: DSAPublicKey,
-        comment: String?,
-        passphrase: String?
-    ): String {
-        val encrypted = !passphrase.isNullOrEmpty()
-        val tw = TypesWriter()
-
-        // Magic header
-        tw.writeBytes(OPENSSH_KEY_V1_MAGIC.toByteArray(Charsets.US_ASCII))
-
-        // Generate salt for encryption if needed
-        val salt = if (encrypted) {
-            ByteArray(OPENSSH_BCRYPT_SALT_SIZE).also { SecureRandom().nextBytes(it) }
-        } else null
-
-        // Cipher name
-        tw.writeString(if (encrypted) OPENSSH_CIPHER_AES256_CTR else "none")
-
-        // KDF name
-        tw.writeString(if (encrypted) OPENSSH_KDF_BCRYPT else "none")
-
-        // KDF options
-        if (encrypted && salt != null) {
-            val kdfOptions = TypesWriter()
-            kdfOptions.writeString(salt, 0, salt.size)
-            kdfOptions.writeUINT32(OPENSSH_BCRYPT_ROUNDS)
-            tw.writeString(kdfOptions.getBytes(), 0, kdfOptions.length())
-        } else {
-            tw.writeString("")
-        }
-
-        // Number of keys
-        tw.writeUINT32(1)
-
-        val params = publicKey.params
-
-        // Public key blob: ssh-dss, p, q, g, y
-        val pubKeyBlob = TypesWriter()
-        pubKeyBlob.writeString("ssh-dss")
-        pubKeyBlob.writeMPInt(params.p)
-        pubKeyBlob.writeMPInt(params.q)
-        pubKeyBlob.writeMPInt(params.g)
-        pubKeyBlob.writeMPInt(publicKey.y)
-        tw.writeString(pubKeyBlob.getBytes(), 0, pubKeyBlob.length())
-
-        // Private key section
-        val privateSection = TypesWriter()
-        val checkInt = SecureRandom().nextInt()
-        privateSection.writeUINT32(checkInt)
-        privateSection.writeUINT32(checkInt)
-
-        privateSection.writeString("ssh-dss")
-        privateSection.writeMPInt(params.p)
-        privateSection.writeMPInt(params.q)
-        privateSection.writeMPInt(params.g)
-        privateSection.writeMPInt(publicKey.y)
-        privateSection.writeMPInt(privateKey.x)
-
-        privateSection.writeString(comment ?: "")
-
-        // Padding to block size (16 for encrypted, 8 for unencrypted)
-        val blockSize = if (encrypted) OPENSSH_AES_BLOCK_SIZE else 8
-        var paddingNeeded = blockSize - (privateSection.length() % blockSize)
-        if (paddingNeeded == blockSize) paddingNeeded = 0
-        for (i in 1..paddingNeeded) {
-            privateSection.writeByte(i)
-        }
-
-        // Encrypt if passphrase provided
-        val privateSectionBytes = if (encrypted && salt != null && passphrase != null) {
-            val derivedKey = deriveOpenSSHKey(passphrase, salt, OPENSSH_BCRYPT_ROUNDS)
-            val key = derivedKey.copyOfRange(0, OPENSSH_AES_KEY_SIZE)
-            val iv = derivedKey.copyOfRange(OPENSSH_AES_KEY_SIZE, OPENSSH_AES_KEY_SIZE + OPENSSH_AES_IV_SIZE)
-            encryptAesCtr(privateSection.getBytes(), key, iv)
-        } else {
-            privateSection.getBytes()
-        }
-
-        tw.writeString(privateSectionBytes, 0, privateSectionBytes.size)
-
-        return formatOpenSSHKey(tw.getBytes())
-    }
-
-    /**
-     * Exports an EC key pair in OpenSSH format (unencrypted).
-     */
-    fun exportOpenSSHEC(
-        privateKey: ECPrivateKey,
-        publicKey: ECPublicKey,
-        comment: String?
-    ): String {
-        return exportOpenSSHEC(privateKey, publicKey, comment, null)
-    }
-
-    /**
-     * Exports an EC key pair in OpenSSH format.
-     * @param passphrase Optional passphrase for encryption. If null or empty, key is unencrypted.
-     */
-    fun exportOpenSSHEC(
-        privateKey: ECPrivateKey,
-        publicKey: ECPublicKey,
-        comment: String?,
-        passphrase: String?
-    ): String {
-        val encrypted = !passphrase.isNullOrEmpty()
-        val tw = TypesWriter()
-
-        // Determine curve name and key type
-        val fieldSize = publicKey.params.curve.field.fieldSize
-        val (curveName, keyType) = when (fieldSize) {
-            256 -> "nistp256" to "ecdsa-sha2-nistp256"
-            384 -> "nistp384" to "ecdsa-sha2-nistp384"
-            521 -> "nistp521" to "ecdsa-sha2-nistp521"
-            else -> throw InvalidKeyException("Unsupported EC curve size: $fieldSize")
-        }
-
-        // Magic header
-        tw.writeBytes(OPENSSH_KEY_V1_MAGIC.toByteArray(Charsets.US_ASCII))
-
-        // Generate salt for encryption if needed
-        val salt = if (encrypted) {
-            ByteArray(OPENSSH_BCRYPT_SALT_SIZE).also { SecureRandom().nextBytes(it) }
-        } else null
-
-        // Cipher name
-        tw.writeString(if (encrypted) OPENSSH_CIPHER_AES256_CTR else "none")
-
-        // KDF name
-        tw.writeString(if (encrypted) OPENSSH_KDF_BCRYPT else "none")
-
-        // KDF options
-        if (encrypted && salt != null) {
-            val kdfOptions = TypesWriter()
-            kdfOptions.writeString(salt, 0, salt.size)
-            kdfOptions.writeUINT32(OPENSSH_BCRYPT_ROUNDS)
-            tw.writeString(kdfOptions.getBytes(), 0, kdfOptions.length())
-        } else {
-            tw.writeString("")
-        }
-
-        // Number of keys
-        tw.writeUINT32(1)
-
-        // Encode public key point in uncompressed format (0x04 || x || y)
-        val publicPoint = ECDSASHA2Verify.encodeECPoint(publicKey.w, publicKey.params.curve)
-
-        // Public key blob: key_type, curve_name, Q
-        val pubKeyBlob = TypesWriter()
-        pubKeyBlob.writeString(keyType)
-        pubKeyBlob.writeString(curveName)
-        pubKeyBlob.writeString(publicPoint, 0, publicPoint.size)
-        tw.writeString(pubKeyBlob.getBytes(), 0, pubKeyBlob.length())
-
-        // Private key section
-        val privateSection = TypesWriter()
-        val checkInt = SecureRandom().nextInt()
-        privateSection.writeUINT32(checkInt)
-        privateSection.writeUINT32(checkInt)
-
-        privateSection.writeString(keyType)
-        privateSection.writeString(curveName)
-        privateSection.writeString(publicPoint, 0, publicPoint.size)
-        privateSection.writeMPInt(privateKey.s)
-
-        privateSection.writeString(comment ?: "")
-
-        // Padding to block size (16 for encrypted, 8 for unencrypted)
-        val blockSize = if (encrypted) OPENSSH_AES_BLOCK_SIZE else 8
-        var paddingNeeded = blockSize - (privateSection.length() % blockSize)
-        if (paddingNeeded == blockSize) paddingNeeded = 0
-        for (i in 1..paddingNeeded) {
-            privateSection.writeByte(i)
-        }
-
-        // Encrypt if passphrase provided
-        val privateSectionBytes = if (encrypted && salt != null && passphrase != null) {
-            val derivedKey = deriveOpenSSHKey(passphrase, salt, OPENSSH_BCRYPT_ROUNDS)
-            val key = derivedKey.copyOfRange(0, OPENSSH_AES_KEY_SIZE)
-            val iv = derivedKey.copyOfRange(OPENSSH_AES_KEY_SIZE, OPENSSH_AES_KEY_SIZE + OPENSSH_AES_IV_SIZE)
-            encryptAesCtr(privateSection.getBytes(), key, iv)
-        } else {
-            privateSection.getBytes()
-        }
-
-        tw.writeString(privateSectionBytes, 0, privateSectionBytes.size)
-
-        return formatOpenSSHKey(tw.getBytes())
-    }
-
-    /**
-     * Formats raw key data into OpenSSH PEM format with proper line wrapping.
-     */
-    private fun formatOpenSSHKey(data: ByteArray): String {
-        val sb = StringBuilder()
-        sb.append(OPENSSH_PRIVATE_KEY_START)
-        sb.append('\n')
-
-        var i = sb.length
-        sb.append(Base64.encode(data))
-        i += 70
-        while (i < sb.length) {
-            sb.insert(i, "\n")
-            i += 71
-        }
-
-        sb.append('\n')
-        sb.append(OPENSSH_PRIVATE_KEY_END)
-        sb.append('\n')
-
-        return sb.toString()
-    }
-
-    /**
-     * Exports any supported key pair in OpenSSH format (unencrypted).
-     * @param privateKey The private key (RSA, DSA, EC, or Ed25519)
-     * @param publicKey The public key
-     * @param comment Optional comment
-     * @return The key in OpenSSH format, or null if the key type is not supported
-     */
-    fun exportOpenSSH(privateKey: PrivateKey, publicKey: PublicKey, comment: String?): String? {
-        return exportOpenSSH(privateKey, publicKey, comment, null)
-    }
-
-    /**
-     * Exports any supported key pair in OpenSSH format.
-     * @param privateKey The private key (RSA, DSA, EC, or Ed25519)
-     * @param publicKey The public key
-     * @param comment Optional comment
-     * @param passphrase Optional passphrase for encryption. If null or empty, key is unencrypted.
-     * @return The key in OpenSSH format, or null if the key type is not supported
-     */
-    fun exportOpenSSH(privateKey: PrivateKey, publicKey: PublicKey, comment: String?, passphrase: String?): String? {
-        return when {
-            privateKey is RSAPrivateCrtKey && publicKey is RSAPublicKey ->
-                exportOpenSSHRSA(privateKey, publicKey, comment, passphrase)
-            privateKey is DSAPrivateKey && publicKey is DSAPublicKey ->
-                exportOpenSSHDSA(privateKey, publicKey, comment, passphrase)
-            privateKey is ECPrivateKey && publicKey is ECPublicKey ->
-                exportOpenSSHEC(privateKey, publicKey, comment, passphrase)
-            privateKey is Ed25519PrivateKey && publicKey is Ed25519PublicKey ->
-                exportOpenSSHEd25519(privateKey, publicKey, comment, passphrase)
-            else -> null
-        }
-    }
 
     private val HEX_DIGITS = charArrayOf(
         '0', '1', '2', '3', '4', '5', '6',

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -112,6 +112,7 @@
 	<string name="pubkey_copy_private">"Copy private key"</string>
 	<string name="pubkey_copy_private_openssh">"Copy private key (OpenSSH)"</string>
 	<string name="pubkey_copy_private_pem">"Copy private key (PEM)"</string>
+	<string name="pubkey_copy_private_encrypted">"Copy private key (encrypted)"</string>
 	<string name="pubkey_copy_public">"Copy public key"</string>
 	<string name="pubkey_export_private">"Export private key"</string>
 	<string name="pubkey_export_private_openssh">"Export private key (OpenSSH)"</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -113,6 +113,9 @@
 	<string name="pubkey_copy_private_openssh">"Copy private key (OpenSSH)"</string>
 	<string name="pubkey_copy_private_pem">"Copy private key (PEM)"</string>
 	<string name="pubkey_copy_public">"Copy public key"</string>
+	<string name="pubkey_export_private">"Export private key"</string>
+	<string name="pubkey_export_private_openssh">"Export private key (OpenSSH)"</string>
+	<string name="pubkey_export_private_pem">"Export private key (PEM)"</string>
 	<!-- Note that the '\n' just splits lines, so it's actually "create or import" -->
 	<string name="pubkey_list_empty">"Tap \"Menu\" to create"\n"or import key pairs."</string>
 	<string name="pubkey_unknown_format">"Unknown format"</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -110,6 +110,8 @@
 	<string name="pubkey_touch_hint">"In order to assure randomness during the key generation, move your finger randomly over the box below."</string>
 	<string name="pubkey_generating">"Generating key pair…"</string>
 	<string name="pubkey_copy_private">"Copy private key"</string>
+	<string name="pubkey_copy_private_openssh">"Copy private key (OpenSSH)"</string>
+	<string name="pubkey_copy_private_pem">"Copy private key (PEM)"</string>
 	<string name="pubkey_copy_public">"Copy public key"</string>
 	<!-- Note that the '\n' just splits lines, so it's actually "create or import" -->
 	<string name="pubkey_list_empty">"Tap \"Menu\" to create"\n"or import key pairs."</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -116,6 +116,14 @@
 	<string name="pubkey_export_private">"Export private key"</string>
 	<string name="pubkey_export_private_openssh">"Export private key (OpenSSH)"</string>
 	<string name="pubkey_export_private_pem">"Export private key (PEM)"</string>
+	<string name="pubkey_export_private_encrypted">"Export private key (encrypted)"</string>
+	<string name="pubkey_export_set_passphrase">"Set export passphrase"</string>
+	<string name="pubkey_export_passphrase_message">"Enter a passphrase to encrypt the exported key"</string>
+	<string name="pubkey_export_confirm_passphrase">"Confirm passphrase"</string>
+	<string name="pubkey_export_passphrase_mismatch">"Passphrases do not match"</string>
+	<string name="pubkey_import_encrypted_title">"Import encrypted key"</string>
+	<string name="pubkey_import_encrypted_message">"Enter password to decrypt key '%1$s' (%2$s)"</string>
+	<string name="pubkey_import_button">"Import"</string>
 	<!-- Note that the '\n' just splits lines, so it's actually "create or import" -->
 	<string name="pubkey_list_empty">"Tap \"Menu\" to create"\n"or import key pairs."</string>
 	<string name="pubkey_unknown_format">"Unknown format"</string>

--- a/app/src/test/java/org/connectbot/util/PubkeyUtilsTest.kt
+++ b/app/src/test/java/org/connectbot/util/PubkeyUtilsTest.kt
@@ -18,16 +18,11 @@ package org.connectbot.util
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.connectbot.util.PubkeyUtils.encodeHex
-import org.connectbot.util.PubkeyUtils.getAlgorithmForOid
-import org.connectbot.util.PubkeyUtils.getOidFromPkcs8Encoded
-import org.connectbot.util.PubkeyUtils.getRSAPublicExponentFromPkcs8Encoded
 import org.connectbot.util.PubkeyUtils.recoverKeyPair
 import org.junit.Assert
-import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.math.BigInteger
-import java.security.NoSuchAlgorithmException
 import java.security.PrivateKey
 import java.security.interfaces.DSAPublicKey
 import java.security.interfaces.ECPublicKey
@@ -48,73 +43,6 @@ class PubkeyUtilsTest {
             "Encoded hex should match expected",
             encodeHex(input), expected
         )
-    }
-
-    @Test
-    @Throws(Exception::class)
-    fun getOidFromPkcs8Encoded_Ec_NistP256() {
-        Assert.assertEquals("1.2.840.10045.2.1", getOidFromPkcs8Encoded(EC_KEY_PKCS8))
-    }
-
-    @Test
-    @Throws(Exception::class)
-    fun getOidFromPkcs8Encoded_Rsa() {
-        Assert.assertEquals("1.2.840.113549.1.1.1", getOidFromPkcs8Encoded(RSA_KEY_PKCS8))
-    }
-
-    @Test
-    @Throws(Exception::class)
-    fun getOidFromPkcs8Encoded_Dsa() {
-        Assert.assertEquals("1.2.840.10040.4.1", getOidFromPkcs8Encoded(DSA_KEY_PKCS8))
-    }
-
-    @Test
-    @Throws(Exception::class)
-    fun getOidFromPkcs8Encoded_NotCorrectDer_Failure() {
-        try {
-            getOidFromPkcs8Encoded(byteArrayOf(0x30, 0x01, 0x00))
-            Assert.fail("Should throw NoSuchAlgorithmException")
-        } catch (expected: NoSuchAlgorithmException) {
-        }
-    }
-
-    @Test
-    @Throws(Exception::class)
-    fun getAlgorithmForOid_Ecdsa() {
-        Assert.assertEquals("EC", getAlgorithmForOid("1.2.840.10045.2.1"))
-    }
-
-    @Test
-    @Throws(Exception::class)
-    fun getAlgorithmForOid_Rsa() {
-        Assert.assertEquals("RSA", getAlgorithmForOid("1.2.840.113549.1.1.1"))
-    }
-
-    @Test
-    @Ignore
-    @Throws(Exception::class)
-    fun getAlgorithmForOid_Dsa() {
-        Assert.assertEquals("DSA", getAlgorithmForOid("1.2.840.10040.4.1"))
-    }
-
-    @Test
-    @Throws(Exception::class)
-    fun getAlgorithmForOid_NullInput_Failure() {
-        try {
-            getAlgorithmForOid(null)
-            Assert.fail("Should throw NoSuchAlgorithmException")
-        } catch (expected: NoSuchAlgorithmException) {
-        }
-    }
-
-    @Test
-    @Throws(Exception::class)
-    fun getAlgorithmForOid_UnknownOid_Failure() {
-        try {
-            getAlgorithmForOid("1.3.66666.2000.4000.1")
-            Assert.fail("Should throw NoSuchAlgorithmException")
-        } catch (expected: NoSuchAlgorithmException) {
-        }
     }
 
     @Test
@@ -166,12 +94,6 @@ class PubkeyUtilsTest {
         override fun getFormat(): String? {
             throw UnsupportedOperationException()
         }
-    }
-
-    @Test
-    @Throws(Exception::class)
-    fun getRSAPublicExponentFromPkcs8Encoded_Success() {
-        Assert.assertEquals(RSA_KEY_E, getRSAPublicExponentFromPkcs8Encoded(RSA_KEY_PKCS8))
     }
 
     companion object {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,7 +23,7 @@ lifecycleViewModel = "2.10.0"
 navigationCompose = "2.9.6"
 activityCompose = "1.12.1"
 
-sshlib = "2.2.32"
+sshlib = "2.2.33"
 termlib = "0.0.8"
 playServicesBasement = "18.9.0"
 conscrypt = "2.5.3"


### PR DESCRIPTION
This PR resolves #571, #686, and some part of #968 and #1643. Encrypted export is only supported for the OpenSSH key format. 
This PR introduces OpenSSH-format key export and import functionality, including exporting to and importing from files. 