### PR TITLE
MINOR FIX: Fix host title

### DIFF
--- a/app/locale/fortune/af.po
+++ b/app/locale/fortune/af.po
@@ -2230,7 +2230,7 @@ msgid "Add host"
 msgstr ""
 
 #. Text for button which, when clicked, saves an existing host.
-msgctxt "hostpref_edit_host"
+msgctxt "hostpref_save_host"
 msgid "Save host"
 msgstr ""
 

--- a/app/locale/fortune/ar.po
+++ b/app/locale/fortune/ar.po
@@ -2232,7 +2232,7 @@ msgid "Add host"
 msgstr ""
 
 #. Text for button which, when clicked, saves an existing host.
-msgctxt "hostpref_edit_host"
+msgctxt "hostpref_save_host"
 msgid "Save host"
 msgstr ""
 

--- a/app/locale/fortune/be.po
+++ b/app/locale/fortune/be.po
@@ -2231,7 +2231,7 @@ msgid "Add host"
 msgstr ""
 
 #. Text for button which, when clicked, saves an existing host.
-msgctxt "hostpref_edit_host"
+msgctxt "hostpref_save_host"
 msgid "Save host"
 msgstr ""
 

--- a/app/locale/fortune/bg.po
+++ b/app/locale/fortune/bg.po
@@ -2228,7 +2228,7 @@ msgid "Add host"
 msgstr ""
 
 #. Text for button which, when clicked, saves an existing host.
-msgctxt "hostpref_edit_host"
+msgctxt "hostpref_save_host"
 msgid "Save host"
 msgstr ""
 

--- a/app/locale/fortune/ca.po
+++ b/app/locale/fortune/ca.po
@@ -2259,7 +2259,7 @@ msgid "Add host"
 msgstr "Afegeix un equip remot"
 
 #. Text for button which, when clicked, saves an existing host.
-msgctxt "hostpref_edit_host"
+msgctxt "hostpref_save_host"
 msgid "Save host"
 msgstr "Desa l'equip remot"
 

--- a/app/locale/fortune/cs.po
+++ b/app/locale/fortune/cs.po
@@ -2252,7 +2252,7 @@ msgid "Add host"
 msgstr "Přidat hostitele"
 
 #. Text for button which, when clicked, saves an existing host.
-msgctxt "hostpref_edit_host"
+msgctxt "hostpref_save_host"
 msgid "Save host"
 msgstr "Uložit hostitele"
 

--- a/app/locale/fortune/da.po
+++ b/app/locale/fortune/da.po
@@ -2244,7 +2244,7 @@ msgid "Add host"
 msgstr ""
 
 #. Text for button which, when clicked, saves an existing host.
-msgctxt "hostpref_edit_host"
+msgctxt "hostpref_save_host"
 msgid "Save host"
 msgstr ""
 

--- a/app/locale/fortune/de.po
+++ b/app/locale/fortune/de.po
@@ -2269,7 +2269,7 @@ msgid "Add host"
 msgstr "Host hinzufügen"
 
 #. Text for button which, when clicked, saves an existing host.
-msgctxt "hostpref_edit_host"
+msgctxt "hostpref_save_host"
 msgid "Save host"
 msgstr "Host speichern"
 

--- a/app/locale/fortune/el.po
+++ b/app/locale/fortune/el.po
@@ -2269,7 +2269,7 @@ msgid "Add host"
 msgstr "Προσθήκη κεντρικού υπολογιστή"
 
 #. Text for button which, when clicked, saves an existing host.
-msgctxt "hostpref_edit_host"
+msgctxt "hostpref_save_host"
 msgid "Save host"
 msgstr "Αποθήκευση κεντρικού υπολογιστή"
 

--- a/app/locale/fortune/en_CA.po
+++ b/app/locale/fortune/en_CA.po
@@ -2228,7 +2228,7 @@ msgid "Add host"
 msgstr ""
 
 #. Text for button which, when clicked, saves an existing host.
-msgctxt "hostpref_edit_host"
+msgctxt "hostpref_save_host"
 msgid "Save host"
 msgstr ""
 

--- a/app/locale/fortune/en_GB.po
+++ b/app/locale/fortune/en_GB.po
@@ -2242,7 +2242,7 @@ msgid "Add host"
 msgstr "Add host"
 
 #. Text for button which, when clicked, saves an existing host.
-msgctxt "hostpref_edit_host"
+msgctxt "hostpref_save_host"
 msgid "Save host"
 msgstr "Save host"
 

--- a/app/locale/fortune/es.po
+++ b/app/locale/fortune/es.po
@@ -2278,7 +2278,7 @@ msgid "Add host"
 msgstr "Añadir host"
 
 #. Text for button which, when clicked, saves an existing host.
-msgctxt "hostpref_edit_host"
+msgctxt "hostpref_save_host"
 msgid "Save host"
 msgstr "Guardar host"
 

--- a/app/locale/fortune/eu.po
+++ b/app/locale/fortune/eu.po
@@ -2253,7 +2253,7 @@ msgid "Add host"
 msgstr "Gehitu ostalaria"
 
 #. Text for button which, when clicked, saves an existing host.
-msgctxt "hostpref_edit_host"
+msgctxt "hostpref_save_host"
 msgid "Save host"
 msgstr "Gorde ostalaria"
 

--- a/app/locale/fortune/fa.po
+++ b/app/locale/fortune/fa.po
@@ -2238,7 +2238,7 @@ msgid "Add host"
 msgstr "افزودن میزبان"
 
 #. Text for button which, when clicked, saves an existing host.
-msgctxt "hostpref_edit_host"
+msgctxt "hostpref_save_host"
 msgid "Save host"
 msgstr "ذخیره میزبان"
 

--- a/app/locale/fortune/fi.po
+++ b/app/locale/fortune/fi.po
@@ -2248,7 +2248,7 @@ msgid "Add host"
 msgstr "Lisää isäntä"
 
 #. Text for button which, when clicked, saves an existing host.
-msgctxt "hostpref_edit_host"
+msgctxt "hostpref_save_host"
 msgid "Save host"
 msgstr "Tallenna isäntä"
 

--- a/app/locale/fortune/fortune.pot
+++ b/app/locale/fortune/fortune.pot
@@ -2221,7 +2221,7 @@ msgid "Add host"
 msgstr ""
 
 #. Text for button which, when clicked, saves an existing host.
-msgctxt "hostpref_edit_host"
+msgctxt "hostpref_save_host"
 msgid "Save host"
 msgstr ""
 

--- a/app/locale/fortune/fr.po
+++ b/app/locale/fortune/fr.po
@@ -2284,7 +2284,7 @@ msgid "Add host"
 msgstr "Ajouter un serveur"
 
 #. Text for button which, when clicked, saves an existing host.
-msgctxt "hostpref_edit_host"
+msgctxt "hostpref_save_host"
 msgid "Save host"
 msgstr "Enregistrer le serveur"
 

--- a/app/locale/fortune/gl.po
+++ b/app/locale/fortune/gl.po
@@ -2250,7 +2250,7 @@ msgid "Add host"
 msgstr "Engadir servidor"
 
 #. Text for button which, when clicked, saves an existing host.
-msgctxt "hostpref_edit_host"
+msgctxt "hostpref_save_host"
 msgid "Save host"
 msgstr "Gardar servidor"
 

--- a/app/locale/fortune/he.po
+++ b/app/locale/fortune/he.po
@@ -2240,7 +2240,7 @@ msgid "Add host"
 msgstr ""
 
 #. Text for button which, when clicked, saves an existing host.
-msgctxt "hostpref_edit_host"
+msgctxt "hostpref_save_host"
 msgid "Save host"
 msgstr ""
 

--- a/app/locale/fortune/hr.po
+++ b/app/locale/fortune/hr.po
@@ -2243,7 +2243,7 @@ msgid "Add host"
 msgstr ""
 
 #. Text for button which, when clicked, saves an existing host.
-msgctxt "hostpref_edit_host"
+msgctxt "hostpref_save_host"
 msgid "Save host"
 msgstr ""
 

--- a/app/locale/fortune/hu.po
+++ b/app/locale/fortune/hu.po
@@ -2244,7 +2244,7 @@ msgid "Add host"
 msgstr ""
 
 #. Text for button which, when clicked, saves an existing host.
-msgctxt "hostpref_edit_host"
+msgctxt "hostpref_save_host"
 msgid "Save host"
 msgstr ""
 

--- a/app/locale/fortune/id.po
+++ b/app/locale/fortune/id.po
@@ -2250,7 +2250,7 @@ msgid "Add host"
 msgstr ""
 
 #. Text for button which, when clicked, saves an existing host.
-msgctxt "hostpref_edit_host"
+msgctxt "hostpref_save_host"
 msgid "Save host"
 msgstr ""
 

--- a/app/locale/fortune/is.po
+++ b/app/locale/fortune/is.po
@@ -2242,7 +2242,7 @@ msgid "Add host"
 msgstr ""
 
 #. Text for button which, when clicked, saves an existing host.
-msgctxt "hostpref_edit_host"
+msgctxt "hostpref_save_host"
 msgid "Save host"
 msgstr ""
 

--- a/app/locale/fortune/it.po
+++ b/app/locale/fortune/it.po
@@ -2271,7 +2271,7 @@ msgid "Add host"
 msgstr "Aggiungi host"
 
 #. Text for button which, when clicked, saves an existing host.
-msgctxt "hostpref_edit_host"
+msgctxt "hostpref_save_host"
 msgid "Save host"
 msgstr "Salva host"
 

--- a/app/locale/fortune/ja.po
+++ b/app/locale/fortune/ja.po
@@ -2233,7 +2233,7 @@ msgid "Add host"
 msgstr "ホストを追加"
 
 #. Text for button which, when clicked, saves an existing host.
-msgctxt "hostpref_edit_host"
+msgctxt "hostpref_save_host"
 msgid "Save host"
 msgstr "ホストを保存"
 

--- a/app/locale/fortune/ka.po
+++ b/app/locale/fortune/ka.po
@@ -2228,7 +2228,7 @@ msgid "Add host"
 msgstr "ჰოსტის დამატება"
 
 #. Text for button which, when clicked, saves an existing host.
-msgctxt "hostpref_edit_host"
+msgctxt "hostpref_save_host"
 msgid "Save host"
 msgstr "ჰოსტის შენახვა"
 

--- a/app/locale/fortune/ko.po
+++ b/app/locale/fortune/ko.po
@@ -2235,7 +2235,7 @@ msgid "Add host"
 msgstr "호스트 추가"
 
 #. Text for button which, when clicked, saves an existing host.
-msgctxt "hostpref_edit_host"
+msgctxt "hostpref_save_host"
 msgid "Save host"
 msgstr "호스트 저장"
 

--- a/app/locale/fortune/lo.po
+++ b/app/locale/fortune/lo.po
@@ -2241,7 +2241,7 @@ msgid "Add host"
 msgstr "ເພີ່ມໂຮສ"
 
 #. Text for button which, when clicked, saves an existing host.
-msgctxt "hostpref_edit_host"
+msgctxt "hostpref_save_host"
 msgid "Save host"
 msgstr "ບັນທຶກໂຮສ"
 

--- a/app/locale/fortune/lt.po
+++ b/app/locale/fortune/lt.po
@@ -2231,7 +2231,7 @@ msgid "Add host"
 msgstr ""
 
 #. Text for button which, when clicked, saves an existing host.
-msgctxt "hostpref_edit_host"
+msgctxt "hostpref_save_host"
 msgid "Save host"
 msgstr ""
 

--- a/app/locale/fortune/lv.po
+++ b/app/locale/fortune/lv.po
@@ -2234,7 +2234,7 @@ msgid "Add host"
 msgstr "Pievienot serveri"
 
 #. Text for button which, when clicked, saves an existing host.
-msgctxt "hostpref_edit_host"
+msgctxt "hostpref_save_host"
 msgid "Save host"
 msgstr "Saglabāt serveri"
 

--- a/app/locale/fortune/mk.po
+++ b/app/locale/fortune/mk.po
@@ -2243,7 +2243,7 @@ msgid "Add host"
 msgstr ""
 
 #. Text for button which, when clicked, saves an existing host.
-msgctxt "hostpref_edit_host"
+msgctxt "hostpref_save_host"
 msgid "Save host"
 msgstr ""
 

--- a/app/locale/fortune/nb.po
+++ b/app/locale/fortune/nb.po
@@ -2243,7 +2243,7 @@ msgid "Add host"
 msgstr ""
 
 #. Text for button which, when clicked, saves an existing host.
-msgctxt "hostpref_edit_host"
+msgctxt "hostpref_save_host"
 msgid "Save host"
 msgstr ""
 

--- a/app/locale/fortune/ne.po
+++ b/app/locale/fortune/ne.po
@@ -2228,7 +2228,7 @@ msgid "Add host"
 msgstr ""
 
 #. Text for button which, when clicked, saves an existing host.
-msgctxt "hostpref_edit_host"
+msgctxt "hostpref_save_host"
 msgid "Save host"
 msgstr ""
 

--- a/app/locale/fortune/nl.po
+++ b/app/locale/fortune/nl.po
@@ -2248,7 +2248,7 @@ msgid "Add host"
 msgstr ""
 
 #. Text for button which, when clicked, saves an existing host.
-msgctxt "hostpref_edit_host"
+msgctxt "hostpref_save_host"
 msgid "Save host"
 msgstr ""
 

--- a/app/locale/fortune/pl.po
+++ b/app/locale/fortune/pl.po
@@ -2259,7 +2259,7 @@ msgid "Add host"
 msgstr "Dodaj host"
 
 #. Text for button which, when clicked, saves an existing host.
-msgctxt "hostpref_edit_host"
+msgctxt "hostpref_save_host"
 msgid "Save host"
 msgstr "Zapisz host"
 

--- a/app/locale/fortune/pt.po
+++ b/app/locale/fortune/pt.po
@@ -2254,7 +2254,7 @@ msgid "Add host"
 msgstr "Adicionar servidor"
 
 #. Text for button which, when clicked, saves an existing host.
-msgctxt "hostpref_edit_host"
+msgctxt "hostpref_save_host"
 msgid "Save host"
 msgstr "Gravar servidor"
 

--- a/app/locale/fortune/pt_BR.po
+++ b/app/locale/fortune/pt_BR.po
@@ -2257,7 +2257,7 @@ msgid "Add host"
 msgstr "Adicionar host"
 
 #. Text for button which, when clicked, saves an existing host.
-msgctxt "hostpref_edit_host"
+msgctxt "hostpref_save_host"
 msgid "Save host"
 msgstr "Salvar host"
 

--- a/app/locale/fortune/ro.po
+++ b/app/locale/fortune/ro.po
@@ -2234,7 +2234,7 @@ msgid "Add host"
 msgstr ""
 
 #. Text for button which, when clicked, saves an existing host.
-msgctxt "hostpref_edit_host"
+msgctxt "hostpref_save_host"
 msgid "Save host"
 msgstr ""
 

--- a/app/locale/fortune/ru.po
+++ b/app/locale/fortune/ru.po
@@ -2257,7 +2257,7 @@ msgid "Add host"
 msgstr "Добавить сервер"
 
 #. Text for button which, when clicked, saves an existing host.
-msgctxt "hostpref_edit_host"
+msgctxt "hostpref_save_host"
 msgid "Save host"
 msgstr "Сохранить сервер"
 

--- a/app/locale/fortune/sk.po
+++ b/app/locale/fortune/sk.po
@@ -2242,7 +2242,7 @@ msgid "Add host"
 msgstr ""
 
 #. Text for button which, when clicked, saves an existing host.
-msgctxt "hostpref_edit_host"
+msgctxt "hostpref_save_host"
 msgid "Save host"
 msgstr ""
 

--- a/app/locale/fortune/sl.po
+++ b/app/locale/fortune/sl.po
@@ -2243,7 +2243,7 @@ msgid "Add host"
 msgstr ""
 
 #. Text for button which, when clicked, saves an existing host.
-msgctxt "hostpref_edit_host"
+msgctxt "hostpref_save_host"
 msgid "Save host"
 msgstr ""
 

--- a/app/locale/fortune/sr.po
+++ b/app/locale/fortune/sr.po
@@ -2247,7 +2247,7 @@ msgid "Add host"
 msgstr ""
 
 #. Text for button which, when clicked, saves an existing host.
-msgctxt "hostpref_edit_host"
+msgctxt "hostpref_save_host"
 msgid "Save host"
 msgstr ""
 

--- a/app/locale/fortune/sv.po
+++ b/app/locale/fortune/sv.po
@@ -2245,7 +2245,7 @@ msgid "Add host"
 msgstr ""
 
 #. Text for button which, when clicked, saves an existing host.
-msgctxt "hostpref_edit_host"
+msgctxt "hostpref_save_host"
 msgid "Save host"
 msgstr ""
 

--- a/app/locale/fortune/ta.po
+++ b/app/locale/fortune/ta.po
@@ -2228,7 +2228,7 @@ msgid "Add host"
 msgstr ""
 
 #. Text for button which, when clicked, saves an existing host.
-msgctxt "hostpref_edit_host"
+msgctxt "hostpref_save_host"
 msgid "Save host"
 msgstr ""
 

--- a/app/locale/fortune/th.po
+++ b/app/locale/fortune/th.po
@@ -2228,7 +2228,7 @@ msgid "Add host"
 msgstr ""
 
 #. Text for button which, when clicked, saves an existing host.
-msgctxt "hostpref_edit_host"
+msgctxt "hostpref_save_host"
 msgid "Save host"
 msgstr ""
 

--- a/app/locale/fortune/tk.po
+++ b/app/locale/fortune/tk.po
@@ -2228,7 +2228,7 @@ msgid "Add host"
 msgstr ""
 
 #. Text for button which, when clicked, saves an existing host.
-msgctxt "hostpref_edit_host"
+msgctxt "hostpref_save_host"
 msgid "Save host"
 msgstr ""
 

--- a/app/locale/fortune/tr.po
+++ b/app/locale/fortune/tr.po
@@ -2247,7 +2247,7 @@ msgid "Add host"
 msgstr ""
 
 #. Text for button which, when clicked, saves an existing host.
-msgctxt "hostpref_edit_host"
+msgctxt "hostpref_save_host"
 msgid "Save host"
 msgstr ""
 

--- a/app/locale/fortune/uk.po
+++ b/app/locale/fortune/uk.po
@@ -2243,7 +2243,7 @@ msgid "Add host"
 msgstr ""
 
 #. Text for button which, when clicked, saves an existing host.
-msgctxt "hostpref_edit_host"
+msgctxt "hostpref_save_host"
 msgid "Save host"
 msgstr ""
 

--- a/app/locale/fortune/vi.po
+++ b/app/locale/fortune/vi.po
@@ -2252,7 +2252,7 @@ msgid "Add host"
 msgstr "Thêm máy chủ (host)"
 
 #. Text for button which, when clicked, saves an existing host.
-msgctxt "hostpref_edit_host"
+msgctxt "hostpref_save_host"
 msgid "Save host"
 msgstr "Lưu máy chủ (host)"
 

--- a/app/locale/fortune/zh_CN.po
+++ b/app/locale/fortune/zh_CN.po
@@ -2237,7 +2237,7 @@ msgid "Add host"
 msgstr "添加主机"
 
 #. Text for button which, when clicked, saves an existing host.
-msgctxt "hostpref_edit_host"
+msgctxt "hostpref_save_host"
 msgid "Save host"
 msgstr "保存主机"
 

--- a/app/locale/fortune/zh_HK.po
+++ b/app/locale/fortune/zh_HK.po
@@ -2228,7 +2228,7 @@ msgid "Add host"
 msgstr ""
 
 #. Text for button which, when clicked, saves an existing host.
-msgctxt "hostpref_edit_host"
+msgctxt "hostpref_save_host"
 msgid "Save host"
 msgstr ""
 

--- a/app/locale/fortune/zh_TW.po
+++ b/app/locale/fortune/zh_TW.po
@@ -2239,7 +2239,7 @@ msgid "Add host"
 msgstr "新增主機"
 
 #. Text for button which, when clicked, saves an existing host.
-msgctxt "hostpref_edit_host"
+msgctxt "hostpref_save_host"
 msgid "Save host"
 msgstr "儲存主機"
 

--- a/app/src/main/java/org/connectbot/ui/screens/hosteditor/HostEditorScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/hosteditor/HostEditorScreen.kt
@@ -170,7 +170,7 @@ fun HostEditorScreenContent(
                             uiState.quickConnect.isNotBlank()
                         }
                     ) {
-                        Text(stringResource(if (hostId == -1L) R.string.hostpref_add_host else R.string.hostpref_edit_host))
+                        Text(stringResource(if (hostId == -1L) R.string.hostpref_add_host else R.string.hostpref_save_host))
                     }
                 }
             )

--- a/app/src/main/java/org/connectbot/ui/screens/hosteditor/HostEditorScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/hosteditor/HostEditorScreen.kt
@@ -145,7 +145,7 @@ fun HostEditorScreenContent(
                 title = {
                     Text(
                         if (hostId == -1L) stringResource(R.string.hostpref_add_host)
-                        else stringResource(R.string.hostpref_edit_host)
+                        else stringResource(R.string.hostpref_setting_title)
                     )
                 },
                 navigationIcon = {

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -217,6 +217,6 @@
   <string name="expand">Amplia</string>
   <string name="hostpref_authagent_with_confirmation">Requereix confirmació</string>
   <string name="hostpref_add_host">Afegeix un equip remot</string>
-  <string name="hostpref_edit_host">Desa l\'equip remot</string>
+  <string name="hostpref_save_host">Desa l\'equip remot</string>
   <string name="pubkey_import_existing">Importa una clau pública existent</string>
 </resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -404,7 +404,7 @@
   <string name="expand">Rozbalit</string>
   <string name="hostpref_authagent_with_confirmation">vyžadovat potvrzení</string>
   <string name="hostpref_add_host">Přidat hostitele</string>
-  <string name="hostpref_edit_host">Uložit hostitele</string>
+  <string name="hostpref_save_host">Uložit hostitele</string>
   <string name="pubkey_import_existing">Importovat veřejný klíč</string>
   <string name="notification_permission_title">Udržet spojení aktivní</string>
   <string name="notification_permission_message">Zobrazení oznámení je vyžadováno pro udržování spojení na pozadí. Bez povolení se mohou spojení ukončit při přepnutí mezi aplikacemi.</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -404,7 +404,7 @@
   <string name="expand">Aufklappen</string>
   <string name="hostpref_authagent_with_confirmation">Bestätigung nötig</string>
   <string name="hostpref_add_host">Host hinzufügen</string>
-  <string name="hostpref_edit_host">Host speichern</string>
+  <string name="hostpref_save_host">Host speichern</string>
   <string name="pubkey_import_existing">Vorhandenen öffentlichen Schlüssel importieren</string>
   <string name="notification_permission_title">Verbindungen aufrechterhalten</string>
   <string name="notification_permission_message">Das Anzeigen einer Benachrichtigung ist erforderlich um Verbindungen im Hintergrund aufrechtzuerhalten Ohne Berechtigung können Verbindungen schließen wenn Sie zwischen Apps wechseln</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -217,6 +217,6 @@
   <string name="expand">Επέκταση</string>
   <string name="hostpref_authagent_with_confirmation">Απαιτείται επιβεβαίωση</string>
   <string name="hostpref_add_host">Προσθήκη κεντρικού υπολογιστή</string>
-  <string name="hostpref_edit_host">Αποθήκευση κεντρικού υπολογιστή</string>
+  <string name="hostpref_save_host">Αποθήκευση κεντρικού υπολογιστή</string>
   <string name="pubkey_import_existing">Εισαγωγή υπάρχοντος δημόσιου κλειδιού</string>
 </resources>

--- a/app/src/main/res/values-en-rGB/strings.xml
+++ b/app/src/main/res/values-en-rGB/strings.xml
@@ -217,6 +217,6 @@
   <string name="expand">Expand</string>
   <string name="hostpref_authagent_with_confirmation">require confirmation</string>
   <string name="hostpref_add_host">Add host</string>
-  <string name="hostpref_edit_host">Save host</string>
+  <string name="hostpref_save_host">Save host</string>
   <string name="pubkey_import_existing">Import existing pubkey</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -404,7 +404,7 @@
   <string name="expand">Expandir</string>
   <string name="hostpref_authagent_with_confirmation">requerir confirmación</string>
   <string name="hostpref_add_host">Añadir host</string>
-  <string name="hostpref_edit_host">Guardar host</string>
+  <string name="hostpref_save_host">Guardar host</string>
   <string name="pubkey_import_existing">Importar clave pública existente</string>
   <string name="notification_permission_title">Mantener las conexiones vivas</string>
   <string name="notification_permission_message">Mostrar una notificación es requerido para mantener las conexiones vivas en segundo plano Sin permiso las conexiones pueden cerrarse cuando cambias de aplicaciones</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -217,6 +217,6 @@
   <string name="expand">Hedatu</string>
   <string name="hostpref_authagent_with_confirmation">Baieztapena behar du</string>
   <string name="hostpref_add_host">Gehitu ostalaria</string>
-  <string name="hostpref_edit_host">Gorde ostalaria</string>
+  <string name="hostpref_save_host">Gorde ostalaria</string>
   <string name="pubkey_import_existing">Inportatu gako publikoa</string>
 </resources>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -157,6 +157,6 @@
   <string name="button_key_f11">F11</string>
   <string name="button_key_f12">F12</string>
   <string name="hostpref_add_host">افزودن میزبان</string>
-  <string name="hostpref_edit_host">ذخیره میزبان</string>
+  <string name="hostpref_save_host">ذخیره میزبان</string>
   <string name="pubkey_import_existing">وارد کردن کلید عمومی موجود</string>
 </resources>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -179,6 +179,6 @@
   <string name="expand">Laajenna</string>
   <string name="hostpref_authagent_with_confirmation">edellytä vahvistusta</string>
   <string name="hostpref_add_host">Lisää isäntä</string>
-  <string name="hostpref_edit_host">Tallenna isäntä</string>
+  <string name="hostpref_save_host">Tallenna isäntä</string>
   <string name="pubkey_import_existing">Tuo nykyinen julkinen avain</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -404,7 +404,7 @@
   <string name="expand">Développer</string>
   <string name="hostpref_authagent_with_confirmation">Demander une confirmation</string>
   <string name="hostpref_add_host">Ajouter un serveur</string>
-  <string name="hostpref_edit_host">Enregistrer le serveur</string>
+  <string name="hostpref_save_host">Enregistrer le serveur</string>
   <string name="pubkey_import_existing">Importer une clé publique</string>
   <string name="notification_permission_title">Garder les connexions actives</string>
   <string name="notification_permission_message">L affichage d une notification est requis pour maintenir les connexions actives en arriere plan Sans autorisation les connexions peuvent se fermer lorsque vous basculez entre les applications</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -216,6 +216,6 @@
   <string name="expand">Expandir</string>
   <string name="hostpref_authagent_with_confirmation">require confirmación</string>
   <string name="hostpref_add_host">Engadir servidor</string>
-  <string name="hostpref_edit_host">Gardar servidor</string>
+  <string name="hostpref_save_host">Gardar servidor</string>
   <string name="pubkey_import_existing">Importar chave pública existente</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -404,7 +404,7 @@
   <string name="expand">Espandi</string>
   <string name="hostpref_authagent_with_confirmation">richiedi conferma</string>
   <string name="hostpref_add_host">Aggiungi host</string>
-  <string name="hostpref_edit_host">Salva host</string>
+  <string name="hostpref_save_host">Salva host</string>
   <string name="pubkey_import_existing">Importa chiave pubblica</string>
   <string name="notification_permission_title">Mantieni le connessioni attive</string>
   <string name="notification_permission_message">La visualizzazione di una notifica è necessaria per mantenere attive le connessioni in background. Senza autorizzazione, le connessioni potrebbero chiudersi quando si cambia app.</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -404,7 +404,7 @@
   <string name="expand">展開</string>
   <string name="hostpref_authagent_with_confirmation">確認が必要</string>
   <string name="hostpref_add_host">ホストを追加</string>
-  <string name="hostpref_edit_host">ホストを保存</string>
+  <string name="hostpref_save_host">ホストを保存</string>
   <string name="pubkey_import_existing">既存の公開鍵をインポート</string>
   <string name="notification_permission_title">接続を維持する</string>
   <string name="notification_permission_message">通知を表示することはバックグラウンドで接続を維持するために必要です。許可なくして、接続はアプリを切り替えたときに閉じることがあります。</string>

--- a/app/src/main/res/values-ka/strings.xml
+++ b/app/src/main/res/values-ka/strings.xml
@@ -113,6 +113,6 @@
   <string name="expand">ამოკეცვა</string>
   <string name="hostpref_authagent_with_confirmation">დადასტურების მოთხოვნა</string>
   <string name="hostpref_add_host">ჰოსტის დამატება</string>
-  <string name="hostpref_edit_host">ჰოსტის შენახვა</string>
+  <string name="hostpref_save_host">ჰოსტის შენახვა</string>
   <string name="pubkey_import_existing">არსებული საჯგასაღების შემოტანა</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -404,7 +404,7 @@
   <string name="expand">Expand</string>
   <string name="hostpref_authagent_with_confirmation">확인 필요</string>
   <string name="hostpref_add_host">호스트 추가</string>
-  <string name="hostpref_edit_host">호스트 저장</string>
+  <string name="hostpref_save_host">호스트 저장</string>
   <string name="pubkey_import_existing">기존 공개키 가져오기</string>
   <string name="notification_permission_title">연결 유지하기</string>
   <string name="notification_permission_message">백그라운드에서 연결을 유지하기 위해 알림 표시가 필요합니다. 권한 없이 앱을 전환할 때 연결이 종료될 수 있습니다.</string>

--- a/app/src/main/res/values-lo/strings.xml
+++ b/app/src/main/res/values-lo/strings.xml
@@ -217,6 +217,6 @@
   <string name="expand">ຂະຫຍາຍ</string>
   <string name="hostpref_authagent_with_confirmation">ຕ້ອງການການຢືນຢັນ</string>
   <string name="hostpref_add_host">ເພີ່ມໂຮສ</string>
-  <string name="hostpref_edit_host">ບັນທຶກໂຮສ</string>
+  <string name="hostpref_save_host">ບັນທຶກໂຮສ</string>
   <string name="pubkey_import_existing">ນຳເຂົ້າ pubkey ທີ່ມີຢູ່</string>
 </resources>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -76,6 +76,6 @@
   <string name="protocol_spinner_label">Protokols</string>
   <string name="expand">Izvērst</string>
   <string name="hostpref_add_host">Pievienot serveri</string>
-  <string name="hostpref_edit_host">Saglabāt serveri</string>
+  <string name="hostpref_save_host">Saglabāt serveri</string>
   <string name="pubkey_import_existing">Ievietot esošu publisko atslēgu</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -404,7 +404,7 @@
   <string name="expand">Rozwiń</string>
   <string name="hostpref_authagent_with_confirmation">wymaga potwierdzenia</string>
   <string name="hostpref_add_host">Dodaj host</string>
-  <string name="hostpref_edit_host">Zapisz host</string>
+  <string name="hostpref_save_host">Zapisz host</string>
   <string name="pubkey_import_existing">Importuj istniejący klucz publiczny</string>
   <string name="notification_permission_title">Utrzymuj połączenia przy życiu</string>
   <string name="notification_permission_message">Wyświetlanie powiadomienia jest wymagane do utrzymania połączeń w tle. Bez zgody połączenia mogą zostać zamknięte podczas przełączania aplikacji.</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -404,7 +404,7 @@
   <string name="expand">Expandir</string>
   <string name="hostpref_authagent_with_confirmation">requer confirmação</string>
   <string name="hostpref_add_host">Adicionar host</string>
-  <string name="hostpref_edit_host">Salvar host</string>
+  <string name="hostpref_save_host">Salvar host</string>
   <string name="pubkey_import_existing">Inportar chaves publica existente</string>
   <string name="notification_permission_title">Mantenha as conexões ativas</string>
   <string name="notification_permission_message">É necessário exibir uma notificação para manter as conexões ativas em segundo plano. Sem permissão, as conexões podem ser encerradas quando você alternar entre aplicativos.</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -215,6 +215,6 @@
   <string name="expand">Expandir</string>
   <string name="hostpref_authagent_with_confirmation">requer confirmação</string>
   <string name="hostpref_add_host">Adicionar servidor</string>
-  <string name="hostpref_edit_host">Gravar servidor</string>
+  <string name="hostpref_save_host">Gravar servidor</string>
   <string name="pubkey_import_existing">Importar chave publica existente</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -404,7 +404,7 @@
   <string name="expand">Развернуть</string>
   <string name="hostpref_authagent_with_confirmation">требуется подтверждение</string>
   <string name="hostpref_add_host">Добавить сервер</string>
-  <string name="hostpref_edit_host">Сохранить сервер</string>
+  <string name="hostpref_save_host">Сохранить сервер</string>
   <string name="pubkey_import_existing">Импортировать существующий ключ</string>
   <string name="notification_permission_title">Поддерживать соединения активными</string>
   <string name="notification_permission_message">Отображение уведомления необходимо для поддержания соединений в фоновом режиме. Без разрешения соединения могут закрываться при переключении между приложениями.</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -215,6 +215,6 @@
   <string name="expand">Mở rộng</string>
   <string name="hostpref_authagent_with_confirmation">cần xác nhận</string>
   <string name="hostpref_add_host">Thêm máy chủ (host)</string>
-  <string name="hostpref_edit_host">Lưu máy chủ (host)</string>
+  <string name="hostpref_save_host">Lưu máy chủ (host)</string>
   <string name="pubkey_import_existing">Import khoá pubkey có sẵn</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -217,6 +217,6 @@
   <string name="expand">展开</string>
   <string name="hostpref_authagent_with_confirmation">需要确认</string>
   <string name="hostpref_add_host">添加主机</string>
-  <string name="hostpref_edit_host">保存主机</string>
+  <string name="hostpref_save_host">保存主机</string>
   <string name="pubkey_import_existing">导入已有的公钥</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -221,6 +221,6 @@
   <string name="expand">展開</string>
   <string name="hostpref_authagent_with_confirmation">需要確認</string>
   <string name="hostpref_add_host">新增主機</string>
-  <string name="hostpref_edit_host">儲存主機</string>
+  <string name="hostpref_save_host">儲存主機</string>
   <string name="pubkey_import_existing">匯入現有公鑰</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1030,6 +1030,8 @@
 	<string name="hostpref_add_host">Add host</string>
 	<!-- Text for button which, when clicked, saves an existing host. -->
 	<string name="hostpref_edit_host">Save host</string>
+	<!-- Title shown in the app bar when editing an existing host's settings. -->
+	<string name="hostpref_setting_title">Host setting</string>
 	<!-- Text for button which, when clicked, brings up picker to import an existing pubkey. -->
 	<string name="pubkey_import_existing">Import existing pubkey</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1029,7 +1029,7 @@
 	<!-- Text for button which, when clicked, adds a new host. -->
 	<string name="hostpref_add_host">Add host</string>
 	<!-- Text for button which, when clicked, saves an existing host. -->
-	<string name="hostpref_edit_host">Save host</string>
+	<string name="hostpref_save_host">Save host</string>
 	<!-- Title shown in the app bar when editing an existing host's settings. -->
 	<string name="hostpref_setting_title">Host setting</string>
 	<!-- Text for button which, when clicked, brings up picker to import an existing pubkey. -->


### PR DESCRIPTION
Fix #1788. The current title of the host editing menu is "Save host," but it seems wrong. I replaced it with "Host setting" and renamed `hostpref_edit_host` to `hostpref_save_host` to avoid further mistakes. 