### PR TITLE
MINOR FIX: Remove unused jbcrypt dependency and dead Tink code

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -228,8 +228,7 @@ tasks.withType<DependencyUpdatesTask>().configureEach {
 dependencies {
     implementation(libs.sshlib)
     implementation(libs.termlib)
-    implementation("com.google.crypto.tink:tink:1.19.0") // For Ed25519 key derivation
-    implementation("org.connectbot:jbcrypt:1.0.2") // For bcrypt_pbkdf in OpenSSH encrypted keys
+    implementation("com.google.crypto.tink:tink:1.19.0") // For Ed25519 key derivation (required by sshlib)
     implementation(libs.androidx.media3.common.ktx)
     implementation(libs.androidx.navigation.testing)
     implementation(libs.androidx.ui)

--- a/app/src/main/java/org/connectbot/util/PubkeyUtils.kt
+++ b/app/src/main/java/org/connectbot/util/PubkeyUtils.kt
@@ -19,9 +19,7 @@ package org.connectbot.util
 import android.util.Log
 import com.trilead.ssh2.crypto.Base64
 import com.trilead.ssh2.crypto.PEMDecoder
-import com.google.crypto.tink.subtle.Ed25519Sign
 import com.trilead.ssh2.crypto.OpenSSHKeyEncoder
-import com.trilead.ssh2.crypto.keys.Ed25519PrivateKey
 import com.trilead.ssh2.crypto.keys.Ed25519Provider
 import com.trilead.ssh2.crypto.keys.Ed25519PublicKey
 import com.trilead.ssh2.signature.DSASHA1Verify
@@ -47,7 +45,6 @@ import java.security.interfaces.ECPublicKey
 import java.security.interfaces.RSAPublicKey
 import java.security.spec.InvalidKeySpecException
 import java.security.spec.InvalidParameterSpecException
-import java.security.spec.KeySpec
 import java.security.spec.PKCS8EncodedKeySpec
 import java.security.spec.X509EncodedKeySpec
 import java.util.Arrays
@@ -170,27 +167,6 @@ object PubkeyUtils {
                 throw BadPasswordException()
             }
         }
-    }
-
-    @JvmStatic
-    @Throws(NoSuchAlgorithmException::class, InvalidKeySpecException::class)
-    fun recoverKeyPair(encoded: ByteArray): KeyPair {
-        val algo = OpenSSHKeyEncoder.getAlgorithmForOid(OpenSSHKeyEncoder.getOidFromPkcs8Encoded(encoded))
-
-        val privKeySpec: KeySpec = PKCS8EncodedKeySpec(encoded)
-
-        val kf = KeyFactory.getInstance(algo)
-        val priv = kf.generatePrivate(privKeySpec)
-
-        // Ed25519 requires special handling to derive the public key
-        if (priv is Ed25519PrivateKey) {
-            val seed = priv.seed
-            val tinkKeyPair = Ed25519Sign.KeyPair.newKeyPairFromSeed(seed)
-            val publicKey = Ed25519PublicKey(tinkKeyPair.publicKey)
-            return KeyPair(publicKey, priv)
-        }
-
-        return KeyPair(OpenSSHKeyEncoder.recoverPublicKey(kf, priv), priv)
     }
 
     /*

--- a/app/src/test/java/org/connectbot/util/PubkeyUtilsTest.kt
+++ b/app/src/test/java/org/connectbot/util/PubkeyUtilsTest.kt
@@ -17,8 +17,8 @@
 package org.connectbot.util
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.trilead.ssh2.crypto.OpenSSHKeyEncoder.recoverKeyPair
 import org.connectbot.util.PubkeyUtils.encodeHex
-import org.connectbot.util.PubkeyUtils.recoverKeyPair
 import org.junit.Assert
 import org.junit.Test
 import org.junit.runner.RunWith


### PR DESCRIPTION
Just remove the garbage introduced in #1688 but not used in the latest main. 
- Remove explicit jbcrypt dependency (transitive from sshlib)
- Remove unused recoverKeyPair() from PubkeyUtils (use sshlib's OpenSSHKeyEncoder.recoverKeyPair directly)
- Remove unused Tink and Ed25519PrivateKey imports from PubkeyUtils

🤖 Generated with [Claude Code](https://claude.com/claude-code)