### PR TITLE
Fix term mode

### DIFF
--- a/app/src/main/java/org/connectbot/service/TerminalBridge.kt
+++ b/app/src/main/java/org/connectbot/service/TerminalBridge.kt
@@ -168,7 +168,11 @@ class TerminalBridge {
         this.manager = manager
         this.host = host
 
-        emulation = manager.getEmulation()
+        // Load profile for this host (always returns a profile, defaulting to Default profile)
+        val profile = manager.profileRepository.getByIdOrDefaultBlocking(host.profileId)
+        currentProfileId = host.profileId
+
+        emulation = profile.emulation
         scrollback = manager.getScrollback()
 
         // create our default paint
@@ -180,10 +184,6 @@ class TerminalBridge {
         localOutput = mutableListOf()
 
         fontSizeChangedListeners = mutableListOf()
-
-        // Load profile for this host (always returns a profile, defaulting to Default profile)
-        val profile = manager.profileRepository.getByIdOrDefaultBlocking(host.profileId)
-        currentProfileId = host.profileId
 
         // Store encoding and font family from profile for later use
         encoding = profile.encoding

--- a/app/src/main/java/org/connectbot/service/TerminalManager.kt
+++ b/app/src/main/java/org/connectbot/service/TerminalManager.kt
@@ -326,10 +326,6 @@ class TerminalManager : Service(), BridgeDisconnectedListener, OnSharedPreferenc
 		return bridge
 	}
 
-	fun getEmulation(): String {
-		return prefs.getString(PreferenceConstants.EMULATION, "xterm-256color")!!
-	}
-
 	fun getScrollback(): Int {
 		var scrollback = 140
 		try {

--- a/app/src/main/java/org/connectbot/ui/screens/profiles/ProfileEditorScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/profiles/ProfileEditorScreen.kt
@@ -29,13 +29,10 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Check
-import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenuItem
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.ListItem
 import androidx.compose.material3.ExposedDropdownMenuAnchorType
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
@@ -47,7 +44,6 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Slider
 import androidx.compose.material3.SnackbarHost
-import androidx.compose.material3.TextButton
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -223,8 +219,6 @@ fun ProfileEditorScreen(
                     emulation = uiState.emulation,
                     customTerminalTypes = uiState.customTerminalTypes,
                     onEmulationSelected = { viewModel.updateEmulation(it) },
-                    onAddCustomTerminalType = { viewModel.addCustomTerminalType(it) },
-                    onRemoveCustomTerminalType = { viewModel.removeCustomTerminalType(it) },
                     modifier = Modifier.fillMaxWidth()
                 )
 
@@ -353,14 +347,9 @@ private fun EmulationSelector(
     emulation: String,
     customTerminalTypes: List<String>,
     onEmulationSelected: (String) -> Unit,
-    onAddCustomTerminalType: (String) -> Unit,
-    onRemoveCustomTerminalType: (String) -> Unit,
     modifier: Modifier = Modifier
 ) {
     var expanded by remember { mutableStateOf(false) }
-    var showAddDialog by remember { mutableStateOf(false) }
-    var showManageDialog by remember { mutableStateOf(false) }
-    var newTerminalType by remember { mutableStateOf("") }
     val presetOptions = listOf(
         "xterm-256color",
         "xterm",
@@ -431,119 +420,8 @@ private fun EmulationSelector(
                         )
                     }
                 }
-                HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
-                DropdownMenuItem(
-                    text = {
-                        Text(
-                            text = stringResource(R.string.button_add_custom),
-                            color = MaterialTheme.colorScheme.primary
-                        )
-                    },
-                    onClick = {
-                        expanded = false
-                        showAddDialog = true
-                    },
-                    contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding
-                )
-                DropdownMenuItem(
-                    text = {
-                        Text(
-                            text = stringResource(R.string.button_manage_custom),
-                            color = if (customTerminalTypes.isNotEmpty()) {
-                                MaterialTheme.colorScheme.primary
-                            } else {
-                                MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
-                            }
-                        )
-                    },
-                    onClick = {
-                        if (customTerminalTypes.isNotEmpty()) {
-                            expanded = false
-                            showManageDialog = true
-                        }
-                    },
-                    enabled = customTerminalTypes.isNotEmpty(),
-                    contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding
-                )
             }
         }
-    }
-
-    // Add custom terminal type dialog
-    if (showAddDialog) {
-        AlertDialog(
-            onDismissRequest = {
-                showAddDialog = false
-                newTerminalType = ""
-            },
-            title = { Text(stringResource(R.string.dialog_customterminal_title)) },
-            text = {
-                OutlinedTextField(
-                    value = newTerminalType,
-                    onValueChange = { newTerminalType = it },
-                    label = { Text(stringResource(R.string.dialog_customterminal_hint)) },
-                    singleLine = true,
-                    modifier = Modifier.fillMaxWidth()
-                )
-            },
-            confirmButton = {
-                TextButton(
-                    onClick = {
-                        if (newTerminalType.isNotBlank()) {
-                            onAddCustomTerminalType(newTerminalType.trim())
-                            showAddDialog = false
-                            newTerminalType = ""
-                        }
-                    },
-                    enabled = newTerminalType.isNotBlank()
-                ) {
-                    Text(stringResource(R.string.button_add))
-                }
-            },
-            dismissButton = {
-                TextButton(onClick = {
-                    showAddDialog = false
-                    newTerminalType = ""
-                }) {
-                    Text(stringResource(android.R.string.cancel))
-                }
-            }
-        )
-    }
-
-    // Manage custom terminal types dialog
-    if (showManageDialog) {
-        AlertDialog(
-            onDismissRequest = { showManageDialog = false },
-            title = { Text(stringResource(R.string.dialog_manage_customterminal_title)) },
-            text = {
-                Column {
-                    customTerminalTypes.forEach { terminalType ->
-                        ListItem(
-                            headlineContent = { Text(terminalType) },
-                            trailingContent = {
-                                IconButton(onClick = {
-                                    onRemoveCustomTerminalType(terminalType)
-                                    if (customTerminalTypes.size <= 1) {
-                                        showManageDialog = false
-                                    }
-                                }) {
-                                    Icon(
-                                        imageVector = Icons.Default.Delete,
-                                        contentDescription = stringResource(R.string.button_remove)
-                                    )
-                                }
-                            }
-                        )
-                    }
-                }
-            },
-            confirmButton = {
-                TextButton(onClick = { showManageDialog = false }) {
-                    Text(stringResource(android.R.string.ok))
-                }
-            }
-        )
     }
 }
 

--- a/app/src/main/java/org/connectbot/ui/screens/profiles/ProfileEditorScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/profiles/ProfileEditorScreen.kt
@@ -29,10 +29,13 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenuItem
-import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.ListItem
 import androidx.compose.material3.ExposedDropdownMenuAnchorType
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
@@ -44,6 +47,7 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Slider
 import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -219,6 +223,8 @@ fun ProfileEditorScreen(
                     emulation = uiState.emulation,
                     customTerminalTypes = uiState.customTerminalTypes,
                     onEmulationSelected = { viewModel.updateEmulation(it) },
+                    onAddCustomTerminalType = { viewModel.addCustomTerminalType(it) },
+                    onRemoveCustomTerminalType = { viewModel.removeCustomTerminalType(it) },
                     modifier = Modifier.fillMaxWidth()
                 )
 
@@ -347,9 +353,14 @@ private fun EmulationSelector(
     emulation: String,
     customTerminalTypes: List<String>,
     onEmulationSelected: (String) -> Unit,
+    onAddCustomTerminalType: (String) -> Unit,
+    onRemoveCustomTerminalType: (String) -> Unit,
     modifier: Modifier = Modifier
 ) {
     var expanded by remember { mutableStateOf(false) }
+    var showAddDialog by remember { mutableStateOf(false) }
+    var showManageDialog by remember { mutableStateOf(false) }
+    var newTerminalType by remember { mutableStateOf("") }
     val presetOptions = listOf(
         "xterm-256color",
         "xterm",
@@ -362,8 +373,6 @@ private fun EmulationSelector(
         "linux",
         "dumb"
     )
-    // Combine preset options with custom terminal types
-    val allOptions = presetOptions + customTerminalTypes
 
     Column(modifier = modifier) {
         Text(
@@ -422,8 +431,119 @@ private fun EmulationSelector(
                         )
                     }
                 }
+                HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
+                DropdownMenuItem(
+                    text = {
+                        Text(
+                            text = stringResource(R.string.button_add_custom),
+                            color = MaterialTheme.colorScheme.primary
+                        )
+                    },
+                    onClick = {
+                        expanded = false
+                        showAddDialog = true
+                    },
+                    contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding
+                )
+                DropdownMenuItem(
+                    text = {
+                        Text(
+                            text = stringResource(R.string.button_manage_custom),
+                            color = if (customTerminalTypes.isNotEmpty()) {
+                                MaterialTheme.colorScheme.primary
+                            } else {
+                                MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
+                            }
+                        )
+                    },
+                    onClick = {
+                        if (customTerminalTypes.isNotEmpty()) {
+                            expanded = false
+                            showManageDialog = true
+                        }
+                    },
+                    enabled = customTerminalTypes.isNotEmpty(),
+                    contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding
+                )
             }
         }
+    }
+
+    // Add custom terminal type dialog
+    if (showAddDialog) {
+        AlertDialog(
+            onDismissRequest = {
+                showAddDialog = false
+                newTerminalType = ""
+            },
+            title = { Text(stringResource(R.string.dialog_customterminal_title)) },
+            text = {
+                OutlinedTextField(
+                    value = newTerminalType,
+                    onValueChange = { newTerminalType = it },
+                    label = { Text(stringResource(R.string.dialog_customterminal_hint)) },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        if (newTerminalType.isNotBlank()) {
+                            onAddCustomTerminalType(newTerminalType.trim())
+                            showAddDialog = false
+                            newTerminalType = ""
+                        }
+                    },
+                    enabled = newTerminalType.isNotBlank()
+                ) {
+                    Text(stringResource(R.string.button_add))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = {
+                    showAddDialog = false
+                    newTerminalType = ""
+                }) {
+                    Text(stringResource(android.R.string.cancel))
+                }
+            }
+        )
+    }
+
+    // Manage custom terminal types dialog
+    if (showManageDialog) {
+        AlertDialog(
+            onDismissRequest = { showManageDialog = false },
+            title = { Text(stringResource(R.string.dialog_manage_customterminal_title)) },
+            text = {
+                Column {
+                    customTerminalTypes.forEach { terminalType ->
+                        ListItem(
+                            headlineContent = { Text(terminalType) },
+                            trailingContent = {
+                                IconButton(onClick = {
+                                    onRemoveCustomTerminalType(terminalType)
+                                    if (customTerminalTypes.size <= 1) {
+                                        showManageDialog = false
+                                    }
+                                }) {
+                                    Icon(
+                                        imageVector = Icons.Default.Delete,
+                                        contentDescription = stringResource(R.string.button_remove)
+                                    )
+                                }
+                            }
+                        )
+                    }
+                }
+            },
+            confirmButton = {
+                TextButton(onClick = { showManageDialog = false }) {
+                    Text(stringResource(android.R.string.ok))
+                }
+            }
+        )
     }
 }
 

--- a/app/src/main/java/org/connectbot/ui/screens/profiles/ProfileEditorViewModel.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/profiles/ProfileEditorViewModel.kt
@@ -187,6 +187,35 @@ class ProfileEditorViewModel @Inject constructor(
         _uiState.update { it.copy(emulation = value) }
     }
 
+    fun addCustomTerminalType(terminalType: String) {
+        if (terminalType.isBlank()) return
+        val currentTypes = _uiState.value.customTerminalTypes
+        if (currentTypes.contains(terminalType)) return
+
+        viewModelScope.launch {
+            val updatedTypes = currentTypes + terminalType
+            val typesString = updatedTypes.joinToString(",")
+            prefs.edit().putString("customTerminalTypes", typesString).apply()
+            _uiState.update { it.copy(customTerminalTypes = updatedTypes) }
+        }
+    }
+
+    fun removeCustomTerminalType(terminalType: String) {
+        viewModelScope.launch {
+            val currentTypes = _uiState.value.customTerminalTypes.toMutableList()
+            if (currentTypes.remove(terminalType)) {
+                val typesString = currentTypes.joinToString(",")
+                prefs.edit().putString("customTerminalTypes", typesString).apply()
+                _uiState.update { it.copy(customTerminalTypes = currentTypes) }
+
+                // If the removed type was the selected emulation, reset to default
+                if (_uiState.value.emulation == terminalType) {
+                    updateEmulation("xterm-256color")
+                }
+            }
+        }
+    }
+
     fun save(onSuccess: () -> Unit) {
         viewModelScope.launch {
             val state = _uiState.value

--- a/app/src/main/java/org/connectbot/ui/screens/profiles/ProfileEditorViewModel.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/profiles/ProfileEditorViewModel.kt
@@ -187,35 +187,6 @@ class ProfileEditorViewModel @Inject constructor(
         _uiState.update { it.copy(emulation = value) }
     }
 
-    fun addCustomTerminalType(terminalType: String) {
-        if (terminalType.isBlank()) return
-        val currentTypes = _uiState.value.customTerminalTypes
-        if (currentTypes.contains(terminalType)) return
-
-        viewModelScope.launch {
-            val updatedTypes = currentTypes + terminalType
-            val typesString = updatedTypes.joinToString(",")
-            prefs.edit().putString("customTerminalTypes", typesString).apply()
-            _uiState.update { it.copy(customTerminalTypes = updatedTypes) }
-        }
-    }
-
-    fun removeCustomTerminalType(terminalType: String) {
-        viewModelScope.launch {
-            val currentTypes = _uiState.value.customTerminalTypes.toMutableList()
-            if (currentTypes.remove(terminalType)) {
-                val typesString = currentTypes.joinToString(",")
-                prefs.edit().putString("customTerminalTypes", typesString).apply()
-                _uiState.update { it.copy(customTerminalTypes = currentTypes) }
-
-                // If the removed type was the selected emulation, reset to default
-                if (_uiState.value.emulation == terminalType) {
-                    updateEmulation("xterm-256color")
-                }
-            }
-        }
-    }
-
     fun save(onSuccess: () -> Unit) {
         viewModelScope.launch {
             val state = _uiState.value

--- a/app/src/main/java/org/connectbot/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/settings/SettingsScreen.kt
@@ -34,7 +34,6 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.FolderOpen
 import androidx.compose.material.icons.filled.FontDownload
-import androidx.compose.material.icons.filled.Terminal
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
@@ -149,9 +148,6 @@ fun SettingsScreen(
         onConnPersistChange = viewModel::updateConnPersist,
         onWifilockChange = viewModel::updateWifilock,
         onBackupkeysChange = viewModel::updateBackupkeys,
-        onEmulationChange = viewModel::updateEmulation,
-        onAddCustomTerminalType = viewModel::addCustomTerminalType,
-        onRemoveCustomTerminalType = viewModel::removeCustomTerminalType,
         onScrollbackChange = viewModel::updateScrollback,
         onFontFamilyChange = viewModel::updateFontFamily,
         onAddCustomFont = viewModel::addCustomFont,
@@ -191,9 +187,6 @@ fun SettingsScreenContent(
     onConnPersistChange: (Boolean) -> Unit,
     onWifilockChange: (Boolean) -> Unit,
     onBackupkeysChange: (Boolean) -> Unit,
-    onEmulationChange: (String) -> Unit,
-    onAddCustomTerminalType: (String) -> Unit,
-    onRemoveCustomTerminalType: (String) -> Unit,
     onScrollbackChange: (String) -> Unit,
     onFontFamilyChange: (String) -> Unit,
     onAddCustomFont: (String) -> Unit,
@@ -274,40 +267,6 @@ fun SettingsScreenContent(
 
             item {
                 PreferenceCategory(title = stringResource(R.string.pref_emulation_category))
-            }
-
-            item {
-                // Build combined list: preset types + custom types
-                val presetTypes = listOf(
-                    "xterm-256color" to "xterm-256color",
-                    "xterm" to "xterm",
-                    "vt100" to "vt100",
-                    "vt102" to "vt102",
-                    "vt220" to "vt220",
-                    "ansi" to "ansi",
-                    "screen" to "screen",
-                    "screen-256color" to "screen-256color",
-                    "linux" to "linux",
-                    "dumb" to "dumb"
-                )
-                val customTypeEntries = uiState.customTerminalTypes.map { it to it }
-                val allEntries = presetTypes + customTypeEntries
-
-                ListPreference(
-                    title = stringResource(R.string.pref_emulation_title),
-                    summary = uiState.emulation,
-                    value = uiState.emulation,
-                    entries = allEntries,
-                    onValueChange = onEmulationChange
-                )
-            }
-
-            item {
-                AddCustomTerminalTypePreference(
-                    customTerminalTypes = uiState.customTerminalTypes,
-                    onAddTerminalType = onAddCustomTerminalType,
-                    onRemoveTerminalType = onRemoveCustomTerminalType
-                )
             }
 
             item {
@@ -921,91 +880,6 @@ private fun SliderPreference(
     HorizontalDivider()
 }
 
-@Composable
-private fun AddCustomTerminalTypePreference(
-    customTerminalTypes: List<String>,
-    onAddTerminalType: (String) -> Unit,
-    onRemoveTerminalType: (String) -> Unit,
-    modifier: Modifier = Modifier
-) {
-    var showAddDialog by remember { mutableStateOf(false) }
-    var newTerminalType by remember { mutableStateOf("") }
-
-    Column(modifier = modifier) {
-        ListItem(
-            headlineContent = { Text(stringResource(R.string.pref_customterminal_title)) },
-            supportingContent = { Text(stringResource(R.string.pref_customterminal_summary)) },
-            modifier = Modifier.clickable { showAddDialog = true }
-        )
-
-        // Show existing custom terminal types with remove option
-        customTerminalTypes.forEach { terminalType ->
-            ListItem(
-                headlineContent = { Text(terminalType) },
-                leadingContent = {
-                    Icon(
-                        imageVector = Icons.Default.Terminal,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.primary
-                    )
-                },
-                trailingContent = {
-                    IconButton(onClick = { onRemoveTerminalType(terminalType) }) {
-                        Icon(
-                            imageVector = Icons.Default.Delete,
-                            contentDescription = stringResource(R.string.button_remove)
-                        )
-                    }
-                },
-                modifier = Modifier.padding(start = 16.dp)
-            )
-        }
-
-        HorizontalDivider()
-    }
-
-    if (showAddDialog) {
-        AlertDialog(
-            onDismissRequest = {
-                showAddDialog = false
-                newTerminalType = ""
-            },
-            title = { Text(stringResource(R.string.dialog_customterminal_title)) },
-            text = {
-                OutlinedTextField(
-                    value = newTerminalType,
-                    onValueChange = { newTerminalType = it },
-                    label = { Text(stringResource(R.string.dialog_customterminal_hint)) },
-                    singleLine = true,
-                    modifier = Modifier.fillMaxWidth()
-                )
-            },
-            confirmButton = {
-                TextButton(
-                    onClick = {
-                        if (newTerminalType.isNotBlank()) {
-                            onAddTerminalType(newTerminalType.trim())
-                            showAddDialog = false
-                            newTerminalType = ""
-                        }
-                    },
-                    enabled = newTerminalType.isNotBlank()
-                ) {
-                    Text(stringResource(R.string.button_add))
-                }
-            },
-            dismissButton = {
-                TextButton(onClick = {
-                    showAddDialog = false
-                    newTerminalType = ""
-                }) {
-                    Text(stringResource(android.R.string.cancel))
-                }
-            }
-        )
-    }
-}
-
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun AddCustomFontPreference(
@@ -1276,8 +1150,6 @@ private fun SettingsScreenPreview() {
                 connPersist = true,
                 wifilock = false,
                 backupkeys = true,
-                emulation = "xterm-256color",
-                customTerminalTypes = listOf("rxvt-unicode", "tmux-256color"),
                 scrollback = "500",
                 rotation = "Default",
                 titlebarhide = false,
@@ -1309,9 +1181,6 @@ private fun SettingsScreenPreview() {
             onConnPersistChange = {},
             onWifilockChange = {},
             onBackupkeysChange = {},
-            onEmulationChange = {},
-            onAddCustomTerminalType = {},
-            onRemoveCustomTerminalType = {},
             onScrollbackChange = {},
             onFontFamilyChange = {},
             onAddCustomFont = {},

--- a/app/src/main/java/org/connectbot/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/settings/SettingsViewModel.kt
@@ -48,8 +48,6 @@ data class SettingsUiState(
     val connPersist: Boolean = true,
     val wifilock: Boolean = true,
     val backupkeys: Boolean = false,
-    val emulation: String = "xterm-256color",
-    val customTerminalTypes: List<String> = emptyList(),
     val scrollback: String = "140",
     val rotation: String = "Default",
     val titlebarhide: Boolean = false,
@@ -121,12 +119,6 @@ class SettingsViewModel @Inject constructor(
         } else {
             customFontsString.split(",").filter { it.isNotBlank() }
         }
-        val customTerminalTypesString = prefs.getString("customTerminalTypes", "") ?: ""
-        val customTerminalTypes = if (customTerminalTypesString.isBlank()) {
-            emptyList()
-        } else {
-            customTerminalTypesString.split(",").filter { it.isNotBlank() }
-        }
         val localFonts = localFontProvider.getImportedFonts()
 
         return SettingsUiState(
@@ -134,8 +126,6 @@ class SettingsViewModel @Inject constructor(
             connPersist = prefs.getBoolean(PreferenceConstants.CONNECTION_PERSIST, true),
             wifilock = prefs.getBoolean("wifilock", true),
             backupkeys = prefs.getBoolean("backupkeys", false),
-            emulation = prefs.getString("emulation", "xterm-256color") ?: "xterm-256color",
-            customTerminalTypes = customTerminalTypes,
             scrollback = prefs.getString("scrollback", "140") ?: "140",
             rotation = prefs.getString("rotation", "Default") ?: "Default",
             titlebarhide = prefs.getBoolean("titlebarhide", false),
@@ -262,10 +252,6 @@ class SettingsViewModel @Inject constructor(
         updateBooleanPref("bumpyarrows", value) { copy(bumpyarrows = value) }
     }
 
-    fun updateEmulation(value: String) {
-        updateStringPref("emulation", value) { copy(emulation = value) }
-    }
-
     fun updateScrollback(value: String) {
         updateStringPref("scrollback", value) { copy(scrollback = value) }
     }
@@ -300,35 +286,6 @@ class SettingsViewModel @Inject constructor(
         viewModelScope.launch {
             prefs.edit().putLong("defaultProfileId", profileId).apply()
             _uiState.update { it.copy(defaultProfileId = profileId) }
-        }
-    }
-
-    fun addCustomTerminalType(terminalType: String) {
-        if (terminalType.isBlank()) return
-        val currentTypes = _uiState.value.customTerminalTypes
-        if (currentTypes.contains(terminalType)) return
-
-        viewModelScope.launch {
-            val updatedTypes = currentTypes + terminalType
-            val typesString = updatedTypes.joinToString(",")
-            prefs.edit().putString("customTerminalTypes", typesString).apply()
-            _uiState.update { it.copy(customTerminalTypes = updatedTypes) }
-        }
-    }
-
-    fun removeCustomTerminalType(terminalType: String) {
-        viewModelScope.launch {
-            val currentTypes = _uiState.value.customTerminalTypes.toMutableList()
-            if (currentTypes.remove(terminalType)) {
-                val typesString = currentTypes.joinToString(",")
-                prefs.edit().putString("customTerminalTypes", typesString).apply()
-                _uiState.update { it.copy(customTerminalTypes = currentTypes) }
-
-                // If the removed type was the selected emulation, reset to default
-                if (_uiState.value.emulation == terminalType) {
-                    updateEmulation("xterm-256color")
-                }
-            }
         }
     }
 

--- a/app/src/main/java/org/connectbot/util/PreferenceConstants.kt
+++ b/app/src/main/java/org/connectbot/util/PreferenceConstants.kt
@@ -24,8 +24,6 @@ object PreferenceConstants {
 
     const val SCROLLBACK: String = "scrollback"
 
-    const val EMULATION: String = "emulation"
-
     const val ROTATION: String = "rotation"
 
     const val BACKUP_KEYS: String = "backupkeys"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1176,6 +1176,12 @@
 	<string name="dialog_customterminal_title">Add Custom Terminal Type</string>
 	<!-- Label/hint for terminal type input field -->
 	<string name="dialog_customterminal_hint">Terminal type (e.g., rxvt-unicode)</string>
+	<!-- Dialog title for managing custom terminal types -->
+	<string name="dialog_manage_customterminal_title">Manage Custom Terminal Types</string>
+	<!-- Button to add a custom item -->
+	<string name="button_add_custom">Add custom…</string>
+	<!-- Button to manage custom items -->
+	<string name="button_manage_custom">Manage custom…</string>
 	<!-- Label for custom value input in list preference dialogs -->
 	<string name="dialog_custom_value_label">Enter custom value</string>
 	<!-- Summary description for Ctrl+A then Space camera button action -->


### PR DESCRIPTION
I found that I embedded the bug in #1697. The terminal emulator mode settings in the profile do not correctly apply to the hosts. This PR fixes that issue.

Terminal emulation is now per-profile only (in ProfileEditorScreen). Previously, TerminalBridge always read from the global preference, while profiles had their own emulation field that was ignored.

Changes:
- Remove emulation selector from global SettingsScreen
- Remove related ViewModel code and UI state
- Update TerminalBridge to use profile.emulation
- Remove unused getEmulation() from TerminalManager
- Remove EMULATION constant from PreferenceConstants

🤖 Generated with [Claude Code](https://claude.com/claude-code)