### PR TITLE
Fix Migrate from legacy Again

### DIFF
--- a/app/src/main/java/org/connectbot/data/migration/DatabaseMigrator.kt
+++ b/app/src/main/java/org/connectbot/data/migration/DatabaseMigrator.kt
@@ -66,6 +66,8 @@ class DatabaseMigrator @Inject constructor(
         private const val LEGACY_HOSTS_DB = "hosts"
         private const val LEGACY_PUBKEYS_DB = "pubkeys"
         private const val MIGRATED_SUFFIX = ".migrated"
+        // Must match DATABASE_NAME in DatabaseModule.kt
+        private const val ROOM_DATABASE_NAME = "connectbot.db"
     }
 
     private val _migrationState = MutableStateFlow(MigrationState())
@@ -128,20 +130,29 @@ class DatabaseMigrator @Inject constructor(
             return@withContext false
         }
 
-        // Check if Room database has any data
-        // Note: We must check profiles table too, not just hosts/pubkeys.
-        // The profiles table may already have a default profile from DatabaseModule.onCreate()
-        // or MIGRATION_4_5, even if hosts/pubkeys are empty. (Fixes #1806)
-        val roomHasData = roomDatabase.hostDao().getAll().isNotEmpty() ||
-                         roomDatabase.pubkeyDao().getAll().isNotEmpty() ||
-                         roomDatabase.profileDao().getAll().isNotEmpty()
+        // IMPORTANT: Check if Room database FILE exists BEFORE accessing Room.
+        // This prevents a race condition where accessing Room triggers lazy initialization,
+        // which fires the onCreate callback that inserts a default profile. If we query
+        // Room first, the profiles table will never be empty, causing migration to be
+        // incorrectly skipped. (Fixes #1623)
+        val roomDbFile = context.getDatabasePath(ROOM_DATABASE_NAME)
+        if (!roomDbFile.exists()) {
+            logDebug("Migration needed: legacy databases exist and Room database file does not exist")
+            return@withContext true
+        }
 
-        if (roomHasData) {
-            logDebug("Room database already has data, skipping migration")
+        // Room database file exists - check if it has actual user data (hosts or pubkeys).
+        // We don't check profiles here because DatabaseModule.onCreate() always creates
+        // a default profile, so profiles table is never empty after Room initialization.
+        val roomHasUserData = roomDatabase.hostDao().getAll().isNotEmpty() ||
+                              roomDatabase.pubkeyDao().getAll().isNotEmpty()
+
+        if (roomHasUserData) {
+            logDebug("Room database already has user data, skipping migration")
             return@withContext false
         }
 
-        logDebug("Migration needed: legacy databases exist and Room is empty")
+        logDebug("Migration needed: legacy databases exist and Room has no user data")
         return@withContext true
     }
 

--- a/app/src/test/java/org/connectbot/data/migration/LegacyMigrationRaceConditionTest.kt
+++ b/app/src/test/java/org/connectbot/data/migration/LegacyMigrationRaceConditionTest.kt
@@ -1,0 +1,346 @@
+/*
+ * ConnectBot: simple, powerful, open-source SSH client for Android
+ * Copyright 2025 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.connectbot.data.migration
+
+import android.content.Context
+import androidx.room.Room
+import androidx.room.RoomDatabase
+import androidx.sqlite.db.SupportSQLiteDatabase
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.connectbot.data.ConnectBotDatabase
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import timber.log.Timber
+import java.io.File
+import java.io.FileOutputStream
+
+/**
+ * Test to verify the root cause of issue #1623: SSH keys disappearing after upgrade.
+ *
+ * The bug is a race condition in DatabaseMigrator.isMigrationNeeded():
+ * 1. User upgrades from old ConnectBot (legacy SQLite databases) to new beta (Room database)
+ * 2. isMigrationNeeded() checks if Room database has any data
+ * 3. This check triggers lazy initialization of Room, which fires the onCreate callback
+ * 4. The onCreate callback inserts a default profile
+ * 5. The check sees the default profile and concludes "Room has data, skip migration"
+ * 6. User's legacy pubkeys and hosts are never migrated
+ *
+ * This test reproduces the exact production scenario to verify the bug.
+ */
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [34])
+class LegacyMigrationRaceConditionTest {
+
+    private lateinit var context: Context
+    private val roomDbName = "connectbot_test_race.db"
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+
+        // Clean up any existing databases
+        context.deleteDatabase(roomDbName)
+        context.deleteDatabase("hosts")
+        context.deleteDatabase("pubkeys")
+        context.deleteDatabase("hosts.migrated")
+        context.deleteDatabase("pubkeys.migrated")
+    }
+
+    @After
+    fun tearDown() {
+        // Clean up
+        context.deleteDatabase(roomDbName)
+        context.deleteDatabase("hosts")
+        context.deleteDatabase("pubkeys")
+        context.deleteDatabase("hosts.migrated")
+        context.deleteDatabase("pubkeys.migrated")
+    }
+
+    /**
+     * This test reproduces the exact scenario from issue #1623.
+     *
+     * Expected behavior: When legacy databases exist and Room database doesn't exist yet,
+     * isMigrationNeeded() should return true.
+     *
+     * Actual behavior (the bug): isMigrationNeeded() returns false because checking the
+     * Room database causes Room to create a default profile, making it appear that Room
+     * already has data.
+     */
+    @Test
+    fun isMigrationNeeded_withLegacyDatabases_shouldReturnTrue() = runTest {
+        // Step 1: Create legacy database files (simulating an upgrade from old ConnectBot)
+        createLegacyHostsDatabase()
+        createLegacyPubkeysDatabase()
+
+        // Verify legacy databases exist
+        val hostsDbFile = context.getDatabasePath("hosts")
+        val pubkeysDbFile = context.getDatabasePath("pubkeys")
+        assertThat(hostsDbFile.exists()).isTrue()
+        assertThat(pubkeysDbFile.exists()).isTrue()
+
+        // Step 2: Verify Room database file does NOT exist yet
+        val roomDbFile = context.getDatabasePath(roomDbName)
+        assertThat(roomDbFile.exists()).isFalse()
+
+        // Step 3: Create Room database with the EXACT same configuration as production
+        // This includes the onCreate callback that inserts a default profile
+        val database = Room.databaseBuilder(
+            context,
+            ConnectBotDatabase::class.java,
+            roomDbName
+        )
+            .addMigrations(ConnectBotDatabase.MIGRATION_4_5)
+            .addCallback(object : RoomDatabase.Callback() {
+                override fun onCreate(db: SupportSQLiteDatabase) {
+                    super.onCreate(db)
+                    // This is the exact same code from DatabaseModule.kt
+                    // It creates a default profile when the database is first created
+                    Timber.d("Room onCreate callback - inserting default profile")
+                    db.execSQL("""
+                        INSERT INTO profiles (name, color_scheme_id, font_size, del_key, encoding, emulation)
+                        VALUES ('Default', -1, 10, 'del', 'UTF-8', 'xterm-256color')
+                    """.trimIndent())
+                }
+            })
+            .allowMainThreadQueries()
+            .build()
+
+        try {
+            // Step 4: Create the migrator (same as production)
+            val legacyHostReader = LegacyHostDatabaseReader(context)
+            val legacyPubkeyReader = LegacyPubkeyDatabaseReader(context)
+            val migrator = DatabaseMigrator(context, database, legacyHostReader, legacyPubkeyReader)
+
+            // Step 5: Call isMigrationNeeded() - this is where the bug manifests
+            // The bug: This call triggers Room lazy initialization, which fires onCreate,
+            // which inserts a default profile, which makes the check fail
+            val isMigrationNeeded = migrator.isMigrationNeeded()
+
+            // Step 6: Assert the expected behavior
+            // BUG: Due to the race condition, this returns FALSE when it should return TRUE
+            // The assertion below will FAIL until the bug is fixed
+            assertThat(isMigrationNeeded)
+                .describedAs(
+                    "isMigrationNeeded() should return true when legacy databases exist " +
+                    "and Room database was just created. The bug causes it to return false " +
+                    "because Room's onCreate callback inserts a default profile before " +
+                    "the migration check completes."
+                )
+                .isTrue()
+
+        } finally {
+            database.close()
+        }
+    }
+
+    /**
+     * This test verifies that the migration check incorrectly sees a non-empty profiles table.
+     *
+     * This demonstrates the mechanism of the bug: the profiles table is populated by Room's
+     * onCreate callback before isMigrationNeeded() can check if migration is needed.
+     */
+    @Test
+    fun roomOnCreate_insertsDefaultProfile_beforeMigrationCheck() = runTest {
+        // Create legacy databases
+        createLegacyHostsDatabase()
+        createLegacyPubkeysDatabase()
+
+        // Verify Room database doesn't exist
+        val roomDbFile = context.getDatabasePath(roomDbName)
+        assertThat(roomDbFile.exists()).isFalse()
+
+        // Create Room database with production-like configuration
+        val database = Room.databaseBuilder(
+            context,
+            ConnectBotDatabase::class.java,
+            roomDbName
+        )
+            .addMigrations(ConnectBotDatabase.MIGRATION_4_5)
+            .addCallback(object : RoomDatabase.Callback() {
+                override fun onCreate(db: SupportSQLiteDatabase) {
+                    super.onCreate(db)
+                    db.execSQL("""
+                        INSERT INTO profiles (name, color_scheme_id, font_size, del_key, encoding, emulation)
+                        VALUES ('Default', -1, 10, 'del', 'UTF-8', 'xterm-256color')
+                    """.trimIndent())
+                }
+            })
+            .allowMainThreadQueries()
+            .build()
+
+        try {
+            // This is the first database access - triggers onCreate
+            val profiles = database.profileDao().getAll()
+
+            // The bug mechanism: profiles table already has the default profile
+            // even though we never explicitly inserted it
+            assertThat(profiles).isNotEmpty()
+            assertThat(profiles.first().name).isEqualTo("Default")
+
+            // And hosts/pubkeys are empty (legacy data was never migrated)
+            val hosts = database.hostDao().getAll()
+            val pubkeys = database.pubkeyDao().getAll()
+            assertThat(hosts).isEmpty()
+            assertThat(pubkeys).isEmpty()
+
+            // This is the exact scenario that causes the bug:
+            // - Legacy databases exist with user data
+            // - Room database was just created
+            // - profiles table has a default profile (from onCreate)
+            // - hosts and pubkeys tables are empty
+            // - isMigrationNeeded() checks: hosts.isEmpty && pubkeys.isEmpty && profiles.isEmpty
+            // - profiles.isEmpty is FALSE (because of the default profile)
+            // - So isMigrationNeeded() returns false, skipping migration
+
+        } finally {
+            database.close()
+        }
+    }
+
+    /**
+     * Creates a minimal legacy hosts database with one host entry.
+     * This simulates the database structure from the old ConnectBot version.
+     */
+    private fun createLegacyHostsDatabase() {
+        val dbFile = context.getDatabasePath("hosts")
+        dbFile.parentFile?.mkdirs()
+
+        val db = android.database.sqlite.SQLiteDatabase.openOrCreateDatabase(dbFile, null)
+        try {
+            // Create the hosts table with the legacy schema (version 27)
+            db.execSQL("""
+                CREATE TABLE IF NOT EXISTS hosts (
+                    _id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    nickname TEXT NOT NULL,
+                    protocol TEXT NOT NULL DEFAULT 'ssh',
+                    username TEXT NOT NULL DEFAULT '',
+                    hostname TEXT NOT NULL,
+                    port INTEGER NOT NULL DEFAULT 22,
+                    hostkey TEXT,
+                    lastconnect INTEGER DEFAULT 0,
+                    color TEXT,
+                    usekeys INTEGER DEFAULT 1,
+                    useauthagent TEXT,
+                    postlogin TEXT,
+                    pubkeyid INTEGER DEFAULT -1,
+                    wantsession INTEGER DEFAULT 1,
+                    compression INTEGER DEFAULT 0,
+                    encoding TEXT DEFAULT 'UTF-8',
+                    stayconnected INTEGER DEFAULT 0,
+                    quickdisconnect INTEGER DEFAULT 0,
+                    fontsize INTEGER DEFAULT 10,
+                    colorscheme INTEGER DEFAULT 1,
+                    delkey TEXT DEFAULT 'DEL',
+                    scrollback INTEGER DEFAULT 140,
+                    ctrl_alt_meta INTEGER DEFAULT 0
+                )
+            """.trimIndent())
+
+            // Insert a sample host
+            db.execSQL("""
+                INSERT INTO hosts (nickname, protocol, username, hostname, port, usekeys)
+                VALUES ('test-server', 'ssh', 'testuser', 'test.example.com', 22, 1)
+            """.trimIndent())
+
+            // Create other tables that might be expected
+            db.execSQL("""
+                CREATE TABLE IF NOT EXISTS portforwards (
+                    _id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    hostid INTEGER NOT NULL,
+                    nickname TEXT NOT NULL,
+                    type TEXT NOT NULL DEFAULT 'local',
+                    sourceport INTEGER NOT NULL,
+                    destaddr TEXT NOT NULL,
+                    destport INTEGER NOT NULL
+                )
+            """.trimIndent())
+
+            db.execSQL("""
+                CREATE TABLE IF NOT EXISTS knownhosts (
+                    _id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    hostid INTEGER,
+                    hostname TEXT NOT NULL,
+                    port INTEGER NOT NULL,
+                    hostkeyalgo TEXT NOT NULL,
+                    hostkey BLOB NOT NULL
+                )
+            """.trimIndent())
+
+            db.execSQL("""
+                CREATE TABLE IF NOT EXISTS color_schemes (
+                    _id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    name TEXT NOT NULL
+                )
+            """.trimIndent())
+
+            db.execSQL("""
+                CREATE TABLE IF NOT EXISTS color_palette (
+                    _id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    scheme_id INTEGER NOT NULL,
+                    color_index INTEGER NOT NULL,
+                    color INTEGER NOT NULL
+                )
+            """.trimIndent())
+
+        } finally {
+            db.close()
+        }
+    }
+
+    /**
+     * Creates a minimal legacy pubkeys database with one key entry.
+     * This simulates the database structure from the old ConnectBot version.
+     */
+    private fun createLegacyPubkeysDatabase() {
+        val dbFile = context.getDatabasePath("pubkeys")
+        dbFile.parentFile?.mkdirs()
+
+        val db = android.database.sqlite.SQLiteDatabase.openOrCreateDatabase(dbFile, null)
+        try {
+            // Create the pubkeys table with the legacy schema (version 2)
+            db.execSQL("""
+                CREATE TABLE IF NOT EXISTS pubkeys (
+                    _id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    nickname TEXT NOT NULL,
+                    type TEXT NOT NULL,
+                    private BLOB NOT NULL,
+                    public BLOB NOT NULL,
+                    encrypted INTEGER DEFAULT 0,
+                    startup INTEGER DEFAULT 0,
+                    confirmuse INTEGER DEFAULT 0,
+                    lifetime INTEGER DEFAULT 0
+                )
+            """.trimIndent())
+
+            // Insert a sample pubkey
+            db.execSQL("""
+                INSERT INTO pubkeys (nickname, type, private, public, encrypted, startup, confirmuse)
+                VALUES ('my-test-key', 'RSA', X'010203', X'040506', 0, 1, 0)
+            """.trimIndent())
+
+        } finally {
+            db.close()
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes the case that happened in the migration to the beta process in #1813. I found that I embedded a bug in #1807. 

Summary                                                                                                                                                                                                                             
                                                                                                                                                                                                                                      
  - Fix race condition in DatabaseMigrator.isMigrationNeeded() that caused legacy SSH keys and hosts to not be migrated when upgrading from older ConnectBot versions                                                                 
  - Add a regression test to prevent future occurrences                                                                                                                                                                                 
                                                                                                                                                                                                                                      
  Test plan                                                                                                                                                                                                                           
                                                                                                                                                                                                                                      
  - Run LegacyMigrationRaceConditionTest - verifies the fix works                                                                                                                                                                     
  - Run full unit test suite - all tests pass                                                                                                                                                                                         
  - Manual test: Install old ConnectBot, import SSH keys, upgrade to this version, verify keys are migrated                                                                                                                           
                                                                                                                                                                                                                                      
  Root Cause Analysis                                                                                                                                                                                                                 
                                                                                                                                                                                                                                      
  When users upgraded from legacy ConnectBot (using SQLite database hosts and pubkeys) to the new beta (using Room database), their SSH keys disappeared.                                                                            
                                                                                                                                                                                                                                      
  The bug was in DatabaseMigrator.isMigrationNeeded():                                                                                                                                                                                
                                                                                                                                                                                                                                      
  1. The method checked if the Room database had any data by querying profileDao().getAll()                                                                                                                                               
  2. This query triggered lazy initialization of Room                                                                                                                                                                                 
  3. Room's onCreate callback in DatabaseModule inserted a default profile                                                                                                                                                            
  4. The check then saw data in the profiles table and concluded "Room has data, skip migration."                                                                                                                                      
  5. Legacy pubkeys and hosts were never migrated                                                                                                                                                                                     
                                                                                                                                                                                                                                      
  Fix                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                      
  Check if the Room database file exists before accessing Room. This prevents the lazy initialization that caused the race condition:                                                                                                 
                                                                                                                                                                                                                                      
  val roomDbFile = context.getDatabasePath(ROOM_DATABASE_NAME)                                                                                                                                                                        
  if (!roomDbFile.exists()) {                                                                                                                                                                                                         
      // Migration needed - don't trigger Room initialization                                                                                                                                                                         
      return true                                                                                                                                                                                                                     
  }                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                      
  Also removed the profiles table check since DatabaseModule.onCreate() always creates a default profile, making it unreliable for detecting user data.