### PR TITLE
Re-arrange notification permission request flow

### DIFF
--- a/app/src/main/java/org/connectbot/ui/ConnectBotApp.kt
+++ b/app/src/main/java/org/connectbot/ui/ConnectBotApp.kt
@@ -39,6 +39,7 @@ fun ConnectBotApp(
     makingShortcut: Boolean,
     onRetryMigration: () -> Unit,
     onShortcutSelected: (Host) -> Unit,
+    onNavigateToConsole: (Host) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     ConnectBotTheme {
@@ -73,6 +74,7 @@ fun ConnectBotApp(
                         startDestination = NavDestinations.HOST_LIST,
                         makingShortcut = makingShortcut,
                         onShortcutSelected = onShortcutSelected,
+                        onNavigateToConsole = onNavigateToConsole,
                         modifier = modifier
                     )
                 }

--- a/app/src/main/java/org/connectbot/ui/PermissionLifecycleObserver.kt
+++ b/app/src/main/java/org/connectbot/ui/PermissionLifecycleObserver.kt
@@ -1,0 +1,52 @@
+/*
+ * ConnectBot: simple, powerful, open-source SSH client for Android
+ * Copyright 2025 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.connectbot.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import org.connectbot.util.NotificationPermissionHelper
+
+/**
+ * Observes lifecycle events and re-checks notification permission status when the screen resumes.
+ * This handles cases where the user grants or revokes permission in Settings and returns to the app.
+ *
+ * @param onPermissionChanged Callback invoked with the current permission state when screen resumes
+ */
+@Composable
+fun ObservePermissionOnResume(onPermissionChanged: (Boolean) -> Unit) {
+    val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                // Check current permission status - may have changed while user was away
+                val isGranted = NotificationPermissionHelper.isNotificationPermissionGranted(context)
+                onPermissionChanged(isGranted)
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
+        }
+    }
+}

--- a/app/src/main/java/org/connectbot/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/org/connectbot/ui/navigation/NavGraph.kt
@@ -46,6 +46,7 @@ fun ConnectBotNavHost(
     startDestination: String = NavDestinations.HOST_LIST,
     makingShortcut: Boolean = false,
     onShortcutSelected: (Host) -> Unit = {},
+    onNavigateToConsole: (Host) -> Unit,
     modifier: Modifier = Modifier
 ) {
     NavHost(
@@ -56,9 +57,7 @@ fun ConnectBotNavHost(
         composable(NavDestinations.HOST_LIST) {
             HostListScreen(
                 makingShortcut = makingShortcut,
-                onNavigateToConsole = { host ->
-                    navController.navigate("${NavDestinations.CONSOLE}/${host.id}")
-                },
+                onNavigateToConsole = onNavigateToConsole,
                 onShortcutSelected = onShortcutSelected,
                 onNavigateToEditHost = { host ->
                     if (host != null) {

--- a/app/src/main/java/org/connectbot/util/NotificationPermissionHelper.kt
+++ b/app/src/main/java/org/connectbot/util/NotificationPermissionHelper.kt
@@ -1,0 +1,44 @@
+/*
+ * ConnectBot: simple, powerful, open-source SSH client for Android
+ * Copyright 2025 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.connectbot.util
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.core.content.ContextCompat
+
+/**
+ * Utility class for checking notification permission status.
+ */
+object NotificationPermissionHelper {
+    /**
+     * Check if notification permission is granted.
+     * Returns true if permission is granted or not needed (SDK < 33).
+     */
+    fun isNotificationPermissionGranted(context: Context): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+            return true
+        }
+
+        return ContextCompat.checkSelfPermission(
+            context,
+            Manifest.permission.POST_NOTIFICATIONS
+        ) == PackageManager.PERMISSION_GRANTED
+    }
+}

--- a/app/src/main/java/org/connectbot/util/PreferenceConstants.kt
+++ b/app/src/main/java/org/connectbot/util/PreferenceConstants.kt
@@ -68,6 +68,7 @@ object PreferenceConstants {
     const val DEFAULT_BELL_VOLUME: Float = 0.25f
 
     const val CONNECTION_PERSIST: String = "connPersist"
+    const val NOTIFICATION_PERMISSION_DENIED: String = "notificationPermissionDenied"
 
     const val SHIFT_FKEYS: String = "shiftfkeys"
     const val CTRL_FKEYS: String = "ctrlfkeys"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -996,6 +996,34 @@
 	     Added to the end of a key description to indicate that the key is encrypted (i.e,
 	     password protected). -->
 	<string name="key_attribute_encrypted">(encrypted)</string>
+
+	<!-- Title for notification permission dialog shown when user first tries to connect to a host.
+	     Explains that notifications keep SSH connections alive. -->
+	<string name="notification_permission_title">Keep connections alive</string>
+
+	<!-- Explanation message shown in permission dialog when user tries to connect to a host.
+	     Explains why notification permission is needed and what happens without it. -->
+	<string name="notification_permission_message">Displaying a notification is required keep connections alive in the background. Without permission, connections may close when you switch apps.</string>
+
+	<!-- Button text to grant notification permission in the permission explanation dialog. -->
+	<string name="grant_permission">Grant permission</string>
+
+	<!-- Button text to proceed with connecting without granting notification permission. -->
+	<string name="connect_anyway">Connect anyway</string>
+
+	<!-- Title for dialog directing users to app settings when notification permission was denied.
+	     Shown when user tries to enable persist connections after denying permission. -->
+	<string name="notification_permission_denied_title">Permission required</string>
+
+	<!-- Message explaining that user must enable notification permission in app settings.
+	     Shown when notification permission was previously denied and user tries to enable persist connections. -->
+	<string name="notification_permission_denied_message">To keep connections alive in the background, you must enable notification permission in app settings.</string>
+
+	<!-- Button text to open ConnectBot app settings page where user can grant notification permission. -->
+	<string name="open_settings">Open settings</string>
+
+	<!-- Message shown to user when they're trying to connect to a host on a local network but
+	     have not granted the permission yet. -->
 	<string name="notification_requirement_explanation">Notification permission is required to display running sessions in the background</string>
 	<string name="continue_anyway">Continue without</string>
 	<string name="allow">Allow</string>

--- a/app/src/test/java/org/connectbot/ui/screens/settings/SettingsViewModelPermissionTest.kt
+++ b/app/src/test/java/org/connectbot/ui/screens/settings/SettingsViewModelPermissionTest.kt
@@ -1,0 +1,399 @@
+/*
+ * ConnectBot: simple, powerful, open-source SSH client for Android
+ * Copyright 2025 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.connectbot.ui.screens.settings
+
+import android.content.SharedPreferences
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.atLeastOnce
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.connectbot.util.PreferenceConstants
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Unit tests for SettingsViewModel notification permission logic.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+class SettingsViewModelPermissionTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private lateinit var prefs: SharedPreferences
+    private lateinit var prefsEditor: SharedPreferences.Editor
+    private lateinit var viewModel: SettingsViewModel
+
+    @Before
+    fun setUp() = runTest {
+        Dispatchers.setMain(testDispatcher)
+        prefs = mock()
+        prefsEditor = mock()
+
+        // Setup mock SharedPreferences
+        whenever(prefs.edit()).thenReturn(prefsEditor)
+        whenever(prefsEditor.putBoolean(any(), any())).thenReturn(prefsEditor)
+        whenever(prefsEditor.putString(any(), any())).thenReturn(prefsEditor)
+        whenever(prefsEditor.putInt(any(), any())).thenReturn(prefsEditor)
+
+        // Setup default preference values
+        whenever(prefs.getBoolean(eq("memkeys"), any())).thenReturn(true)
+        whenever(prefs.getBoolean(eq(PreferenceConstants.CONNECTION_PERSIST), any())).thenReturn(false)
+        whenever(prefs.getBoolean(eq("wifilock"), any())).thenReturn(false)
+        whenever(prefs.getBoolean(eq("backupkeys"), any())).thenReturn(false)
+        whenever(prefs.getString(eq("emulation"), any())).thenReturn("xterm-256color")
+        whenever(prefs.getInt(eq("scrollback"), any())).thenReturn(140)
+        whenever(prefs.getString(eq("rotation"), any())).thenReturn("Default")
+        whenever(prefs.getString(eq("fullscreen"), any())).thenReturn("Default")
+        whenever(prefs.getBoolean(eq("titlebarhide"), any())).thenReturn(false)
+        whenever(prefs.getBoolean(eq("pg_updn_gestures"), any())).thenReturn(false)
+        whenever(prefs.getString(eq("volumefont"), any())).thenReturn("Default")
+        whenever(prefs.getInt(eq("keepalive"), any())).thenReturn(0)
+        whenever(prefs.getBoolean(eq("alwaysvisible"), any())).thenReturn(false)
+        whenever(prefs.getBoolean(eq("shiftfkeys"), any())).thenReturn(false)
+        whenever(prefs.getBoolean(eq("ctrlfkeys"), any())).thenReturn(false)
+        whenever(prefs.getBoolean(eq("stickymodifiers"), any())).thenReturn(true)
+        whenever(prefs.getString(eq("keymode"), any())).thenReturn("Use right-side keys")
+        whenever(prefs.getString(eq("camera"), any())).thenReturn("None")
+        whenever(prefs.getBoolean(eq("bumpyarrows"), any())).thenReturn(true)
+        whenever(prefs.getString(eq("bell"), any())).thenReturn("Vibrate")
+        whenever(prefs.getInt(eq("bellvolume"), any())).thenReturn(100)
+        whenever(prefs.getBoolean(eq("bellvibrate"), any())).thenReturn(true)
+        whenever(prefs.getBoolean(eq("bellnotification"), any())).thenReturn(false)
+        whenever(prefs.getBoolean(eq(PreferenceConstants.NOTIFICATION_PERMISSION_DENIED), any())).thenReturn(false)
+
+        viewModel = SettingsViewModel(prefs)
+        advanceUntilIdle()
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    // region updateConnPersist tests
+
+    @Test
+    fun updateConnPersist_TurningOn_FirstTime_RequestsPermissionAndOptimisticallyUpdates() = runTest {
+        val permissionRequests = mutableListOf<Unit>()
+        val job = launch {
+            viewModel.requestNotificationPermission.collect {
+                permissionRequests.add(it)
+            }
+        }
+
+        viewModel.updateConnPersist(true)
+        advanceUntilIdle()
+
+        assertEquals("Should request permission", 1, permissionRequests.size)
+        // Should optimistically update preference to ON while waiting for permission result
+        verify(prefsEditor).putBoolean(eq(PreferenceConstants.CONNECTION_PERSIST), eq(true))
+
+        job.cancel()
+    }
+
+    @Test
+    fun updateConnPersist_TurningOn_AfterDenied_ShowsPermissionDeniedDialog() = runTest {
+        // First deny permission
+        viewModel.updateConnPersist(true)
+        advanceUntilIdle()
+        viewModel.onNotificationPermissionResult(false)
+        advanceUntilIdle()
+
+        // Update mock to return true for wasPermissionDenied after denial
+        whenever(prefs.getBoolean(eq(PreferenceConstants.NOTIFICATION_PERMISSION_DENIED), any())).thenReturn(true)
+
+        val dialogEvents = mutableListOf<Unit>()
+        val job = launch {
+            viewModel.showPermissionDeniedDialog.collect {
+                dialogEvents.add(it)
+            }
+        }
+
+        // Try to turn on again
+        viewModel.updateConnPersist(true)
+        advanceUntilIdle()
+
+        assertEquals("Should show permission denied dialog", 1, dialogEvents.size)
+
+        job.cancel()
+    }
+
+    @Test
+    fun updateConnPersist_TurningOff_UpdatesPreference() = runTest {
+        // Setup connPersist as ON
+        whenever(prefs.getBoolean(eq(PreferenceConstants.CONNECTION_PERSIST), any())).thenReturn(true)
+        viewModel = SettingsViewModel(prefs)
+        advanceUntilIdle()
+
+        viewModel.updateConnPersist(false)
+        advanceUntilIdle()
+
+        verify(prefsEditor).putBoolean(eq(PreferenceConstants.CONNECTION_PERSIST), eq(false))
+        verify(prefsEditor).apply()
+    }
+
+    @Test
+    fun updateConnPersist_AlreadyOn_UpdatesPreference() = runTest {
+        // Setup connPersist as ON
+        whenever(prefs.getBoolean(eq(PreferenceConstants.CONNECTION_PERSIST), any())).thenReturn(true)
+        viewModel = SettingsViewModel(prefs)
+        advanceUntilIdle()
+
+        viewModel.updateConnPersist(true)
+        advanceUntilIdle()
+
+        verify(prefsEditor).putBoolean(eq(PreferenceConstants.CONNECTION_PERSIST), eq(true))
+        verify(prefsEditor).apply()
+    }
+
+    // endregion
+
+    // region onNotificationPermissionResult tests
+
+    @Test
+    fun onNotificationPermissionResult_Granted_EnablesConnPersistAndClearsDenialState() = runTest {
+        // First deny permission to set the denial state
+        viewModel.onNotificationPermissionResult(false)
+        advanceUntilIdle()
+
+        // Then grant permission (simulating user going to settings)
+        viewModel.onNotificationPermissionResult(true)
+        advanceUntilIdle()
+
+        verify(prefsEditor).putBoolean(eq(PreferenceConstants.NOTIFICATION_PERMISSION_DENIED), eq(false))
+        verify(prefsEditor).putBoolean(eq(PreferenceConstants.CONNECTION_PERSIST), eq(true))
+        verify(prefsEditor, atLeastOnce()).apply()
+
+        // Verify denial state is persisted by recreating ViewModel
+        whenever(prefs.getBoolean(eq(PreferenceConstants.CONNECTION_PERSIST), any())).thenReturn(false)
+        // The NOTIFICATION_PERMISSION_DENIED flag is still false in SharedPreferences
+        viewModel = SettingsViewModel(prefs)
+        advanceUntilIdle()
+
+        val permissionRequests = mutableListOf<Unit>()
+        val job = launch {
+            viewModel.requestNotificationPermission.collect {
+                permissionRequests.add(it)
+            }
+        }
+
+        viewModel.updateConnPersist(true)
+        advanceUntilIdle()
+
+        // Should request permission (not show dialog) because denial state was cleared and persisted
+        assertEquals("New ViewModel should read persisted state: not denied", 1, permissionRequests.size)
+
+        job.cancel()
+    }
+
+    @Test
+    fun onNotificationPermissionResult_Denied_KeepsConnPersistOffAndSetsDenialState() = runTest {
+        viewModel.onNotificationPermissionResult(false)
+        advanceUntilIdle()
+
+        verify(prefsEditor).putBoolean(eq(PreferenceConstants.NOTIFICATION_PERMISSION_DENIED), eq(true))
+        verify(prefsEditor).putBoolean(eq(PreferenceConstants.CONNECTION_PERSIST), eq(false))
+        verify(prefsEditor, atLeastOnce()).apply()
+
+        // Update mock to return true for wasPermissionDenied
+        whenever(prefs.getBoolean(eq(PreferenceConstants.NOTIFICATION_PERMISSION_DENIED), any())).thenReturn(true)
+
+        // Verify denial state is set by trying to turn on again
+        val dialogEvents = mutableListOf<Unit>()
+        val job = launch {
+            viewModel.showPermissionDeniedDialog.collect {
+                dialogEvents.add(it)
+            }
+        }
+
+        viewModel.updateConnPersist(true)
+        advanceUntilIdle()
+
+        assertEquals("Should show permission denied dialog", 1, dialogEvents.size)
+
+        job.cancel()
+    }
+
+    @Test
+    fun denialState_PersistsAcrossViewModelRecreation() = runTest {
+        // Deny permission
+        viewModel.onNotificationPermissionResult(false)
+        advanceUntilIdle()
+
+        // Update the mock to return true for NOTIFICATION_PERMISSION_DENIED (simulating persistence)
+        whenever(prefs.getBoolean(eq(PreferenceConstants.NOTIFICATION_PERMISSION_DENIED), any())).thenReturn(true)
+
+        // Recreate ViewModel (simulating process death/configuration change)
+        viewModel = SettingsViewModel(prefs)
+        advanceUntilIdle()
+
+        // Try to turn on connPersist
+        val dialogEvents = mutableListOf<Unit>()
+        val job = launch {
+            viewModel.showPermissionDeniedDialog.collect {
+                dialogEvents.add(it)
+            }
+        }
+
+        viewModel.updateConnPersist(true)
+        advanceUntilIdle()
+
+        // Should show dialog (not request permission) because denial state was persisted
+        assertEquals("Denial state should persist across ViewModel recreation", 1, dialogEvents.size)
+
+        job.cancel()
+    }
+
+    // endregion
+
+    // region Integration tests
+
+    @Test
+    fun permissionFlow_GrantedOnFirstAttempt_EnablesConnPersist() = runTest {
+        val permissionRequests = mutableListOf<Unit>()
+        val requestJob = launch {
+            viewModel.requestNotificationPermission.collect {
+                permissionRequests.add(it)
+            }
+        }
+
+        // User turns on connPersist
+        viewModel.updateConnPersist(true)
+        advanceUntilIdle()
+
+        assertEquals("Should request permission", 1, permissionRequests.size)
+
+        // User grants permission
+        viewModel.onNotificationPermissionResult(true)
+        advanceUntilIdle()
+
+        // Preference should be set to true (called twice: optimistic update + permission granted)
+        verify(prefsEditor, atLeastOnce()).putBoolean(eq(PreferenceConstants.CONNECTION_PERSIST), eq(true))
+
+        requestJob.cancel()
+    }
+
+    @Test
+    fun permissionFlow_DeniedThenRetried_ShowsDialog() = runTest {
+        // First attempt - request permission
+        val permissionRequests = mutableListOf<Unit>()
+        val requestJob = launch {
+            viewModel.requestNotificationPermission.collect {
+                permissionRequests.add(it)
+            }
+        }
+
+        viewModel.updateConnPersist(true)
+        advanceUntilIdle()
+
+        assertEquals("Should request permission first time", 1, permissionRequests.size)
+
+        // User denies
+        viewModel.onNotificationPermissionResult(false)
+        advanceUntilIdle()
+
+        // Preference should end up false (called twice: first optimistic true, then denied false)
+        verify(prefsEditor, atLeastOnce()).putBoolean(eq(PreferenceConstants.CONNECTION_PERSIST), eq(false))
+
+        // Update mock to return true for wasPermissionDenied after denial
+        whenever(prefs.getBoolean(eq(PreferenceConstants.NOTIFICATION_PERMISSION_DENIED), any())).thenReturn(true)
+
+        requestJob.cancel()
+
+        // Second attempt - should show dialog instead
+        val dialogEvents = mutableListOf<Unit>()
+        val dialogJob = launch {
+            viewModel.showPermissionDeniedDialog.collect {
+                dialogEvents.add(it)
+            }
+        }
+
+        viewModel.updateConnPersist(true)
+        advanceUntilIdle()
+
+        assertEquals("Should show dialog second time", 1, dialogEvents.size)
+
+        dialogJob.cancel()
+    }
+
+    @Test
+    fun permissionFlow_DeniedThenGranted_ClearsDenialState() = runTest {
+        // First attempt - deny
+        viewModel.updateConnPersist(true)
+        advanceUntilIdle()
+        viewModel.onNotificationPermissionResult(false)
+        advanceUntilIdle()
+
+        // Update mock to return true for wasPermissionDenied after denial
+        whenever(prefs.getBoolean(eq(PreferenceConstants.NOTIFICATION_PERMISSION_DENIED), any())).thenReturn(true)
+
+        // Second attempt - should show dialog
+        val dialogEvents = mutableListOf<Unit>()
+        val dialogJob = launch {
+            viewModel.showPermissionDeniedDialog.collect {
+                dialogEvents.add(it)
+            }
+        }
+
+        viewModel.updateConnPersist(true)
+        advanceUntilIdle()
+
+        assertEquals("Should show dialog", 1, dialogEvents.size)
+        dialogJob.cancel()
+
+        // User goes to settings and grants permission, then tries again
+        viewModel.onNotificationPermissionResult(true)
+        advanceUntilIdle()
+
+        // Update mock to return false after granting permission
+        whenever(prefs.getBoolean(eq(PreferenceConstants.NOTIFICATION_PERMISSION_DENIED), any())).thenReturn(false)
+
+        // Third attempt - should request permission again (not show dialog)
+        val permissionRequests = mutableListOf<Unit>()
+        val requestJob = launch {
+            viewModel.requestNotificationPermission.collect {
+                permissionRequests.add(it)
+            }
+        }
+
+        viewModel.updateConnPersist(true)
+        advanceUntilIdle()
+
+        assertEquals("Should request permission after being granted", 1, permissionRequests.size)
+
+        requestJob.cancel()
+    }
+
+    // endregion
+}


### PR DESCRIPTION
This will give some context in to what we're requesting before requesting for it. Also it will direct the user to the settings application if they had denied the request already.