### PR TITLE
Multiple sessions

### DIFF
--- a/app/src/androidTest/java/org/connectbot/service/TerminalBridgeWriteSerializationTest.kt
+++ b/app/src/androidTest/java/org/connectbot/service/TerminalBridgeWriteSerializationTest.kt
@@ -182,7 +182,7 @@ class TerminalBridgeWriteSerializationTest {
                 main = Dispatchers.Main,
             )
 
-            val bridge = TerminalBridge(manager, host, dispatchers)
+            val bridge = TerminalBridge(manager, host, sessionId = 1L, dispatchers = dispatchers)
             try {
                 val transport = LossyNonThreadSafeTransport()
                 bridge.transport = transport

--- a/app/src/main/java/org/connectbot/data/SchemaBasedExporter.kt
+++ b/app/src/main/java/org/connectbot/data/SchemaBasedExporter.kt
@@ -352,15 +352,7 @@ class SchemaBasedExporter(
             }
 
             when (field.affinity) {
-                "INTEGER" -> {
-                    val value = row.get(field.fieldPath)
-                    val longValue = when (value) {
-                        is Boolean -> if (value) 1L else 0L
-                        is Number -> value.toLong()
-                        else -> row.getLong(field.fieldPath)
-                    }
-                    values.put(field.columnName, longValue)
-                }
+                "INTEGER" -> values.put(field.columnName, row.getLong(field.fieldPath))
 
                 "TEXT" -> values.put(field.columnName, row.getString(field.fieldPath))
 

--- a/app/src/main/java/org/connectbot/data/SchemaBasedExporter.kt
+++ b/app/src/main/java/org/connectbot/data/SchemaBasedExporter.kt
@@ -352,7 +352,15 @@ class SchemaBasedExporter(
             }
 
             when (field.affinity) {
-                "INTEGER" -> values.put(field.columnName, row.getLong(field.fieldPath))
+                "INTEGER" -> {
+                    val value = row.get(field.fieldPath)
+                    val longValue = when (value) {
+                        is Boolean -> if (value) 1L else 0L
+                        is Number -> value.toLong()
+                        else -> row.getLong(field.fieldPath)
+                    }
+                    values.put(field.columnName, longValue)
+                }
 
                 "TEXT" -> values.put(field.columnName, row.getString(field.fieldPath))
 

--- a/app/src/main/java/org/connectbot/service/TerminalBridge.kt
+++ b/app/src/main/java/org/connectbot/service/TerminalBridge.kt
@@ -154,8 +154,13 @@ class TerminalBridge {
 
     private val dispatchers: CoroutineDispatchers
 
-    /* package */
-    var transport: AbsTransport? = null
+    /**
+     * Unique session identifier for this bridge.
+     * Used to distinguish multiple sessions to the same host.
+     */
+    val sessionId: Long
+
+    /* package */ var transport: AbsTransport? = null
 
     val defaultPaint: Paint
 
@@ -251,10 +256,15 @@ class TerminalBridge {
      * Create new terminal bridge with following parameters. We will immediately
      * launch thread to start SSH connection and handle any hostkey verification
      * and password authentication.
+     *
+     * @param manager The TerminalManager service
+     * @param host The host configuration for this connection
+     * @param sessionId Unique session identifier (for multi-session support)
      */
-    constructor(manager: TerminalManager, host: Host, dispatchers: CoroutineDispatchers) {
+    constructor(manager: TerminalManager, host: Host, sessionId: Long, dispatchers: CoroutineDispatchers) {
         this.manager = manager
         this.host = host
+        this.sessionId = sessionId
         this.dispatchers = dispatchers
 
         // Load profile for this host (always returns a profile, defaulting to Default profile)

--- a/app/src/main/java/org/connectbot/service/TerminalBridge.kt
+++ b/app/src/main/java/org/connectbot/service/TerminalBridge.kt
@@ -160,7 +160,8 @@ class TerminalBridge {
      */
     val sessionId: Long
 
-    /* package */ var transport: AbsTransport? = null
+    /* package */
+    var transport: AbsTransport? = null
 
     val defaultPaint: Paint
 

--- a/app/src/main/java/org/connectbot/service/TerminalManager.kt
+++ b/app/src/main/java/org/connectbot/service/TerminalManager.kt
@@ -93,8 +93,10 @@ class TerminalManager :
 
     // Maps for multi-session support: hostId -> list of bridges
     private val hostBridgesMap: MutableMap<Long, MutableList<WeakReference<TerminalBridge>>> = HashMap()
+
     // Quick lookup by session ID
     private val bridgesBySessionId: MutableMap<Long, WeakReference<TerminalBridge>> = HashMap()
+
     // Track last-used session per host for navigation
     private val lastUsedSessionByHost: MutableMap<Long, Long> = HashMap()
 
@@ -104,6 +106,7 @@ class TerminalManager :
     // Legacy maps for backwards compatibility (deprecated)
     @Deprecated("Use hostBridgesMap instead")
     private val hostBridgeMap: MutableMap<Host, WeakReference<TerminalBridge>> = HashMap()
+
     @Deprecated("Use getConnectedBridges instead")
     private val nicknameBridgeMap: MutableMap<String, WeakReference<TerminalBridge>> = HashMap()
 
@@ -128,12 +131,10 @@ class TerminalManager :
     private val _hostStatusChanged = MutableSharedFlow<Unit>(replay = 0, extraBufferCapacity = 10)
     val hostStatusChangedFlow: SharedFlow<Unit> = _hostStatusChanged.asSharedFlow()
 
-    private val _serviceErrors =
-        MutableSharedFlow<ServiceError>(replay = 0, extraBufferCapacity = 10)
+    private val _serviceErrors = MutableSharedFlow<ServiceError>(replay = 0, extraBufferCapacity = 10)
     val serviceErrors: SharedFlow<ServiceError> = _serviceErrors.asSharedFlow()
 
-    private val _loadedKeysChanged =
-        MutableSharedFlow<Set<String>>(replay = 1, extraBufferCapacity = 1)
+    private val _loadedKeysChanged = MutableSharedFlow<Set<String>>(replay = 1, extraBufferCapacity = 1)
     val loadedKeysChangedFlow: SharedFlow<Set<String>> = _loadedKeysChanged.asSharedFlow()
 
     // Encrypted keys marked "unlock at startup" that still need a passphrase from the user.
@@ -552,9 +553,7 @@ class TerminalManager :
      * @param hostId the database ID of the host
      * @return true if at least one session is connected
      */
-    fun isHostConnected(hostId: Long): Boolean {
-        return getSessionCount(hostId) > 0
-    }
+    fun isHostConnected(hostId: Long): Boolean = getSessionCount(hostId) > 0
 
     /**
      * Called by child bridge when somehow it's been disconnected.
@@ -621,8 +620,7 @@ class TerminalManager :
 
     private fun emitLoadedKeysChanged() {
         scope.launch {
-            val keys = HashSet(loadedKeypairs.keys)
-            _loadedKeysChanged.emit(keys)
+            _loadedKeysChanged.emit(loadedKeypairs.keys.toSet())
         }
     }
 
@@ -771,11 +769,7 @@ class TerminalManager :
 
         loadedKeypairs[pubkey.nickname] = keyHolder
 
-        Timber.d(
-            "Added biometric key '%s' to in-memory cache (expires in %d seconds)",
-            pubkey.nickname,
-            BIOMETRIC_AUTH_VALIDITY_SECONDS,
-        )
+        Timber.d("Added biometric key '%s' to in-memory cache (expires in %d seconds)", pubkey.nickname, BIOMETRIC_AUTH_VALIDITY_SECONDS)
         emitLoadedKeysChanged()
         return BiometricKeyResult.Success
     }
@@ -884,29 +878,23 @@ class TerminalManager :
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        /*
-         * We want this service to continue running until it is explicitly
-         * stopped, so return sticky.
-         */
+		/*
+		 * We want this service to continue running until it is explicitly
+		 * stopped, so return sticky.
+		 */
         return START_STICKY
     }
 
     override fun onRebind(intent: Intent) {
         super.onRebind(intent)
-        Timber.i(
-            "Someone rebound to TerminalManager with %d bridges active",
-            bridgesFlow.value.size,
-        )
+        Timber.i("Someone rebound to TerminalManager with %d bridges active", bridgesFlow.value.size)
         isUiBound = true
         keepServiceAlive()
         setResizeAllowed(true)
     }
 
     override fun onUnbind(intent: Intent): Boolean {
-        Timber.i(
-            "Someone unbound from TerminalManager with %d bridges active",
-            bridgesFlow.value.size,
-        )
+        Timber.i("Someone unbound from TerminalManager with %d bridges active", bridgesFlow.value.size)
 
         isUiBound = false
         setResizeAllowed(true)

--- a/app/src/main/java/org/connectbot/service/TerminalManager.kt
+++ b/app/src/main/java/org/connectbot/service/TerminalManager.kt
@@ -87,7 +87,24 @@ class TerminalManager :
     private val _bridgesFlow = MutableStateFlow<List<TerminalBridge>>(emptyList())
     val bridgesFlow: StateFlow<List<TerminalBridge>> = _bridgesFlow.asStateFlow()
 
+    @Deprecated("Use bridgesFlow instead", ReplaceWith("bridgesFlow.value"))
+    val bridges: List<TerminalBridge>
+        get() = _bridges.toList()
+
+    // Maps for multi-session support: hostId -> list of bridges
+    private val hostBridgesMap: MutableMap<Long, MutableList<WeakReference<TerminalBridge>>> = HashMap()
+    // Quick lookup by session ID
+    private val bridgesBySessionId: MutableMap<Long, WeakReference<TerminalBridge>> = HashMap()
+    // Track last-used session per host for navigation
+    private val lastUsedSessionByHost: MutableMap<Long, Long> = HashMap()
+
+    // Session ID counter (starts at 1)
+    private val nextSessionId = AtomicLong(1L)
+
+    // Legacy maps for backwards compatibility (deprecated)
+    @Deprecated("Use hostBridgesMap instead")
     private val hostBridgeMap: MutableMap<Host, WeakReference<TerminalBridge>> = HashMap()
+    @Deprecated("Use getConnectedBridges instead")
     private val nicknameBridgeMap: MutableMap<String, WeakReference<TerminalBridge>> = HashMap()
 
     private val _disconnected = ArrayList<Host>()
@@ -326,23 +343,38 @@ class TerminalManager :
     }
 
     /**
+     * Generate a unique session ID for a new bridge.
+     */
+    private fun generateSessionId(): Long = nextSessionId.getAndIncrement()
+
+    /**
      * Open a new SSH session using the given parameters.
+     * Multiple sessions to the same host are now allowed.
      */
     private fun openConnection(host: Host): TerminalBridge {
-        // throw exception if terminal already open
-        if (getConnectedBridge(host) != null) {
-            throw IllegalArgumentException("Connection already open for that nickname")
-        }
-
-        val bridge = TerminalBridge(this, host, dispatchers)
+        val sessionId = generateSessionId()
+        val bridge = TerminalBridge(this, host, sessionId, dispatchers)
         bridge.setOnDisconnectedListener(this)
         bridge.startConnection()
 
         synchronized(_bridges) {
             _bridges.add(bridge)
             val wr = WeakReference(bridge)
+
+            // Add to multi-session maps
+            val hostBridges = hostBridgesMap.getOrPut(host.id) { mutableListOf() }
+            hostBridges.add(wr)
+            bridgesBySessionId[sessionId] = wr
+
+            // Mark as last-used session for this host
+            lastUsedSessionByHost[host.id] = sessionId
+
+            // Legacy maps (for backwards compatibility)
+            @Suppress("DEPRECATION")
             hostBridgeMap[bridge.host] = wr
+            @Suppress("DEPRECATION")
             nicknameBridgeMap[bridge.host.nickname] = wr
+
             _bridgesFlow.value = _bridges.toList()
         }
 
@@ -438,9 +470,90 @@ class TerminalManager :
      * @param nickname
      * @return TerminalBridge that matches nickname
      */
+    @Deprecated("Use getConnectedBridges(hostId) for multi-session support")
     fun getConnectedBridge(nickname: String?): TerminalBridge? {
+        @Suppress("DEPRECATION")
         val wr = nicknameBridgeMap[nickname ?: return null]
         return wr?.get()
+    }
+
+    /**
+     * Get all connected bridges for a given host ID.
+     * Supports multiple sessions per host.
+     *
+     * @param hostId the database ID of the host
+     * @return List of connected TerminalBridge objects for this host
+     */
+    fun getConnectedBridges(hostId: Long): List<TerminalBridge> {
+        synchronized(_bridges) {
+            return hostBridgesMap[hostId]?.mapNotNull { it.get() } ?: emptyList()
+        }
+    }
+
+    /**
+     * Get a bridge by its session ID.
+     *
+     * @param sessionId the unique session identifier
+     * @return TerminalBridge with that session ID, or null if not found
+     */
+    fun getBridgeBySessionId(sessionId: Long): TerminalBridge? {
+        synchronized(_bridges) {
+            return bridgesBySessionId[sessionId]?.get()
+        }
+    }
+
+    /**
+     * Get the number of active sessions for a host.
+     *
+     * @param hostId the database ID of the host
+     * @return number of active sessions
+     */
+    fun getSessionCount(hostId: Long): Int {
+        synchronized(_bridges) {
+            return hostBridgesMap[hostId]?.count { it.get() != null } ?: 0
+        }
+    }
+
+    /**
+     * Get the last-used bridge for a host.
+     * Returns the most recently opened or interacted-with session.
+     *
+     * @param hostId the database ID of the host
+     * @return the last-used TerminalBridge, or the first available if none tracked
+     */
+    fun getLastUsedBridge(hostId: Long): TerminalBridge? {
+        synchronized(_bridges) {
+            val lastSessionId = lastUsedSessionByHost[hostId]
+            if (lastSessionId != null) {
+                val bridge = bridgesBySessionId[lastSessionId]?.get()
+                if (bridge != null) return bridge
+            }
+            // Fallback to first available session
+            return hostBridgesMap[hostId]?.firstNotNullOfOrNull { it.get() }
+        }
+    }
+
+    /**
+     * Mark a session as recently used.
+     * Called when user interacts with a session.
+     *
+     * @param sessionId the session to mark as used
+     */
+    fun markSessionUsed(sessionId: Long) {
+        synchronized(_bridges) {
+            val bridge = bridgesBySessionId[sessionId]?.get() ?: return
+            lastUsedSessionByHost[bridge.host.id] = sessionId
+        }
+    }
+
+    /**
+     * Check if any sessions are connected for a host.
+     *
+     * @param hostId the database ID of the host
+     * @return true if at least one session is connected
+     */
+    fun isHostConnected(hostId: Long): Boolean {
+        return getSessionCount(hostId) > 0
     }
 
     /**
@@ -448,13 +561,35 @@ class TerminalManager :
      */
     override fun onDisconnected(bridge: TerminalBridge) {
         var shouldHideRunningNotification = false
-        Timber.d("Bridge Disconnected. Removing it.")
+        Timber.d("Bridge Disconnected. Removing it. SessionId=${bridge.sessionId}")
 
         synchronized(_bridges) {
             // remove this bridge from our list
             _bridges.remove(bridge)
 
+            // Remove from multi-session maps
+            bridgesBySessionId.remove(bridge.sessionId)
+            hostBridgesMap[bridge.host.id]?.removeIf { it.get() == bridge || it.get() == null }
+            // Clean up empty lists
+            if (hostBridgesMap[bridge.host.id]?.isEmpty() == true) {
+                hostBridgesMap.remove(bridge.host.id)
+            }
+
+            // Update last-used if this was the last-used session
+            if (lastUsedSessionByHost[bridge.host.id] == bridge.sessionId) {
+                // Set to another session if one exists, or remove
+                val remaining = hostBridgesMap[bridge.host.id]?.mapNotNull { it.get() }
+                if (remaining.isNullOrEmpty()) {
+                    lastUsedSessionByHost.remove(bridge.host.id)
+                } else {
+                    lastUsedSessionByHost[bridge.host.id] = remaining.last().sessionId
+                }
+            }
+
+            // Legacy maps cleanup
+            @Suppress("DEPRECATION")
             hostBridgeMap.remove(bridge.host)
+            @Suppress("DEPRECATION")
             nicknameBridgeMap.remove(bridge.host.nickname)
 
             if (bridge.isUsingNetwork()) {

--- a/app/src/main/java/org/connectbot/service/TerminalManager.kt
+++ b/app/src/main/java/org/connectbot/service/TerminalManager.kt
@@ -1,6 +1,6 @@
 /*
  * ConnectBot: simple, powerful, open-source SSH client for Android
- * Copyright 2025 Kenny Root
+ * Copyright 2025-2026 Kenny Root
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
@@ -56,6 +56,7 @@ import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Link
 import androidx.compose.material.icons.filled.LinkOff
 import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.OpenInNew
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.SwapHoriz
 import androidx.compose.material3.AlertDialog
@@ -68,12 +69,14 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.PrimaryTabRow
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.ScaffoldDefaults
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult
+import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
@@ -113,6 +116,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.withLink
 import androidx.compose.ui.unit.dp
@@ -914,6 +918,41 @@ fun ConsoleScreen(
                 .windowInsetsPadding(WindowInsets.imeAnimationTarget)
                 .onPreviewKeyEvent(handleShortcut),
         ) {
+            if (hasMultipleSessions) {
+                PrimaryTabRow(
+                    selectedTabIndex = uiState.currentBridgeIndex,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    uiState.bridges.forEachIndexed { index, bridge ->
+                        val hostId = bridge.host.id
+                        val sessionCount = uiState.sessionCounts[hostId] ?: 1
+                        val sessionNumber = if (sessionCount > 1) {
+                            val bridgesForHost = uiState.bridges.filter { it.host.id == hostId }
+                            bridgesForHost.indexOfFirst { it.sessionId == bridge.sessionId } + 1
+                        } else {
+                            0
+                        }
+                        val tabTitle = if (sessionNumber > 0) {
+                            "${bridge.host.nickname} #$sessionNumber"
+                        } else {
+                            bridge.host.nickname
+                        }
+
+                        Tab(
+                            selected = index == uiState.currentBridgeIndex,
+                            onClick = { selectBridgePreservingKeyboard(index) },
+                            text = {
+                                Text(
+                                    tabTitle,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
+                                )
+                            },
+                        )
+                    }
+                }
+            }
+
             when {
                 uiState.isLoading -> {
                     LoadingScreen(modifier = Modifier.fillMaxSize())
@@ -938,7 +977,7 @@ fun ConsoleScreen(
                             Modifier
                         }
 
-                        key(bridge.host.id) {
+                        key(bridge.sessionId) {
                             ConsoleTerminalPage(
                                 bridge = bridge,
                                 isActive = true,
@@ -1131,10 +1170,18 @@ fun ConsoleScreen(
                                 contentDescription = stringResource(R.string.button_more_options),
                             )
                         }
+                        // Get sessions for the current host (for switch session menu)
+                        val sessionsForCurrentHost = currentBridge?.let { bridge ->
+                            uiState.bridges.filter { it.host.id == bridge.host.id }
+                        } ?: emptyList()
+                        val hasMultipleSessionsForCurrentHost = sessionsForCurrentHost.size > 1
+                        var showSwitchSessionMenu by remember { mutableStateOf(false) }
+
                         DropdownMenu(
                             expanded = showMenu,
                             onDismissRequest = {
                                 showMenu = false
+                                showSwitchSessionMenu = false
                                 // Hide title bar again after closing menu if auto-hide is enabled
                                 if (titleBarHide) {
                                     showTitleBar = false
@@ -1174,6 +1221,64 @@ fun ConsoleScreen(
                                     },
                                     enabled = uiState.currentBridgeIndex < uiState.bridges.lastIndex,
                                 )
+                            }
+
+                            // Open new session
+                            DropdownMenuItem(
+                                text = { Text(stringResource(R.string.list_host_new_session)) },
+                                onClick = {
+                                    showMenu = false
+                                    viewModel.openNewSession()
+                                },
+                                leadingIcon = {
+                                    Icon(Icons.Default.OpenInNew, contentDescription = null)
+                                },
+                                enabled = currentBridge != null,
+                            )
+
+                            // Switch session (if multiple sessions exist for current host)
+                            if (hasMultipleSessionsForCurrentHost) {
+                                Box {
+                                    DropdownMenuItem(
+                                        text = { Text(stringResource(R.string.console_menu_switch_session)) },
+                                        onClick = {
+                                            showSwitchSessionMenu = !showSwitchSessionMenu
+                                        },
+                                        leadingIcon = {
+                                            Icon(Icons.Default.SwapHoriz, contentDescription = null)
+                                        },
+                                    )
+
+                                    // Switch session submenu
+                                    DropdownMenu(
+                                        expanded = showSwitchSessionMenu,
+                                        onDismissRequest = { showSwitchSessionMenu = false },
+                                    ) {
+                                        sessionsForCurrentHost.forEachIndexed { index, bridge ->
+                                            val isCurrentSession = bridge.sessionId == currentBridge?.sessionId
+                                            DropdownMenuItem(
+                                                text = {
+                                                    Text(
+                                                        stringResource(R.string.console_menu_session_number, index + 1),
+                                                        fontWeight = if (isCurrentSession) FontWeight.Bold else null,
+                                                    )
+                                                },
+                                                onClick = {
+                                                    showSwitchSessionMenu = false
+                                                    showMenu = false
+                                                    val bridgeIndex = uiState.bridges.indexOfFirst {
+                                                        it.sessionId == bridge.sessionId
+                                                    }
+                                                    if (bridgeIndex >= 0) {
+                                                        selectBridgePreservingKeyboard(bridgeIndex)
+                                                    }
+                                                    termFocusRequester.requestFocus()
+                                                },
+                                                enabled = !isCurrentSession,
+                                            )
+                                        }
+                                    }
+                                }
                             }
 
                             // Disconnect/Close

--- a/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
@@ -1054,7 +1054,7 @@ fun ConsoleScreen(
                 onConfirm = {
                     showDisconnectDialog = false
                     viewModel.disconnectCurrentSession()
-                }
+                },
             )
         }
 

--- a/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
@@ -1051,8 +1051,7 @@ fun ConsoleScreen(
         }
 
         if (showDisconnectDialog && currentBridge != null) {
-            HostDisconnectDialog(
-                host = currentBridge.host,
+            SessionDisconnectDialog(
                 onDismiss = { showDisconnectDialog = false },
                 onConfirm = {
                     showDisconnectDialog = false
@@ -1420,15 +1419,14 @@ fun ConsoleScreen(
 }
 
 @Composable
-private fun HostDisconnectDialog(
-    host: Host,
+private fun SessionDisconnectDialog(
     onDismiss: () -> Unit,
     onConfirm: () -> Unit,
 ) {
     AlertDialog(
         onDismissRequest = onDismiss,
         text = {
-            Text(stringResource(R.string.disconnect_host_alert, host.nickname))
+            Text(stringResource(R.string.disconnect_session_alert))
         },
         confirmButton = {
             TextButton(

--- a/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
@@ -69,14 +69,12 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.PrimaryTabRow
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.ScaffoldDefaults
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult
-import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
@@ -916,41 +914,6 @@ fun ConsoleScreen(
                 .windowInsetsPadding(WindowInsets.imeAnimationTarget)
                 .onPreviewKeyEvent(handleShortcut),
         ) {
-            if (hasMultipleSessions) {
-                PrimaryTabRow(
-                    selectedTabIndex = uiState.currentBridgeIndex,
-                    modifier = Modifier.fillMaxWidth(),
-                ) {
-                    uiState.bridges.forEachIndexed { index, bridge ->
-                        val hostId = bridge.host.id
-                        val sessionCount = uiState.sessionCounts[hostId] ?: 1
-                        val sessionNumber = if (sessionCount > 1) {
-                            val bridgesForHost = uiState.bridges.filter { it.host.id == hostId }
-                            bridgesForHost.indexOfFirst { it.sessionId == bridge.sessionId } + 1
-                        } else {
-                            0
-                        }
-                        val tabTitle = if (sessionNumber > 0) {
-                            "${bridge.host.nickname} #$sessionNumber"
-                        } else {
-                            bridge.host.nickname
-                        }
-
-                        Tab(
-                            selected = index == uiState.currentBridgeIndex,
-                            onClick = { selectBridgePreservingKeyboard(index) },
-                            text = {
-                                Text(
-                                    tabTitle,
-                                    maxLines = 1,
-                                    overflow = TextOverflow.Ellipsis,
-                                )
-                            },
-                        )
-                    }
-                }
-            }
-
             when {
                 uiState.isLoading -> {
                     LoadingScreen(modifier = Modifier.fillMaxSize())
@@ -1090,13 +1053,19 @@ fun ConsoleScreen(
             val density = LocalDensity.current
             TopAppBar(
                 title = {
+                    val sessionsForHost = currentBridge?.let { bridge ->
+                        uiState.bridges.filter { it.host.id == bridge.host.id }
+                    }.orEmpty()
                     val sessionNumber = currentBridge?.let { bridge ->
-                        val bridgesForHost = uiState.bridges.filter { it.host.id == bridge.host.id }
-                        bridgesForHost.indexOfFirst { it.sessionId == bridge.sessionId } + 1
+                        sessionsForHost.indexOfFirst { it.sessionId == bridge.sessionId } + 1
                     } ?: 0
 
-                    val titleText = if (currentBridge != null && sessionNumber > 0) {
-                        "${currentBridge.host.nickname} #$sessionNumber"
+                    val titleText = if (currentBridge != null && sessionsForHost.size > 1) {
+                        stringResource(
+                            R.string.console_session_title,
+                            sessionNumber,
+                            currentBridge.host.nickname,
+                        )
                     } else {
                         currentBridge?.host?.nickname
                             ?: stringResource(R.string.console_default_title)

--- a/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
@@ -513,14 +513,12 @@ fun ConsoleScreen(
     onNavigateToSettings: () -> Unit = {},
     viewModel: ConsoleViewModel = hiltViewModel(),
 ) {
+    val currentOnNavigateBack by rememberUpdatedState(onNavigateBack)
+    val currentOnNavigateToSettings by rememberUpdatedState(onNavigateToSettings)
     val context = LocalContext.current
     val terminalManager = LocalTerminalManager.current
     val uiState by viewModel.uiState.collectAsState()
     val coroutineScope = rememberCoroutineScope()
-
-    // Capture latest callback for use in effects
-    val currentOnNavigateBack by rememberUpdatedState(onNavigateBack)
-    val currentOnNavigateToSettings by rememberUpdatedState(onNavigateToSettings)
 
     LaunchedEffect(terminalManager) {
         terminalManager?.let { viewModel.setTerminalManager(it) }

--- a/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
@@ -1093,9 +1093,19 @@ fun ConsoleScreen(
             val density = LocalDensity.current
             TopAppBar(
                 title = {
-                    Text(
+                    val sessionNumber = currentBridge?.let { bridge ->
+                        val bridgesForHost = uiState.bridges.filter { it.host.id == bridge.host.id }
+                        bridgesForHost.indexOfFirst { it.sessionId == bridge.sessionId } + 1
+                    } ?: 0
+
+                    val titleText = if (currentBridge != null && sessionNumber > 0) {
+                        "${currentBridge.host.nickname} #$sessionNumber"
+                    } else {
                         currentBridge?.host?.nickname
-                            ?: stringResource(R.string.console_default_title),
+                            ?: stringResource(R.string.console_default_title)
+                    }
+                    Text(
+                        titleText,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
                     )

--- a/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
@@ -1056,8 +1056,8 @@ fun ConsoleScreen(
                 onDismiss = { showDisconnectDialog = false },
                 onConfirm = {
                     showDisconnectDialog = false
-                    currentBridge.dispatchDisconnect(DisconnectReason.USER_REQUESTED)
-                },
+                    viewModel.disconnectAllSessionsForCurrentHost()
+                }
             )
         }
 

--- a/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
@@ -1056,7 +1056,7 @@ fun ConsoleScreen(
                 onDismiss = { showDisconnectDialog = false },
                 onConfirm = {
                     showDisconnectDialog = false
-                    viewModel.disconnectAllSessionsForCurrentHost()
+                    viewModel.disconnectCurrentSession()
                 }
             )
         }

--- a/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
@@ -1411,7 +1411,8 @@ private fun SessionDisconnectDialog(
 }
 
 @Composable
-private fun SessionPickerDialog(
+@VisibleForTesting
+internal fun SessionPickerDialog(
     bridges: List<TerminalBridge>,
     currentBridgeIndex: Int,
     onDismiss: () -> Unit,
@@ -1430,7 +1431,7 @@ private fun SessionPickerDialog(
             ) {
                 items(
                     count = bridges.size,
-                    key = { index -> bridges[index].host.id },
+                    key = { index -> bridges[index].sessionId },
                 ) { index ->
                     val bridge = bridges[index]
                     TextButton(

--- a/app/src/main/java/org/connectbot/ui/screens/console/ConsoleViewModel.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/console/ConsoleViewModel.kt
@@ -29,6 +29,7 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext

--- a/app/src/main/java/org/connectbot/ui/screens/console/ConsoleViewModel.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/console/ConsoleViewModel.kt
@@ -33,6 +33,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.connectbot.di.CoroutineDispatchers
+import org.connectbot.service.DisconnectReason
 import org.connectbot.service.TerminalBridge
 import org.connectbot.service.TerminalManager
 import org.connectbot.terminal.ProgressState
@@ -332,6 +333,8 @@ class ConsoleViewModel @Inject constructor(
         val index = _uiState.value.bridges.indexOfFirst { it.sessionId == sessionId }
         if (index >= 0) {
             selectBridge(index)
+        } else {
+            selectedSessionId = sessionId
         }
     }
 
@@ -343,7 +346,7 @@ class ConsoleViewModel @Inject constructor(
     }
 
     /**
-     * Open a new session to the current host.
+     * Open a new session to the current host and navigate to it.
      */
     fun openNewSession() {
         val currentBridge = getCurrentBridge() ?: return
@@ -352,6 +355,7 @@ class ConsoleViewModel @Inject constructor(
                 val newBridge = withContext(dispatchers.io) {
                     terminalManager?.openConnectionForHostId(currentBridge.host.id)
                 }
+                // Navigate to the new session
                 newBridge?.let { bridge ->
                     selectBridgeBySessionId(bridge.sessionId)
                 }
@@ -369,6 +373,16 @@ class ConsoleViewModel @Inject constructor(
     fun getSessionsForCurrentHost(): List<TerminalBridge> {
         val currentBridge = getCurrentBridge() ?: return emptyList()
         return _uiState.value.bridges.filter { it.host.id == currentBridge.host.id }
+    }
+
+    /**
+     * Disconnect all sessions for the current host.
+     */
+    fun disconnectAllSessionsForCurrentHost() {
+        val sessions = getSessionsForCurrentHost()
+        sessions.forEach { bridge ->
+            bridge.dispatchDisconnect(DisconnectReason.USER_REQUESTED)
+        }
     }
 
     /**

--- a/app/src/main/java/org/connectbot/ui/screens/console/ConsoleViewModel.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/console/ConsoleViewModel.kt
@@ -50,6 +50,8 @@ data class ConsoleUiState(
     // Progress state from OSC 9;4 escape sequences
     val progressState: ProgressState? = null,
     val progressValue: Int = 0,
+    // Session counts for hosts that have multiple sessions (for tab display)
+    val sessionCounts: Map<Long, Int> = emptyMap(),
 )
 
 @HiltViewModel
@@ -60,9 +62,10 @@ class ConsoleViewModel @Inject constructor(
     private val notificationPermissionHelper: NotificationPermissionHelper,
 ) : ViewModel() {
     private val hostId: Long = savedStateHandle.get<Long>("hostId") ?: -1L
+    private val initialSessionId: Long = savedStateHandle.get<Long>("sessionId") ?: -1L
     private var terminalManager: TerminalManager? = null
     private var pendingInitialHostId: Long? = hostId.takeIf { it != -1L }
-    private var selectedHostId: Long? = null
+    private var selectedSessionId: Long? = initialSessionId.takeIf { it != -1L }
 
     private val bellJobs = mutableMapOf<Long, Job>()
     private val progressJobs = mutableMapOf<Long, Job>()
@@ -154,15 +157,15 @@ class ConsoleViewModel @Inject constructor(
         jobs: MutableMap<Long, Job>,
         createJob: (TerminalBridge) -> Job,
     ) {
-        val activeHostIds = bridges.map { it.host.id }.toSet()
+        val activeSessionIds = bridges.map { it.sessionId }.toSet()
 
-        val removedIds = jobs.keys.filter { it !in activeHostIds }
-        removedIds.forEach { hostId ->
-            jobs.remove(hostId)?.cancel()
+        val removedIds = jobs.keys.filter { it !in activeSessionIds }
+        removedIds.forEach { sessionId ->
+            jobs.remove(sessionId)?.cancel()
         }
 
         bridges.forEach { bridge ->
-            jobs.getOrPut(bridge.host.id) {
+            jobs.getOrPut(bridge.sessionId) {
                 createJob(bridge)
             }
         }
@@ -189,13 +192,23 @@ class ConsoleViewModel @Inject constructor(
         updateProgressState(progressInfo)
     }
 
-    private fun findBridgeIndex(bridges: List<TerminalBridge>, bridgeHostId: Long?): Int {
+    private fun findBridgeIndexByHost(bridges: List<TerminalBridge>, bridgeHostId: Long?): Int {
         if (bridgeHostId == null) {
             return -1
         }
 
         return bridges.indexOfFirst { bridge ->
             bridge.host.id == bridgeHostId
+        }
+    }
+
+    private fun findBridgeIndexBySession(bridges: List<TerminalBridge>, bridgeSessionId: Long?): Int {
+        if (bridgeSessionId == null) {
+            return -1
+        }
+
+        return bridges.indexOfFirst { bridge ->
+            bridge.sessionId == bridgeSessionId
         }
     }
 
@@ -255,25 +268,34 @@ class ConsoleViewModel @Inject constructor(
 
     private fun updateBridges(allBridges: List<TerminalBridge>) {
         val currentState = _uiState.value
-        val selectedIndex = findBridgeIndex(allBridges, selectedHostId)
-        val requestedIndex = findBridgeIndex(allBridges, pendingInitialHostId)
-        val requestedBridgeAvailable = requestedIndex != -1
+        val selectedIndex = findBridgeIndexBySession(allBridges, selectedSessionId)
+        val requestedHostIndex = findBridgeIndexByHost(allBridges, pendingInitialHostId)
+        val lastUsedIndex = if (currentState.bridges.isEmpty() && hostId != -1L) {
+            terminalManager?.getLastUsedBridge(hostId)?.let { bridge ->
+                findBridgeIndexBySession(allBridges, bridge.sessionId)
+            } ?: -1
+        } else {
+            -1
+        }
 
         val newIndex = when {
-            requestedBridgeAvailable -> requestedIndex
             selectedIndex != -1 -> selectedIndex
+            lastUsedIndex != -1 -> lastUsedIndex
+            requestedHostIndex != -1 -> requestedHostIndex
             currentState.currentBridgeIndex >= allBridges.size -> (allBridges.size - 1).coerceAtLeast(0)
             else -> currentState.currentBridgeIndex
         }
 
-        if (requestedBridgeAvailable) {
+        if (requestedHostIndex != -1) {
             pendingInitialHostId = null
-            selectedHostId = allBridges.getOrNull(newIndex)?.host?.id
-        } else if (pendingInitialHostId == null) {
-            selectedHostId = allBridges.getOrNull(newIndex)?.host?.id
         }
 
+        selectedSessionId = allBridges.getOrNull(newIndex)?.sessionId
         val waitingForRequestedHost = pendingInitialHostId != null
+
+        // Calculate session counts for each host
+        val sessionCounts = allBridges.groupBy { it.host.id }
+            .mapValues { it.value.size }
 
         _uiState.update {
             it.copy(
@@ -281,18 +303,72 @@ class ConsoleViewModel @Inject constructor(
                 currentBridgeIndex = newIndex,
                 isLoading = waitingForRequestedHost,
                 error = null,
+                sessionCounts = sessionCounts,
             )
         }
 
         updateCurrentBridgeProgress(allBridges, newIndex)
+
+        // Mark the current session as used
+        val currentBridge = _uiState.value.bridges.getOrNull(_uiState.value.currentBridgeIndex)
+        currentBridge?.let { terminalManager?.markSessionUsed(it.sessionId) }
     }
 
     fun selectBridge(index: Int) {
         if (index in _uiState.value.bridges.indices) {
-            selectedHostId = _uiState.value.bridges[index].host.id
+            val bridge = _uiState.value.bridges[index]
+            selectedSessionId = bridge.sessionId
             _uiState.update { it.copy(currentBridgeIndex = index) }
             updateCurrentBridgeProgress()
+            // Mark the selected session as used
+            terminalManager?.markSessionUsed(bridge.sessionId)
         }
+    }
+
+    /**
+     * Select a bridge by its session ID.
+     */
+    fun selectBridgeBySessionId(sessionId: Long) {
+        val index = _uiState.value.bridges.indexOfFirst { it.sessionId == sessionId }
+        if (index >= 0) {
+            selectBridge(index)
+        }
+    }
+
+    /**
+     * Get the current bridge (if any).
+     */
+    fun getCurrentBridge(): TerminalBridge? {
+        return _uiState.value.bridges.getOrNull(_uiState.value.currentBridgeIndex)
+    }
+
+    /**
+     * Open a new session to the current host.
+     */
+    fun openNewSession() {
+        val currentBridge = getCurrentBridge() ?: return
+        viewModelScope.launch {
+            try {
+                val newBridge = withContext(dispatchers.io) {
+                    terminalManager?.openConnectionForHostId(currentBridge.host.id)
+                }
+                newBridge?.let { bridge ->
+                    selectBridgeBySessionId(bridge.sessionId)
+                }
+            } catch (e: Exception) {
+                _uiState.update {
+                    it.copy(error = e.message ?: "Failed to open new session")
+                }
+            }
+        }
+    }
+
+    /**
+     * Get all sessions for the current host (for switch session menu).
+     */
+    fun getSessionsForCurrentHost(): List<TerminalBridge> {
+        val currentBridge = getCurrentBridge() ?: return emptyList()
+        return _uiState.value.bridges.filter { it.host.id == currentBridge.host.id }
     }
 
     /**

--- a/app/src/main/java/org/connectbot/ui/screens/console/ConsoleViewModel.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/console/ConsoleViewModel.kt
@@ -29,7 +29,6 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -342,9 +341,7 @@ class ConsoleViewModel @Inject constructor(
     /**
      * Get the current bridge (if any).
      */
-    fun getCurrentBridge(): TerminalBridge? {
-        return _uiState.value.bridges.getOrNull(_uiState.value.currentBridgeIndex)
-    }
+    fun getCurrentBridge(): TerminalBridge? = _uiState.value.bridges.getOrNull(_uiState.value.currentBridgeIndex)
 
     /**
      * Open a new session to the current host and navigate to it.

--- a/app/src/main/java/org/connectbot/ui/screens/console/ConsoleViewModel.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/console/ConsoleViewModel.kt
@@ -291,8 +291,10 @@ class ConsoleViewModel @Inject constructor(
             pendingInitialHostId = null
         }
 
-        selectedSessionId = allBridges.getOrNull(newIndex)?.sessionId
         val waitingForRequestedHost = pendingInitialHostId != null
+        if (!waitingForRequestedHost) {
+            selectedSessionId = allBridges.getOrNull(newIndex)?.sessionId
+        }
 
         // Calculate session counts for each host
         val sessionCounts = allBridges.groupBy { it.host.id }

--- a/app/src/main/java/org/connectbot/ui/screens/console/ConsoleViewModel.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/console/ConsoleViewModel.kt
@@ -376,13 +376,10 @@ class ConsoleViewModel @Inject constructor(
     }
 
     /**
-     * Disconnect all sessions for the current host.
+     * Disconnect only the current session.
      */
-    fun disconnectAllSessionsForCurrentHost() {
-        val sessions = getSessionsForCurrentHost()
-        sessions.forEach { bridge ->
-            bridge.dispatchDisconnect(DisconnectReason.USER_REQUESTED)
-        }
+    fun disconnectCurrentSession() {
+        getCurrentBridge()?.dispatchDisconnect(DisconnectReason.USER_REQUESTED)
     }
 
     /**

--- a/app/src/main/java/org/connectbot/ui/screens/hostlist/HostListScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/hostlist/HostListScreen.kt
@@ -844,7 +844,7 @@ private fun HostDisconnectDialog(
         onDismissRequest = onDismiss,
         title = { Text(stringResource(R.string.list_host_disconnect)) },
         text = {
-            Text(stringResource(R.string.disconnect_host_alert, host.nickname))
+            Text(stringResource(R.string.disconnect_all_sessions_alert, host.nickname))
         },
         confirmButton = {
             TextButton(

--- a/app/src/main/java/org/connectbot/ui/screens/hostlist/HostListScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/hostlist/HostListScreen.kt
@@ -562,7 +562,7 @@ private fun HostListItem(
         ConnectionState.UNKNOWN -> Color.Transparent
     }
 
-    Box {
+    Box(modifier = modifier) {
         ListItem(
             headlineContent = {
                 Text(

--- a/app/src/main/java/org/connectbot/ui/screens/hostlist/HostListScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/hostlist/HostListScreen.kt
@@ -275,7 +275,10 @@ fun HostListScreen(
         onImportHosts = { importLauncher.launch(arrayOf("application/json")) },
         shouldShowNotificationWarning = shouldShowNotificationWarning,
         onNotificationSnackbarFinish = onNotificationSnackbarFinish,
-        onOpenNewSession = viewModel::connectToHost,
+        onOpenNewSession = { host ->
+            viewModel.connectToHost(host)
+            onNavigateToConsole(host)
+        },
         modifier = modifier,
     )
 }

--- a/app/src/main/java/org/connectbot/ui/screens/hostlist/HostListScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/hostlist/HostListScreen.kt
@@ -562,248 +562,250 @@ private fun HostListItem(
         ConnectionState.UNKNOWN -> Color.Transparent
     }
 
-    Box(modifier = modifier) {
-        ListItem(
-            headlineContent = {
-                Text(
-                    text = host.nickname,
-                    fontWeight = FontWeight.Bold,
-                )
-            },
-            supportingContent = {
-                Text("${host.protocol}://${host.hostname}:${host.port}")
-            },
-            leadingContent = {
-                Box(
-                    modifier = Modifier.size(40.dp),
-                ) {
-                    // Main host icon with colored background and border
+    Column(modifier = modifier) {
+        Box {
+            ListItem(
+                headlineContent = {
+                    Text(
+                        text = host.nickname,
+                        fontWeight = FontWeight.Bold,
+                    )
+                },
+                supportingContent = {
+                    Text("${host.protocol}://${host.hostname}:${host.port}")
+                },
+                leadingContent = {
                     Box(
-                        modifier = Modifier
-                            .size(40.dp)
-                            .background(
-                                color = parseColor(host.color),
-                                shape = CircleShape,
-                            )
-                            .border(
-                                width = 3.dp,
-                                color = borderColor,
-                                shape = CircleShape,
-                            ),
-                        contentAlignment = Alignment.Center,
+                        modifier = Modifier.size(40.dp),
                     ) {
-                        Icon(
-                            imageVector = when (host.protocol) {
-                                "ssh" -> Icons.Default.Computer
-                                "telnet" -> Icons.Default.Computer
-                                else -> Icons.Default.Link
-                            },
-                            contentDescription = when (connectionState) {
-                                ConnectionState.CONNECTED -> stringResource(R.string.image_description_connected)
-                                ConnectionState.DISCONNECTED -> stringResource(R.string.image_description_disconnected)
-                                ConnectionState.UNKNOWN -> null
-                            },
-                            tint = Color.White,
-                            modifier = Modifier.size(24.dp),
-                        )
-                    }
-
-                    // Status badge icon in lower right corner
-                    if (connectionState != ConnectionState.UNKNOWN) {
+                        // Main host icon with colored background and border
                         Box(
                             modifier = Modifier
-                                .align(Alignment.BottomEnd)
-                                .size(16.dp)
+                                .size(40.dp)
                                 .background(
-                                    color = MaterialTheme.colorScheme.surface,
+                                    color = parseColor(host.color),
+                                    shape = CircleShape,
+                                )
+                                .border(
+                                    width = 3.dp,
+                                    color = borderColor,
                                     shape = CircleShape,
                                 ),
+                            contentAlignment = Alignment.Center,
                         ) {
                             Icon(
-                                imageVector = when (connectionState) {
-                                    ConnectionState.CONNECTED -> Icons.Default.CheckCircle
-                                    ConnectionState.DISCONNECTED -> Icons.Default.Error
-                                    ConnectionState.UNKNOWN -> Icons.Default.Computer // Unreachable
+                                imageVector = when (host.protocol) {
+                                    "ssh" -> Icons.Default.Computer
+                                    "telnet" -> Icons.Default.Computer
+                                    else -> Icons.Default.Link
                                 },
-                                contentDescription = null,
-                                tint = when (connectionState) {
-                                    ConnectionState.CONNECTED -> colorResource(R.color.host_green)
-                                    ConnectionState.DISCONNECTED -> colorResource(R.color.host_red)
-                                    ConnectionState.UNKNOWN -> Color.Gray // Unreachable
+                                contentDescription = when (connectionState) {
+                                    ConnectionState.CONNECTED -> stringResource(R.string.image_description_connected)
+                                    ConnectionState.DISCONNECTED -> stringResource(R.string.image_description_disconnected)
+                                    ConnectionState.UNKNOWN -> null
                                 },
-                                modifier = Modifier.size(16.dp),
+                                tint = Color.White,
+                                modifier = Modifier.size(24.dp),
                             )
                         }
-                    }
 
-                    // Session count badge (top right corner) when multiple sessions
-                    if (sessionCount > 1) {
-                        Badge(
-                            modifier = Modifier
-                                .align(Alignment.TopEnd)
-                                .offset(x = 4.dp, y = (-4).dp),
-                        ) {
-                            Text(sessionCount.toString())
+                        // Status badge icon in lower right corner
+                        if (connectionState != ConnectionState.UNKNOWN) {
+                            Box(
+                                modifier = Modifier
+                                    .align(Alignment.BottomEnd)
+                                    .size(16.dp)
+                                    .background(
+                                        color = MaterialTheme.colorScheme.surface,
+                                        shape = CircleShape,
+                                    ),
+                            ) {
+                                Icon(
+                                    imageVector = when (connectionState) {
+                                        ConnectionState.CONNECTED -> Icons.Default.CheckCircle
+                                        ConnectionState.DISCONNECTED -> Icons.Default.Error
+                                        ConnectionState.UNKNOWN -> Icons.Default.Computer // Unreachable
+                                    },
+                                    contentDescription = null,
+                                    tint = when (connectionState) {
+                                        ConnectionState.CONNECTED -> colorResource(R.color.host_green)
+                                        ConnectionState.DISCONNECTED -> colorResource(R.color.host_red)
+                                        ConnectionState.UNKNOWN -> Color.Gray // Unreachable
+                                    },
+                                    modifier = Modifier.size(16.dp),
+                                )
+                            }
+                        }
+
+                        // Session count badge (top right corner) when multiple sessions
+                        if (sessionCount > 1) {
+                            Badge(
+                                modifier = Modifier
+                                    .align(Alignment.TopEnd)
+                                    .offset(x = 4.dp, y = (-4).dp),
+                            ) {
+                                Text(sessionCount.toString())
+                            }
                         }
                     }
-                }
-            },
-            trailingContent = {
-                if (!makingShortcut) {
-                    Box {
-                        IconButton(
-                            onClick = { showMenu = true },
-                            modifier = Modifier.testTag(HostListTestTags.itemMenuButton(host.id)),
-                        ) {
-                            Icon(Icons.Default.MoreVert, contentDescription = stringResource(R.string.button_host_options))
-                        }
-                        DropdownMenu(
-                            expanded = showMenu,
-                            onDismissRequest = { showMenu = false },
-                        ) {
-                            // Show "Open new session" option for connected hosts
-                            if (isConnected) {
+                },
+                trailingContent = {
+                    if (!makingShortcut) {
+                        Box {
+                            IconButton(
+                                onClick = { showMenu = true },
+                                modifier = Modifier.testTag(HostListTestTags.itemMenuButton(host.id)),
+                            ) {
+                                Icon(Icons.Default.MoreVert, contentDescription = stringResource(R.string.button_host_options))
+                            }
+                            DropdownMenu(
+                                expanded = showMenu,
+                                onDismissRequest = { showMenu = false },
+                            ) {
+                                // Show "Open new session" option for connected hosts
+                                if (isConnected) {
+                                    DropdownMenuItem(
+                                        text = { Text(stringResource(R.string.list_host_new_session)) },
+                                        onClick = {
+                                            showMenu = false
+                                            onOpenNewSession()
+                                        },
+                                        leadingIcon = {
+                                            Icon(Icons.Default.OpenInNew, null)
+                                        },
+                                    )
+                                }
                                 DropdownMenuItem(
-                                    text = { Text(stringResource(R.string.list_host_new_session)) },
+                                    text = { Text(stringResource(R.string.list_host_edit)) },
                                     onClick = {
                                         showMenu = false
-                                        onOpenNewSession()
+                                        onEdit()
                                     },
                                     leadingIcon = {
-                                        Icon(Icons.Default.OpenInNew, null)
+                                        Icon(Icons.Default.Edit, null)
+                                    },
+                                )
+                                DropdownMenuItem(
+                                    text = { Text(stringResource(R.string.list_host_portforwards)) },
+                                    onClick = {
+                                        showMenu = false
+                                        onPortForwards()
+                                    },
+                                    leadingIcon = {
+                                        Icon(Icons.Default.Link, null)
+                                    },
+                                )
+                                DropdownMenuItem(
+                                    text = { Text(stringResource(R.string.list_host_duplicate)) },
+                                    onClick = {
+                                        showMenu = false
+                                        onDuplicate()
+                                    },
+                                    leadingIcon = {
+                                        Icon(Icons.Default.ContentCopy, null)
+                                    },
+                                )
+                                if (host.protocol == "ssh") {
+                                    DropdownMenuItem(
+                                        text = { Text(stringResource(R.string.list_host_forget_keys)) },
+                                        onClick = {
+                                            showMenu = false
+                                            showForgetHostKeysDialog = true
+                                        },
+                                        leadingIcon = {
+                                            Icon(Icons.Default.Key, null)
+                                        },
+                                    )
+                                }
+                                DropdownMenuItem(
+                                    text = { Text(stringResource(R.string.list_host_disconnect)) },
+                                    onClick = {
+                                        showMenu = false
+                                        showDisconnectDialog = true
+                                    },
+                                    enabled = connectionState == ConnectionState.CONNECTED,
+                                    leadingIcon = {
+                                        Icon(Icons.Default.LinkOff, null)
+                                    },
+                                )
+                                DropdownMenuItem(
+                                    text = { Text(stringResource(R.string.list_host_delete)) },
+                                    onClick = {
+                                        showMenu = false
+                                        showDeleteDialog = true
+                                    },
+                                    leadingIcon = {
+                                        Icon(Icons.Default.Delete, null)
                                     },
                                 )
                             }
-                            DropdownMenuItem(
-                                text = { Text(stringResource(R.string.list_host_edit)) },
-                                onClick = {
-                                    showMenu = false
-                                    onEdit()
-                                },
-                                leadingIcon = {
-                                    Icon(Icons.Default.Edit, null)
-                                },
-                            )
-                            DropdownMenuItem(
-                                text = { Text(stringResource(R.string.list_host_portforwards)) },
-                                onClick = {
-                                    showMenu = false
-                                    onPortForwards()
-                                },
-                                leadingIcon = {
-                                    Icon(Icons.Default.Link, null)
-                                },
-                            )
-                            DropdownMenuItem(
-                                text = { Text(stringResource(R.string.list_host_duplicate)) },
-                                onClick = {
-                                    showMenu = false
-                                    onDuplicate()
-                                },
-                                leadingIcon = {
-                                    Icon(Icons.Default.ContentCopy, null)
-                                },
-                            )
-                            if (host.protocol == "ssh") {
-                                DropdownMenuItem(
-                                    text = { Text(stringResource(R.string.list_host_forget_keys)) },
-                                    onClick = {
-                                        showMenu = false
-                                        showForgetHostKeysDialog = true
-                                    },
-                                    leadingIcon = {
-                                        Icon(Icons.Default.Key, null)
-                                    },
-                                )
-                            }
-                            DropdownMenuItem(
-                                text = { Text(stringResource(R.string.list_host_disconnect)) },
-                                onClick = {
-                                    showMenu = false
-                                    showDisconnectDialog = true
-                                },
-                                enabled = connectionState == ConnectionState.CONNECTED,
-                                leadingIcon = {
-                                    Icon(Icons.Default.LinkOff, null)
-                                },
-                            )
-                            DropdownMenuItem(
-                                text = { Text(stringResource(R.string.list_host_delete)) },
-                                onClick = {
-                                    showMenu = false
-                                    showDeleteDialog = true
-                                },
-                                leadingIcon = {
-                                    Icon(Icons.Default.Delete, null)
-                                },
-                            )
                         }
                     }
-                }
-            },
-            modifier = modifier
-                .combinedClickable(
-                    onClick = onClick,
-                    onLongClick = {
-                        // Show context menu on long press for connected hosts (when not making shortcut)
-                        if (isConnected && !makingShortcut) {
-                            showLongPressMenu = true
-                        }
+                },
+                modifier = Modifier
+                    .combinedClickable(
+                        onClick = onClick,
+                        onLongClick = {
+                            // Show context menu on long press for connected hosts (when not making shortcut)
+                            if (isConnected && !makingShortcut) {
+                                showLongPressMenu = true
+                            }
+                        },
+                    )
+                    .testTag(HostListTestTags.itemRow(host.id)),
+            )
+
+            // Long-press context menu
+            DropdownMenu(
+                expanded = showLongPressMenu,
+                onDismissRequest = { showLongPressMenu = false },
+            ) {
+                DropdownMenuItem(
+                    text = { Text(stringResource(R.string.list_host_new_session)) },
+                    onClick = {
+                        showLongPressMenu = false
+                        onOpenNewSession()
+                    },
+                    leadingIcon = {
+                        Icon(Icons.Default.OpenInNew, null)
                     },
                 )
-                .testTag(HostListTestTags.itemRow(host.id)),
-        )
+            }
+        }
+        HorizontalDivider()
 
-        // Long-press context menu
-        DropdownMenu(
-            expanded = showLongPressMenu,
-            onDismissRequest = { showLongPressMenu = false },
-        ) {
-            DropdownMenuItem(
-                text = { Text(stringResource(R.string.list_host_new_session)) },
-                onClick = {
-                    showLongPressMenu = false
-                    onOpenNewSession()
-                },
-                leadingIcon = {
-                    Icon(Icons.Default.OpenInNew, null)
+        if (showDeleteDialog) {
+            HostDeleteDialog(
+                host = host,
+                onDismiss = { showDeleteDialog = false },
+                onConfirm = {
+                    showDeleteDialog = false
+                    onDelete()
                 },
             )
         }
-    }
-    HorizontalDivider()
 
-    if (showDeleteDialog) {
-        HostDeleteDialog(
-            host = host,
-            onDismiss = { showDeleteDialog = false },
-            onConfirm = {
-                showDeleteDialog = false
-                onDelete()
-            },
-        )
-    }
+        if (showDisconnectDialog) {
+            HostDisconnectDialog(
+                host = host,
+                onDismiss = { showDisconnectDialog = false },
+                onConfirm = {
+                    showDisconnectDialog = false
+                    onDisconnect()
+                },
+            )
+        }
 
-    if (showDisconnectDialog) {
-        HostDisconnectDialog(
-            host = host,
-            onDismiss = { showDisconnectDialog = false },
-            onConfirm = {
-                showDisconnectDialog = false
-                onDisconnect()
-            },
-        )
-    }
-
-    if (showForgetHostKeysDialog) {
-        ForgetHostKeysDialog(
-            host = host,
-            onDismiss = { showForgetHostKeysDialog = false },
-            onConfirm = {
-                showForgetHostKeysDialog = false
-                onForgetHostKeys()
-            },
-        )
+        if (showForgetHostKeysDialog) {
+            ForgetHostKeysDialog(
+                host = host,
+                onDismiss = { showForgetHostKeysDialog = false },
+                onConfirm = {
+                    showForgetHostKeysDialog = false
+                    onForgetHostKeys()
+                },
+            )
+        }
     }
 }
 

--- a/app/src/main/java/org/connectbot/ui/screens/hostlist/HostListScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/hostlist/HostListScreen.kt
@@ -20,15 +20,17 @@ package org.connectbot.ui.screens.hostlist
 import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
@@ -48,7 +50,9 @@ import androidx.compose.material.icons.filled.Link
 import androidx.compose.material.icons.filled.LinkOff
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.OpenInNew
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Badge
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -271,6 +275,7 @@ fun HostListScreen(
         onImportHosts = { importLauncher.launch(arrayOf("application/json")) },
         shouldShowNotificationWarning = shouldShowNotificationWarning,
         onNotificationSnackbarFinish = onNotificationSnackbarFinish,
+        onOpenNewSession = viewModel::connectToHost,
         modifier = modifier,
     )
 }
@@ -300,6 +305,7 @@ fun HostListScreenContent(
     onImportHosts: () -> Unit = {},
     shouldShowNotificationWarning: () -> Boolean = { false },
     onNotificationSnackbarFinish: () -> Unit = {},
+    onOpenNewSession: (Host) -> Unit = {},
 ) {
     var showMenu by remember { mutableStateOf(false) }
     var showDisconnectAllDialog by remember { mutableStateOf(false) }
@@ -482,6 +488,8 @@ fun HostListScreenContent(
                             HostListItem(
                                 host = host,
                                 connectionState = uiState.connectionStates[host.id] ?: ConnectionState.UNKNOWN,
+                                sessionCount = uiState.sessionCounts[host.id] ?: 0,
+                                makingShortcut = makingShortcut,
                                 onClick = {
                                     if (makingShortcut) {
                                         onSelectShortcut(host)
@@ -495,7 +503,7 @@ fun HostListScreenContent(
                                 onForgetHostKeys = { onForgetHostKeys(host) },
                                 onDisconnect = { onDisconnectHost(host) },
                                 onDelete = { onDeleteHost(host) },
-                                makingShortcut = makingShortcut,
+                                onOpenNewSession = { onOpenNewSession(host) },
                             )
                         }
                     }
@@ -515,10 +523,13 @@ fun HostListScreenContent(
     }
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun HostListItem(
     host: Host,
     connectionState: ConnectionState,
+    sessionCount: Int = 0,
+    makingShortcut: Boolean = false,
     onClick: () -> Unit,
     onEdit: () -> Unit,
     onPortForwards: () -> Unit,
@@ -526,13 +537,16 @@ private fun HostListItem(
     onForgetHostKeys: () -> Unit,
     onDisconnect: () -> Unit,
     onDelete: () -> Unit,
+    onOpenNewSession: () -> Unit = {},
     modifier: Modifier = Modifier,
-    makingShortcut: Boolean = false,
 ) {
     var showMenu by remember { mutableStateOf(false) }
     var showDeleteDialog by remember { mutableStateOf(false) }
     var showDisconnectDialog by remember { mutableStateOf(false) }
     var showForgetHostKeysDialog by remember { mutableStateOf(false) }
+    var showLongPressMenu by remember { mutableStateOf(false) }
+
+    val isConnected = connectionState == ConnectionState.CONNECTED
 
     // Determine border color based on connection state
     val borderColor = when (connectionState) {
@@ -545,7 +559,7 @@ private fun HostListItem(
         ConnectionState.UNKNOWN -> Color.Transparent
     }
 
-    Column(modifier = modifier) {
+    Box {
         ListItem(
             headlineContent = {
                 Text(
@@ -618,6 +632,17 @@ private fun HostListItem(
                             )
                         }
                     }
+
+                    // Session count badge (top right corner) when multiple sessions
+                    if (sessionCount > 1) {
+                        Badge(
+                            modifier = Modifier
+                                .align(Alignment.TopEnd)
+                                .offset(x = 4.dp, y = (-4).dp),
+                        ) {
+                            Text(sessionCount.toString())
+                        }
+                    }
                 }
             },
             trailingContent = {
@@ -633,6 +658,19 @@ private fun HostListItem(
                             expanded = showMenu,
                             onDismissRequest = { showMenu = false },
                         ) {
+                            // Show "Open new session" option for connected hosts
+                            if (isConnected) {
+                                DropdownMenuItem(
+                                    text = { Text(stringResource(R.string.list_host_new_session)) },
+                                    onClick = {
+                                        showMenu = false
+                                        onOpenNewSession()
+                                    },
+                                    leadingIcon = {
+                                        Icon(Icons.Default.OpenInNew, null)
+                                    },
+                                )
+                            }
                             DropdownMenuItem(
                                 text = { Text(stringResource(R.string.list_host_edit)) },
                                 onClick = {
@@ -700,44 +738,69 @@ private fun HostListItem(
                     }
                 }
             },
-            modifier = Modifier
-                .clickable(onClick = onClick)
+            modifier = modifier
+                .combinedClickable(
+                    onClick = onClick,
+                    onLongClick = {
+                        // Show context menu on long press for connected hosts (when not making shortcut)
+                        if (isConnected && !makingShortcut) {
+                            showLongPressMenu = true
+                        }
+                    },
+                )
                 .testTag(HostListTestTags.itemRow(host.id)),
         )
-        HorizontalDivider()
 
-        if (showDeleteDialog) {
-            HostDeleteDialog(
-                host = host,
-                onDismiss = { showDeleteDialog = false },
-                onConfirm = {
-                    showDeleteDialog = false
-                    onDelete()
+        // Long-press context menu
+        DropdownMenu(
+            expanded = showLongPressMenu,
+            onDismissRequest = { showLongPressMenu = false },
+        ) {
+            DropdownMenuItem(
+                text = { Text(stringResource(R.string.list_host_new_session)) },
+                onClick = {
+                    showLongPressMenu = false
+                    onOpenNewSession()
+                },
+                leadingIcon = {
+                    Icon(Icons.Default.OpenInNew, null)
                 },
             )
         }
+    }
+    HorizontalDivider()
 
-        if (showDisconnectDialog) {
-            HostDisconnectDialog(
-                host = host,
-                onDismiss = { showDisconnectDialog = false },
-                onConfirm = {
-                    showDisconnectDialog = false
-                    onDisconnect()
-                },
-            )
-        }
+    if (showDeleteDialog) {
+        HostDeleteDialog(
+            host = host,
+            onDismiss = { showDeleteDialog = false },
+            onConfirm = {
+                showDeleteDialog = false
+                onDelete()
+            },
+        )
+    }
 
-        if (showForgetHostKeysDialog) {
-            ForgetHostKeysDialog(
-                host = host,
-                onDismiss = { showForgetHostKeysDialog = false },
-                onConfirm = {
-                    showForgetHostKeysDialog = false
-                    onForgetHostKeys()
-                },
-            )
-        }
+    if (showDisconnectDialog) {
+        HostDisconnectDialog(
+            host = host,
+            onDismiss = { showDisconnectDialog = false },
+            onConfirm = {
+                showDisconnectDialog = false
+                onDisconnect()
+            },
+        )
+    }
+
+    if (showForgetHostKeysDialog) {
+        ForgetHostKeysDialog(
+            host = host,
+            onDismiss = { showForgetHostKeysDialog = false },
+            onConfirm = {
+                showForgetHostKeysDialog = false
+                onForgetHostKeys()
+            },
+        )
     }
 }
 

--- a/app/src/main/java/org/connectbot/ui/screens/hostlist/HostListViewModel.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/hostlist/HostListViewModel.kt
@@ -31,6 +31,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.connectbot.R

--- a/app/src/main/java/org/connectbot/ui/screens/hostlist/HostListViewModel.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/hostlist/HostListViewModel.kt
@@ -52,6 +52,7 @@ enum class ConnectionState {
 data class HostListUiState(
     val hosts: List<Host> = emptyList(),
     val connectionStates: Map<Long, ConnectionState> = emptyMap(),
+    val sessionCounts: Map<Long, Int> = emptyMap(),
     val isLoading: Boolean = false,
     val error: String? = null,
     val sortedByColor: Boolean = false,
@@ -186,21 +187,18 @@ class HostListViewModel @Inject constructor(
         val states = hosts.associate { host ->
             host.id to getConnectionState(host)
         }
-        _uiState.update { it.copy(connectionStates = states) }
+        val counts = hosts.associate { host ->
+            host.id to (terminalManager?.getSessionCount(host.id) ?: 0)
+        }
+        _uiState.update { it.copy(connectionStates = states, sessionCounts = counts) }
     }
 
     private fun getConnectionState(host: Host): ConnectionState {
         val manager = terminalManager ?: return ConnectionState.UNKNOWN
 
-        // Check if host has an active bridge
-        val bridge = manager.bridgesFlow.value.find { it.host.id == host.id }
-        if (bridge != null) {
-            // Bridge exists but may be disconnected or in grace period
-            return if (bridge.disconnected || bridge.isInGracePeriod()) {
-                ConnectionState.DISCONNECTED
-            } else {
-                ConnectionState.CONNECTED
-            }
+        // Check if any sessions are connected for this host
+        if (manager.isHostConnected(host.id)) {
+            return ConnectionState.CONNECTED
         }
 
         // Check if in disconnected list by comparing ID
@@ -215,6 +213,51 @@ class HostListViewModel @Inject constructor(
         val newSortedByColor = !_uiState.value.sortedByColor
         sharedPreferences.edit { putBoolean(PreferenceConstants.SORT_BY_COLOR, newSortedByColor) }
         _uiState.update { it.copy(sortedByColor = newSortedByColor) }
+    }
+
+    /**
+     * Open a new session to a host.
+     * This always creates a new session, even if sessions already exist.
+     */
+    fun connectToHost(host: Host) {
+        viewModelScope.launch {
+            try {
+                withContext(Dispatchers.IO) {
+                    // Build URI from host
+                    val uri = android.net.Uri.Builder()
+                        .scheme(host.protocol)
+                        .encodedAuthority("${host.username}@${host.hostname}:${host.port}")
+                        .build()
+                    terminalManager?.openConnection(uri)
+                }
+            } catch (e: Exception) {
+                _uiState.update {
+                    it.copy(error = e.message ?: "Failed to connect")
+                }
+            }
+        }
+    }
+
+    /**
+     * Get the session ID of the last-used session for a host.
+     * Returns null if no sessions exist.
+     */
+    fun getLastUsedSessionId(hostId: Long): Long? {
+        return terminalManager?.getLastUsedBridge(hostId)?.sessionId
+    }
+
+    /**
+     * Check if a host has any connected sessions.
+     */
+    fun isHostConnected(hostId: Long): Boolean {
+        return terminalManager?.isHostConnected(hostId) ?: false
+    }
+
+    /**
+     * Get the number of sessions for a host.
+     */
+    fun getSessionCount(hostId: Long): Int {
+        return terminalManager?.getSessionCount(hostId) ?: 0
     }
 
     fun deleteHost(host: Host) {

--- a/app/src/main/java/org/connectbot/ui/screens/hostlist/HostListViewModel.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/hostlist/HostListViewModel.kt
@@ -1,6 +1,6 @@
 /*
  * ConnectBot: simple, powerful, open-source SSH client for Android
- * Copyright 2025 Kenny Root
+ * Copyright 2025-2026 Kenny Root
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/org/connectbot/ui/screens/hostlist/HostListViewModel.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/hostlist/HostListViewModel.kt
@@ -24,6 +24,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -31,7 +32,6 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.connectbot.R
@@ -243,23 +243,17 @@ class HostListViewModel @Inject constructor(
      * Get the session ID of the last-used session for a host.
      * Returns null if no sessions exist.
      */
-    fun getLastUsedSessionId(hostId: Long): Long? {
-        return terminalManager?.getLastUsedBridge(hostId)?.sessionId
-    }
+    fun getLastUsedSessionId(hostId: Long): Long? = terminalManager?.getLastUsedBridge(hostId)?.sessionId
 
     /**
      * Check if a host has any connected sessions.
      */
-    fun isHostConnected(hostId: Long): Boolean {
-        return terminalManager?.isHostConnected(hostId) ?: false
-    }
+    fun isHostConnected(hostId: Long): Boolean = terminalManager?.isHostConnected(hostId) ?: false
 
     /**
      * Get the number of sessions for a host.
      */
-    fun getSessionCount(hostId: Long): Int {
-        return terminalManager?.getSessionCount(hostId) ?: 0
-    }
+    fun getSessionCount(hostId: Long): Int = terminalManager?.getSessionCount(hostId) ?: 0
 
     fun deleteHost(host: Host) {
         viewModelScope.launch {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -613,6 +613,10 @@
 	<string name="console_url_not_supported">This URL type is not supported</string>
 	<!-- Dialog title for an SSH authentication banner sent by a server. Parameter is the host or jump host name. -->
 	<string name="auth_banner_title">Authentication message from %1$s</string>
+	<!-- Button to switch between sessions for the same host. -->
+	<string name="console_menu_switch_session">"Switch session"</string>
+	<!-- Format string for session number in switch session menu. -->
+	<string name="console_menu_session_number">"Session #%1$d"</string>
 
 	<!-- Button label to answer "Yes" to a yes/no prompt -->
 	<string name="button_yes">"Yes"</string>
@@ -661,6 +665,10 @@
 	<string name="list_host_duplicate">"Duplicate host"</string>
 	<!-- Context menu action to forget stored host keys for the selected host -->
 	<string name="list_host_forget_keys">"Forget host keys"</string>
+	<!-- Context menu action to open a new session to the selected host -->
+	<string name="list_host_new_session">"Open new session"</string>
+	<!-- Empty state message when no hosts have been created yet -->
+	<string name="list_host_empty">"No hosts created yet."</string>
 
 	<!-- Default screen rotation preference selection -->
 	<string name="list_rotation_default">"Default"</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1059,6 +1059,8 @@
 	<!-- Console screen messages -->
 	<!-- Default title for console screen when no specific host is connected -->
 	<string name="console_default_title">Console</string>
+	<!-- Console title when a host has multiple sessions. First parameter is the session number; second is the host nickname. -->
+	<string name="console_session_title">#%1$d %2$s</string>
 
 	<!-- Host editor screen labels -->
 	<!-- Label for quick connect input field -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1245,8 +1245,10 @@
 	<string name="migration_debug_log_title">Debug Log</string>
 	<!-- Button text to copy debug log to clipboard for reporting issues -->
 	<string name="migration_copy_debug_log">Copy Debug Log</string>
-	<!-- Shown in the alert dialog when a user chooses the 'disconnect' item to disconnect from a SSH or Telnet host. -->
-	<string name="disconnect_host_alert">Are you sure you want to disconnect from \'%1$s\'?</string>
+	<!-- Shown in the alert dialog when a user chooses to close/disconnect a single session from the terminal. -->
+	<string name="disconnect_session_alert">Are you sure you want to close this session?</string>
+	<!-- Shown in the alert dialog when a user chooses to disconnect all sessions for a host from the host list. -->
+	<string name="disconnect_all_sessions_alert">Are you sure you want to disconnect all sessions from \'%1$s\'?</string>
 	<!-- Shown in the alert dialog when a user chooses the 'delete host' item to delete a host. -->
 	<string name="delete_host_confirm">Are you sure you want to delete host \'%1$s\'?</string>
 	<!-- Shown in the alert dialog when a user chooses the 'forget host keys' item. -->

--- a/app/src/test/kotlin/org/connectbot/ConsoleScreenTest.kt
+++ b/app/src/test/kotlin/org/connectbot/ConsoleScreenTest.kt
@@ -140,6 +140,27 @@ class ConsoleScreenTest {
         }
     }
 
+    private fun mockConsoleBridge(
+        id: Long = 1L,
+        hostname: String = "test-host",
+        isDisconnected: Boolean = false,
+    ): TerminalBridge {
+        val bridge = mock(TerminalBridge::class.java)
+        val host = Host(
+            id = id,
+            hostname = hostname,
+            nickname = hostname,
+            protocol = "ssh",
+            port = 22,
+            username = "test",
+        )
+        `when`(bridge.host).thenReturn(host)
+        `when`(bridge.sessionId).thenReturn(id)
+        `when`(bridge.isDisconnected).thenReturn(isDisconnected)
+        `when`(bridge.isSessionOpen).thenReturn(!isDisconnected)
+        return bridge
+    }
+
     @Test
     fun consoleScreen_showsNotificationWarningSnackbar_whenConnPersistDisabled() {
         val warning = composeTestRule.activity.getString(R.string.notification_permission_console_warning)
@@ -404,8 +425,7 @@ class ConsoleScreenTest {
             .commit()
 
         val mockViewModel = mock(ConsoleViewModel::class.java)
-        val mockBridge = mock(TerminalBridge::class.java)
-        `when`(mockBridge.isDisconnected).thenReturn(false)
+        val mockBridge = mockConsoleBridge(isDisconnected = false)
 
         val uiStateFlow = MutableStateFlow(
             ConsoleUiState(
@@ -437,8 +457,7 @@ class ConsoleScreenTest {
             .commit()
 
         val mockViewModel = mock(ConsoleViewModel::class.java)
-        val mockBridge = mock(TerminalBridge::class.java)
-        `when`(mockBridge.isDisconnected).thenReturn(false)
+        val mockBridge = mockConsoleBridge(isDisconnected = false)
 
         val uiStateFlow = MutableStateFlow(
             ConsoleUiState(
@@ -470,8 +489,7 @@ class ConsoleScreenTest {
             .commit()
 
         val mockViewModel = mock(ConsoleViewModel::class.java)
-        val mockBridge = mock(TerminalBridge::class.java)
-        `when`(mockBridge.isDisconnected).thenReturn(true)
+        val mockBridge = mockConsoleBridge(isDisconnected = true)
 
         val uiStateFlow = MutableStateFlow(
             ConsoleUiState(

--- a/app/src/test/kotlin/org/connectbot/ConsoleScreenTest.kt
+++ b/app/src/test/kotlin/org/connectbot/ConsoleScreenTest.kt
@@ -142,6 +142,7 @@ class ConsoleScreenTest {
 
     private fun mockConsoleBridge(
         id: Long = 1L,
+        sessionId: Long = id,
         hostname: String = "test-host",
         isDisconnected: Boolean = false,
     ): TerminalBridge {
@@ -155,7 +156,7 @@ class ConsoleScreenTest {
             username = "test",
         )
         `when`(bridge.host).thenReturn(host)
-        `when`(bridge.sessionId).thenReturn(id)
+        `when`(bridge.sessionId).thenReturn(sessionId)
         `when`(bridge.isDisconnected).thenReturn(isDisconnected)
         `when`(bridge.isSessionOpen).thenReturn(!isDisconnected)
         return bridge
@@ -281,6 +282,53 @@ class ConsoleScreenTest {
         composeTestRule
             .onNodeWithTag("top_app_bar")
             .assertIsDisplayed()
+    }
+
+    @Test
+    fun consoleScreen_showsHostnameWithoutSessionNumber_forSingleSession() {
+        val mockViewModel = mock(ConsoleViewModel::class.java)
+        val bridge = mockConsoleBridge(hostname = "a-long-hostname")
+        `when`(mockViewModel.uiState).thenReturn(
+            MutableStateFlow(
+                ConsoleUiState(
+                    bridges = listOf(bridge),
+                    currentBridgeIndex = 0,
+                    isLoading = true,
+                ),
+            ),
+        )
+        `when`(mockViewModel.networkStatusMessages).thenReturn(MutableSharedFlow())
+        `when`(mockViewModel.shouldShowNotificationWarning()).thenReturn(false)
+
+        setContent(mockConsoleViewModel = mockViewModel)
+        navigateToConsoleScreen(hostId = 1L)
+
+        composeTestRule.onNodeWithText("a-long-hostname").assertIsDisplayed()
+        composeTestRule.onNodeWithText("#1 a-long-hostname").assertIsNotDisplayed()
+    }
+
+    @Test
+    fun consoleScreen_showsSessionNumberBeforeHostname_forMultipleSessionsOnHost() {
+        val mockViewModel = mock(ConsoleViewModel::class.java)
+        val firstBridge = mockConsoleBridge(sessionId = 10L, hostname = "a-long-hostname")
+        val secondBridge = mockConsoleBridge(sessionId = 20L, hostname = "a-long-hostname")
+        `when`(mockViewModel.uiState).thenReturn(
+            MutableStateFlow(
+                ConsoleUiState(
+                    bridges = listOf(firstBridge, secondBridge),
+                    currentBridgeIndex = 1,
+                    isLoading = true,
+                ),
+            ),
+        )
+        `when`(mockViewModel.networkStatusMessages).thenReturn(MutableSharedFlow())
+        `when`(mockViewModel.shouldShowNotificationWarning()).thenReturn(false)
+
+        setContent(mockConsoleViewModel = mockViewModel)
+        navigateToConsoleScreen(hostId = 1L)
+
+        composeTestRule.onNodeWithText("#2 a-long-hostname").assertIsDisplayed()
+        composeTestRule.onNodeWithText("a-long-hostname #2").assertIsNotDisplayed()
     }
 
     @Test

--- a/app/src/test/kotlin/org/connectbot/ConsoleScreenTest.kt
+++ b/app/src/test/kotlin/org/connectbot/ConsoleScreenTest.kt
@@ -63,6 +63,7 @@ import org.connectbot.ui.LocalTerminalManager
 import org.connectbot.ui.screens.console.ConsoleScreen
 import org.connectbot.ui.screens.console.ConsoleUiState
 import org.connectbot.ui.screens.console.ConsoleViewModel
+import org.connectbot.ui.screens.console.SessionPickerDialog
 import org.connectbot.ui.theme.ConnectBotTheme
 import org.connectbot.util.PreferenceConstants
 import org.junit.After
@@ -329,6 +330,25 @@ class ConsoleScreenTest {
 
         composeTestRule.onNodeWithText("#2 a-long-hostname").assertIsDisplayed()
         composeTestRule.onNodeWithText("a-long-hostname #2").assertIsNotDisplayed()
+    }
+
+    @Test
+    fun consoleScreen_sessionPickerSupportsMultipleSessionsForSameHost() {
+        val firstBridge = mockConsoleBridge(id = 1L, sessionId = 10L, hostname = "same-host")
+        val secondBridge = mockConsoleBridge(id = 1L, sessionId = 20L, hostname = "same-host")
+        composeTestRule.setContent {
+            ConnectBotTheme {
+                SessionPickerDialog(
+                    bridges = listOf(firstBridge, secondBridge),
+                    currentBridgeIndex = 0,
+                    onDismiss = {},
+                    onSelectBridge = {},
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("\u2022 same-host").assertIsDisplayed()
+        composeTestRule.onNodeWithText("same-host").assertIsDisplayed()
     }
 
     @Test

--- a/app/src/test/kotlin/org/connectbot/ui/screens/console/ConsoleViewModelTest.kt
+++ b/app/src/test/kotlin/org/connectbot/ui/screens/console/ConsoleViewModelTest.kt
@@ -644,6 +644,7 @@ class ConsoleViewModelTest {
             username = "test",
         )
         whenever(bridge.host).thenReturn(host)
+        whenever(bridge.sessionId).thenReturn(id)
         whenever(bridge.isSessionOpen).thenReturn(true)
         whenever(bridge.isDisconnected).thenReturn(false)
         whenever(bridge.bellEvents).thenReturn(MutableSharedFlow())

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,8 +53,26 @@ spotless {
     kotlin {
         target("app/src/**/*.kt")
         ktlint("1.8.0")
+            .editorConfigOverride(
+                mapOf(
+                    "ij_kotlin_imports_layout" to "*,java.**,javax.**,kotlin.**,^",
+                    "ktlint_code_style" to "android_studio",
+                    "ktlint_function_naming_ignore_when_annotated_with" to "Composable",
+                    "ktlint_standard_property-naming" to "disabled",
+                    "ktlint_standard_backing-property-naming" to "disabled",
+                    "ktlint_standard_filename" to "disabled",
+                    "ktlint_standard_discouraged-comment-location" to "disabled",
+                    "ktlint_standard_max-line-length" to "disabled",
+                    "ktlint_standard_kdoc" to "disabled",
+                    "ktlint_compose_compositionlocal-allowlist" to "disabled",
+                ),
+            )
             .customRuleSets(listOf("io.nlopez.compose.rules:ktlint:0.6.3"))
         licenseHeaderFile("spotless/license-header.txt")
+    }
+
+    groovyGradle {
+        target("**/*.gradle")
     }
 
     kotlinGradle {


### PR DESCRIPTION
This resolves #1522. I decided to implement this because a similar feature is available in Termius.

Current behavior:
- **Opening sessions**: Tapping the host opens a single new session or connects to an existing one. Long-pressing the host displays an option to open a new session rather than connecting to the existing one. Alternatively, you can add a new session via the menu in the terminal view.
- **Deleting sessions**: Closing the connection from the host menu closes all sessions. Closing the connection from the terminal view closes only the current session.
- **Switching sessions**: The only way to switch sessions is via the menu in the terminal view.

I initially considered using a horizontal swipe to switch sessions. However, that gesture seems to be consumed by termlib, and I want to avoid including changes to termlib in this PR. 