### PR TITLE
Measure TopAppBar correctly

### DIFF
--- a/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
@@ -28,12 +28,15 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.imeAnimationTarget
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.union
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material.icons.Icons
@@ -76,6 +79,7 @@ import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -303,11 +307,17 @@ fun ConsoleScreen(
 
         // Terminal content with keyboard overlay
         // This Box is transparent to accessibility - it's just for layout
+        val layoutDirection = LocalLayoutDirection.current
         Box(
             modifier = Modifier
                 .fillMaxSize()
                 .consumeWindowInsets(innerPadding)
-                .padding(innerPadding)
+                .padding(
+                    start = innerPadding.calculateStartPadding(layoutDirection),
+                    end = innerPadding.calculateEndPadding(layoutDirection),
+                    top = if (!titleBarHide) 0.dp else innerPadding.calculateTopPadding(),
+                    bottom = innerPadding.calculateBottomPadding()
+                )
                 .windowInsetsPadding(WindowInsets.imeAnimationTarget)
         ) {
             when {
@@ -476,17 +486,18 @@ fun ConsoleScreen(
         // Overlay TopAppBar - always visible when titleBarHide is false,
         // or temporarily visible when titleBarHide is true and showTitleBar is true
         if (!titleBarHide || showTitleBar) {
+            val density = LocalDensity.current
             TopAppBar(
                 title = {
                     Text(
                         currentBridge?.host?.nickname
                             ?: stringResource(R.string.console_default_title),
                         maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                        modifier = Modifier.onSizeChanged {
-                            titleBarHeight = it.height.dp
-                        }
+                        overflow = TextOverflow.Ellipsis
                     )
+                },
+                modifier = Modifier.onSizeChanged {
+                    titleBarHeight = with(density) { it.height.toDp() }
                 },
                 navigationIcon = {
                     IconButton(onClick = onNavigateBack) {


### PR DESCRIPTION
This was unintentionally measuring the height of the text instead of the TopAppBar itself. This caused it to look slightly off because it made the TopAppBar about 5dp too tall.

Fixes #1713