### PR TITLE
Use adjustResize on all API versions

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -63,7 +63,7 @@
 			android:exported="true"
 			android:launchMode="singleTop"
 			android:resizeableActivity="true"
-			android:windowSoftInputMode="adjustNothing"
+			android:windowSoftInputMode="adjustResize"
 			android:theme="@android:style/Theme.NoTitleBar">
 			<intent-filter>
 				<action android:name="android.intent.action.MAIN"/>


### PR DESCRIPTION
adjustNothing seems to work on API 30+ devices, but not API 29 and below. Meanwhile adjustResize seems to work on all API versions.

Fixes #1745