### PR TITLE
Add public key export to file functionality

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -114,6 +114,7 @@
 	<string name="pubkey_copy_private_pem">"Copy private key (PEM)"</string>
 	<string name="pubkey_copy_private_encrypted">"Copy private key (encrypted)"</string>
 	<string name="pubkey_copy_public">"Copy public key"</string>
+	<string name="pubkey_export_public">"Export public key"</string>
 	<string name="pubkey_export_private">"Export private key"</string>
 	<string name="pubkey_export_private_openssh">"Export private key (OpenSSH)"</string>
 	<string name="pubkey_export_private_pem">"Export private key (PEM)"</string>


### PR DESCRIPTION
Fix #749.

Previously, only private key export was supported. Users can now export public keys to a file from the key menu, saving them in OpenSSH authorized_keys format with a .pub extension.

🤖 Generated with [Claude Code](https://claude.com/claude-code)