### PR TITLE
Add OSC52 support

### DIFF
--- a/app/src/main/java/org/connectbot/service/TerminalBridge.kt
+++ b/app/src/main/java/org/connectbot/service/TerminalBridge.kt
@@ -186,6 +186,7 @@ class TerminalBridge {
             },
             onClipboardCopy = { text ->
                 // OSC 52 clipboard support - copy remote text to local clipboard
+                Log.i(TAG, "OSC 52 clipboard copy: ${text.length} chars")
                 val clipboard = manager.getSystemService(Context.CLIPBOARD_SERVICE) as? ClipboardManager
                 clipboard?.setPrimaryClip(ClipData.newPlainText("terminal", text))
             }

--- a/app/src/main/java/org/connectbot/service/TerminalBridge.kt
+++ b/app/src/main/java/org/connectbot/service/TerminalBridge.kt
@@ -17,6 +17,9 @@
 
 package org.connectbot.service
 
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
 import android.graphics.Paint
 import android.graphics.Typeface
 import android.util.Log
@@ -180,6 +183,11 @@ class TerminalBridge {
                 scope.launch(Dispatchers.IO) {
                     transport?.setDimensions(it.columns, it.rows, 0, 0)
                 }
+            },
+            onClipboardCopy = { text ->
+                // OSC 52 clipboard support - copy remote text to local clipboard
+                val clipboard = manager.getSystemService(Context.CLIPBOARD_SERVICE) as? ClipboardManager
+                clipboard?.setPrimaryClip(ClipData.newPlainText("terminal", text))
             }
         )
 


### PR DESCRIPTION
This PR fixes #1570. However, this PR currently requires the local build of connectbot/termlib#50. Hence, this PR is still a draft. 
I've tested the functionality with a command like the following on my host. 
`echo "Hello World" | (echo -ne "\e]52;;"; base64 | tr -d "\n"; echo -e "\e\\")`