### PR TITLE
Prompt for username when connecting if not configured (#705)

### DIFF
--- a/app/src/main/java/org/connectbot/transport/SSH.kt
+++ b/app/src/main/java/org/connectbot/transport/SSH.kt
@@ -313,6 +313,20 @@ class SSH : AbsTransport, ConnectionMonitor, InteractiveCallback, AuthAgentCallb
     }
 
     private fun authenticate() {
+        // Prompt for username if not configured
+        if (host?.username.isNullOrEmpty()) {
+            val username = bridge?.requestStringPrompt(
+                null,
+                manager?.res?.getString(R.string.prompt_username),
+                false
+            )
+            if (username.isNullOrEmpty()) {
+                bridge?.outputLine(manager?.res?.getString(R.string.terminal_auth_fail))
+                return
+            }
+            host = host?.copy(username = username)
+        }
+
         try {
             val currentHost = host ?: return
             if (connection?.authenticateWithNone(currentHost.username) == true) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -146,6 +146,8 @@
 	<string name="prompt_destination">"Destination:"</string>
 	<!-- Prompt presented to the user when the server requests that they change their password. This is the entry for the old password. -->
 	<string name="prompt_old_password">"Old password:"</string>
+	<!-- Prompt for user to enter their username when the host has no username configured. -->
+	<string name="prompt_username">"Username:"</string>
 	<!-- Prompt for user to enter their password to log into the host when using 'password' authentication. -->
 	<string name="prompt_password">"Password:"</string>
 	<!-- Added after a "Password:" prompt to indicate user needs to confirm entry. -->


### PR DESCRIPTION
This PR fixes #705. 
When a host is saved without a username, prompt the user to enter one at connection time before attempting authentication.

🤖 Generated with [Claude Code](https://claude.com/claude-code)