### PR TITLE
Update termlib to 0.0.8

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,7 +22,7 @@ navigationCompose = "2.9.6"
 activityCompose = "1.12.1"
 
 sshlib = "2.2.32"
-termlib = "0.0.7"
+termlib = "0.0.8"
 playServicesBasement = "18.9.0"
 conscrypt = "2.5.3"
 conscryptOpenJdk = "2.5.2"


### PR DESCRIPTION
This fixes the hardware keyboard double-applying CTRL that @leonerd reported on IRC.