### PR TITLE
Show IME after biometric prompt completes

### DIFF
--- a/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
@@ -95,6 +95,7 @@ import org.connectbot.ui.components.ResizeDialog
 import org.connectbot.ui.components.TERMINAL_KEYBOARD_HEIGHT_DP
 import org.connectbot.ui.components.TerminalKeyboard
 import org.connectbot.ui.components.UrlScanDialog
+import org.connectbot.service.PromptRequest
 
 /**
  * Check if a hardware keyboard is currently attached to the device.
@@ -206,6 +207,21 @@ fun ConsoleScreen(
             showSoftwareKeyboard = false
         }
         imeVisible = systemImeVisible
+    }
+
+    // Get current prompt state to check if biometric prompt is active
+    val currentBridgeForPrompt = uiState.bridges.getOrNull(uiState.currentBridgeIndex)
+    val promptState by currentBridgeForPrompt?.promptManager?.promptState?.collectAsState()
+        ?: remember { mutableStateOf<PromptRequest?>(null) }
+    var wasBiometricPromptActive by remember { mutableStateOf(false) }
+    val isBiometricPromptActive = promptState is PromptRequest.BiometricPrompt
+
+    // Show software keyboard after biometric prompt completes (unless hardware keyboard is connected)
+    LaunchedEffect(isBiometricPromptActive) {
+        if (wasBiometricPromptActive && !isBiometricPromptActive && !hasHardwareKeyboard) {
+            showSoftwareKeyboard = true
+        }
+        wasBiometricPromptActive = isBiometricPromptActive
     }
 
     // Unified auto-hide timer for both keyboard and title bar


### PR DESCRIPTION
When authenticating with biometric keys, the system's BiometricPrompt dialog dismisses the IME. This adds a LaunchedEffect that monitors the completion of the biometric prompt and automatically shows the software keyboard afterward (unless a hardware keyboard is connected). 
If my understanding is correct, actually, "dismissed" might not be a proper description. For passphrase-encrypted keys, this app shows the IME to enter the pass and keeps it open, so it stays on the screen. For fingerprint-encrypted keys, the IME is not required to unlock, so it does not appear. This PR pops the IME after authentication to fix this behavior. 

Fixes #1689

🤖 Generated with [Claude Code](https://claude.com/claude-code)