### PR TITLE
Skip version 3 of the database

### DIFF
--- a/app/src/main/java/org/connectbot/data/ConnectBotDatabase.kt
+++ b/app/src/main/java/org/connectbot/data/ConnectBotDatabase.kt
@@ -71,7 +71,7 @@ import org.connectbot.data.entity.Pubkey
     exportSchema = true,
     autoMigrations = [
         AutoMigration(from = 1, to = 2),
-        AutoMigration(from = 2, to = 3),
+        AutoMigration(from = 2, to = 4),
         AutoMigration(from = 3, to = 4)
     ]
 )


### PR DESCRIPTION
This caused a unique constraint exception for some that had multple keys with different "host:port" combinations. Just skip past it for those that have not encountered it.