### PR TITLE
Add force size option to terminal profiles (#334, #1053)

### DIFF
--- a/app/schemas/org.connectbot.data.ConnectBotDatabase/6.json
+++ b/app/schemas/org.connectbot.data.ConnectBotDatabase/6.json
@@ -1,0 +1,656 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 6,
+    "identityHash": "6545c0c2dc3f70b21ed4ee9c9b08cb25",
+    "entities": [
+      {
+        "tableName": "hosts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `nickname` TEXT NOT NULL, `protocol` TEXT NOT NULL, `username` TEXT NOT NULL, `hostname` TEXT NOT NULL, `port` INTEGER NOT NULL, `host_key_algo` TEXT, `last_connect` INTEGER NOT NULL, `color` TEXT, `use_keys` INTEGER NOT NULL, `use_auth_agent` TEXT, `post_login` TEXT, `pubkey_id` INTEGER NOT NULL, `want_session` INTEGER NOT NULL, `compression` INTEGER NOT NULL, `stay_connected` INTEGER NOT NULL, `quick_disconnect` INTEGER NOT NULL, `scrollback_lines` INTEGER NOT NULL, `use_ctrl_alt_as_meta_key` INTEGER NOT NULL, `jump_host_id` INTEGER, `profile_id` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nickname",
+            "columnName": "nickname",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "protocol",
+            "columnName": "protocol",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hostname",
+            "columnName": "hostname",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "port",
+            "columnName": "port",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hostKeyAlgo",
+            "columnName": "host_key_algo",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastConnect",
+            "columnName": "last_connect",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "useKeys",
+            "columnName": "use_keys",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "useAuthAgent",
+            "columnName": "use_auth_agent",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "postLogin",
+            "columnName": "post_login",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pubkeyId",
+            "columnName": "pubkey_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "wantSession",
+            "columnName": "want_session",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "compression",
+            "columnName": "compression",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stayConnected",
+            "columnName": "stay_connected",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "quickDisconnect",
+            "columnName": "quick_disconnect",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scrollbackLines",
+            "columnName": "scrollback_lines",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "useCtrlAltAsMetaKey",
+            "columnName": "use_ctrl_alt_as_meta_key",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "jumpHostId",
+            "columnName": "jump_host_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "profileId",
+            "columnName": "profile_id",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_hosts_nickname",
+            "unique": true,
+            "columnNames": [
+              "nickname"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_hosts_nickname` ON `${TABLE_NAME}` (`nickname`)"
+          },
+          {
+            "name": "index_hosts_protocol_username_hostname_port",
+            "unique": false,
+            "columnNames": [
+              "protocol",
+              "username",
+              "hostname",
+              "port"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_hosts_protocol_username_hostname_port` ON `${TABLE_NAME}` (`protocol`, `username`, `hostname`, `port`)"
+          }
+        ]
+      },
+      {
+        "tableName": "pubkeys",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `nickname` TEXT NOT NULL, `type` TEXT NOT NULL, `private_key` BLOB, `public_key` BLOB NOT NULL, `encrypted` INTEGER NOT NULL, `startup` INTEGER NOT NULL, `confirmation` INTEGER NOT NULL, `created_date` INTEGER NOT NULL, `storage_type` TEXT NOT NULL, `allow_backup` INTEGER NOT NULL, `keystore_alias` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nickname",
+            "columnName": "nickname",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "privateKey",
+            "columnName": "private_key",
+            "affinity": "BLOB"
+          },
+          {
+            "fieldPath": "publicKey",
+            "columnName": "public_key",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "encrypted",
+            "columnName": "encrypted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startup",
+            "columnName": "startup",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "confirmation",
+            "columnName": "confirmation",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdDate",
+            "columnName": "created_date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storageType",
+            "columnName": "storage_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "allowBackup",
+            "columnName": "allow_backup",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "keystoreAlias",
+            "columnName": "keystore_alias",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_pubkeys_nickname",
+            "unique": true,
+            "columnNames": [
+              "nickname"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_pubkeys_nickname` ON `${TABLE_NAME}` (`nickname`)"
+          },
+          {
+            "name": "index_pubkeys_storage_type",
+            "unique": false,
+            "columnNames": [
+              "storage_type"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_pubkeys_storage_type` ON `${TABLE_NAME}` (`storage_type`)"
+          },
+          {
+            "name": "index_pubkeys_allow_backup",
+            "unique": false,
+            "columnNames": [
+              "allow_backup"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_pubkeys_allow_backup` ON `${TABLE_NAME}` (`allow_backup`)"
+          }
+        ]
+      },
+      {
+        "tableName": "port_forwards",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `host_id` INTEGER NOT NULL, `nickname` TEXT NOT NULL, `type` TEXT NOT NULL, `source_port` INTEGER NOT NULL, `dest_addr` TEXT, `dest_port` INTEGER NOT NULL, FOREIGN KEY(`host_id`) REFERENCES `hosts`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hostId",
+            "columnName": "host_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nickname",
+            "columnName": "nickname",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourcePort",
+            "columnName": "source_port",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "destAddr",
+            "columnName": "dest_addr",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "destPort",
+            "columnName": "dest_port",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_port_forwards_host_id",
+            "unique": false,
+            "columnNames": [
+              "host_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_port_forwards_host_id` ON `${TABLE_NAME}` (`host_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "hosts",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "host_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "known_hosts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `host_id` INTEGER, `hostname` TEXT NOT NULL, `port` INTEGER NOT NULL, `host_key_algo` TEXT NOT NULL, `host_key` BLOB NOT NULL, FOREIGN KEY(`host_id`) REFERENCES `hosts`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hostId",
+            "columnName": "host_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "hostname",
+            "columnName": "hostname",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "port",
+            "columnName": "port",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hostKeyAlgo",
+            "columnName": "host_key_algo",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hostKey",
+            "columnName": "host_key",
+            "affinity": "BLOB",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_known_hosts_host_id",
+            "unique": false,
+            "columnNames": [
+              "host_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_known_hosts_host_id` ON `${TABLE_NAME}` (`host_id`)"
+          },
+          {
+            "name": "index_known_hosts_host_id_host_key",
+            "unique": false,
+            "columnNames": [
+              "host_id",
+              "host_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_known_hosts_host_id_host_key` ON `${TABLE_NAME}` (`host_id`, `host_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "hosts",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "host_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "color_schemes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `is_built_in` INTEGER NOT NULL, `description` TEXT NOT NULL, `foreground` INTEGER NOT NULL, `background` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isBuiltIn",
+            "columnName": "is_built_in",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "foreground",
+            "columnName": "foreground",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "background",
+            "columnName": "background",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_color_schemes_name",
+            "unique": true,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_color_schemes_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "color_palette",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `scheme_id` INTEGER NOT NULL, `color_index` INTEGER NOT NULL, `color` INTEGER NOT NULL, FOREIGN KEY(`scheme_id`) REFERENCES `color_schemes`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "schemeId",
+            "columnName": "scheme_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "colorIndex",
+            "columnName": "color_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_color_palette_scheme_id",
+            "unique": false,
+            "columnNames": [
+              "scheme_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_color_palette_scheme_id` ON `${TABLE_NAME}` (`scheme_id`)"
+          },
+          {
+            "name": "index_color_palette_scheme_id_color_index",
+            "unique": true,
+            "columnNames": [
+              "scheme_id",
+              "color_index"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_color_palette_scheme_id_color_index` ON `${TABLE_NAME}` (`scheme_id`, `color_index`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "color_schemes",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "scheme_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "profiles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `icon_color` TEXT, `color_scheme_id` INTEGER NOT NULL DEFAULT -1, `font_family` TEXT, `font_size` INTEGER NOT NULL DEFAULT 10, `del_key` TEXT NOT NULL DEFAULT 'del', `encoding` TEXT NOT NULL DEFAULT 'UTF-8', `emulation` TEXT NOT NULL DEFAULT 'xterm-256color', `force_size_rows` INTEGER, `force_size_columns` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "iconColor",
+            "columnName": "icon_color",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "colorSchemeId",
+            "columnName": "color_scheme_id",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "-1"
+          },
+          {
+            "fieldPath": "fontFamily",
+            "columnName": "font_family",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fontSize",
+            "columnName": "font_size",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "10"
+          },
+          {
+            "fieldPath": "delKey",
+            "columnName": "del_key",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'del'"
+          },
+          {
+            "fieldPath": "encoding",
+            "columnName": "encoding",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'UTF-8'"
+          },
+          {
+            "fieldPath": "emulation",
+            "columnName": "emulation",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'xterm-256color'"
+          },
+          {
+            "fieldPath": "forceSizeRows",
+            "columnName": "force_size_rows",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "forceSizeColumns",
+            "columnName": "force_size_columns",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_profiles_name",
+            "unique": true,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_profiles_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '6545c0c2dc3f70b21ed4ee9c9b08cb25')"
+    ]
+  }
+}

--- a/app/src/main/java/org/connectbot/data/ConnectBotDatabase.kt
+++ b/app/src/main/java/org/connectbot/data/ConnectBotDatabase.kt
@@ -55,6 +55,7 @@ import org.connectbot.data.entity.Pubkey
  * - Version 3: Added unique index on known_hosts (hostname, port) (AutoMigration)
  * - Version 4: Changed known_hosts index to (host_id, host_key) (AutoMigration)
  * - Version 5: Added profiles table and profile_id column to hosts (manual migration)
+ * - Version 6: Added force_size_rows and force_size_columns to profiles (AutoMigration)
  * - Future versions: Use Room AutoMigration when possible for simple schema changes
  *
  * Security Considerations:
@@ -71,12 +72,13 @@ import org.connectbot.data.entity.Pubkey
         ColorPalette::class,
         Profile::class
     ],
-    version = 5,
+    version = 6,
     exportSchema = true,
     autoMigrations = [
         AutoMigration(from = 1, to = 2),
         AutoMigration(from = 2, to = 4),
-        AutoMigration(from = 3, to = 4)
+        AutoMigration(from = 3, to = 4),
+        AutoMigration(from = 5, to = 6)
     ]
 )
 @TypeConverters(Converters::class)
@@ -93,7 +95,7 @@ abstract class ConnectBotDatabase : RoomDatabase() {
          * Current database schema version.
          * This is also used for JSON export/import versioning.
          */
-        const val SCHEMA_VERSION = 5
+        const val SCHEMA_VERSION = 6
 
         /**
          * Migration from version 4 to 5: Add profiles table and profile_id to hosts.
@@ -218,5 +220,6 @@ abstract class ConnectBotDatabase : RoomDatabase() {
                 db.execSQL("CREATE INDEX IF NOT EXISTS `index_hosts_protocol_username_hostname_port` ON `hosts` (`protocol`, `username`, `hostname`, `port`)")
             }
         }
+
     }
 }

--- a/app/src/main/java/org/connectbot/data/entity/Profile.kt
+++ b/app/src/main/java/org/connectbot/data/entity/Profile.kt
@@ -37,6 +37,8 @@ import androidx.room.PrimaryKey
  * @property delKey DEL key behavior ("del" or "backspace")
  * @property encoding Character encoding (e.g., "UTF-8")
  * @property emulation Terminal emulation mode (e.g., "xterm-256color")
+ * @property forceSizeRows Forced terminal rows (null = auto-size based on screen)
+ * @property forceSizeColumns Forced terminal columns (null = auto-size based on screen)
  */
 @Entity(
     tableName = "profiles",
@@ -71,7 +73,13 @@ data class Profile(
     val encoding: String = "UTF-8",
 
     @ColumnInfo(defaultValue = "'xterm-256color'")
-    val emulation: String = "xterm-256color"
+    val emulation: String = "xterm-256color",
+
+    @ColumnInfo(name = "force_size_rows")
+    val forceSizeRows: Int? = null,
+
+    @ColumnInfo(name = "force_size_columns")
+    val forceSizeColumns: Int? = null
 ) {
     companion object {
         /**

--- a/app/src/main/java/org/connectbot/service/TerminalBridge.kt
+++ b/app/src/main/java/org/connectbot/service/TerminalBridge.kt
@@ -109,6 +109,14 @@ class TerminalBridge {
     /** Font family from profile for terminal display */
     val fontFamily: String?
 
+    /** Force size rows from profile (null = auto-size) */
+    var profileForceSizeRows: Int? = null
+        private set
+
+    /** Force size columns from profile (null = auto-size) */
+    var profileForceSizeColumns: Int? = null
+        private set
+
     // Terminal emulator from ConnectBot Terminal library
     val terminalEmulator: TerminalEmulator
 
@@ -190,6 +198,10 @@ class TerminalBridge {
         // Store encoding and font family from profile for later use
         encoding = profile.encoding
         fontFamily = profile.fontFamily
+
+        // Store force size from profile
+        profileForceSizeRows = profile.forceSizeRows
+        profileForceSizeColumns = profile.forceSizeColumns
 
         // Use settings from profile
         var fontSizeSp = profile.fontSize
@@ -361,6 +373,10 @@ class TerminalBridge {
             val ansiColors = fullColorPalette.sliceArray(0 until 16)
             terminalEmulator.applyColorScheme(ansiColors, defaultFgColor, defaultBgColor)
         }
+
+        // Update force size from profile
+        profileForceSizeRows = profile.forceSizeRows
+        profileForceSizeColumns = profile.forceSizeColumns
 
         // Note: encoding and fontFamily changes require reconnection to take effect
         // as they are deeply integrated into the terminal initialization

--- a/app/src/main/java/org/connectbot/ui/components/ResizeDialog.kt
+++ b/app/src/main/java/org/connectbot/ui/components/ResizeDialog.kt
@@ -41,8 +41,10 @@ import org.connectbot.service.TerminalBridge
 @Composable
 fun ResizeDialog(
     currentBridge: TerminalBridge,
+    isForced: Boolean,
     onDismiss: () -> Unit,
-    onResize: (Int, Int) -> Unit
+    onResize: (Int, Int) -> Unit,
+    onDisableForceSize: () -> Unit
 ) {
     val dimensions = currentBridge.terminalEmulator.dimensions
 
@@ -84,6 +86,18 @@ fun ResizeDialog(
                     singleLine = true,
                     modifier = Modifier.fillMaxWidth()
                 )
+
+                if (isForced) {
+                    TextButton(
+                        onClick = {
+                            onDisableForceSize()
+                            onDismiss()
+                        },
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Text(stringResource(R.string.resize_disable_force_size))
+                    }
+                }
             }
         },
         confirmButton = {

--- a/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
@@ -260,6 +260,19 @@ fun ConsoleScreen(
     val canForwardPorts = currentBridge?.canFowardPorts() == true
     val snackbarHostState = remember { SnackbarHostState() }
 
+    // Initialize forceSize from profile when bridge changes
+    LaunchedEffect(currentBridge) {
+        currentBridge?.let { bridge ->
+            val rows = bridge.profileForceSizeRows
+            val cols = bridge.profileForceSizeColumns
+            if (rows != null && cols != null) {
+                forceSize = Pair(rows, cols)
+            } else {
+                forceSize = null
+            }
+        }
+    }
+
     // Show snackbar when there's an error
     LaunchedEffect(uiState.error) {
         uiState.error?.let { error ->
@@ -482,10 +495,15 @@ fun ConsoleScreen(
         if (showResizeDialog && currentBridge != null) {
             ResizeDialog(
                 currentBridge = currentBridge,
+                isForced = forceSize != null,
                 onDismiss = { showResizeDialog = false },
                 onResize = { width, height ->
                     // Resize the terminal emulator
                     forceSize = Pair(height, width)
+                },
+                onDisableForceSize = {
+                    // Disable force size for this session
+                    forceSize = null
                 }
             )
         }

--- a/app/src/main/java/org/connectbot/ui/screens/profiles/ProfileEditorScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/profiles/ProfileEditorScreen.kt
@@ -19,11 +19,14 @@ package org.connectbot.ui.screens.profiles
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -46,8 +49,10 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Slider
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -236,6 +241,18 @@ fun ProfileEditorScreen(
                 EncodingSelector(
                     encoding = uiState.encoding,
                     onEncodingSelected = { viewModel.updateEncoding(it) },
+                    modifier = Modifier.fillMaxWidth()
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                ForceSizeSelector(
+                    enabled = uiState.forceSizeEnabled,
+                    rows = uiState.forceSizeRows,
+                    columns = uiState.forceSizeColumns,
+                    onEnabledChange = { viewModel.updateForceSizeEnabled(it) },
+                    onRowsChange = { viewModel.updateForceSizeRows(it) },
+                    onColumnsChange = { viewModel.updateForceSizeColumns(it) },
                     modifier = Modifier.fillMaxWidth()
                 )
 
@@ -658,6 +675,78 @@ private fun IconColorSelector(
                         contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding
                     )
                 }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ForceSizeSelector(
+    enabled: Boolean,
+    rows: Int,
+    columns: Int,
+    onEnabledChange: (Boolean) -> Unit,
+    onRowsChange: (Int) -> Unit,
+    onColumnsChange: (Int) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(modifier = modifier) {
+        Text(
+            text = stringResource(R.string.profile_editor_force_size_title),
+            style = MaterialTheme.typography.titleMedium,
+            modifier = Modifier.padding(bottom = 4.dp)
+        )
+        Text(
+            text = stringResource(R.string.profile_editor_force_size_summary),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(bottom = 8.dp)
+        )
+
+        Row(
+            verticalAlignment = androidx.compose.ui.Alignment.CenterVertically,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text(
+                text = stringResource(R.string.profile_editor_force_size_enable),
+                style = MaterialTheme.typography.bodyLarge,
+                modifier = Modifier.weight(1f)
+            )
+            Switch(
+                checked = enabled,
+                onCheckedChange = onEnabledChange
+            )
+        }
+
+        if (enabled) {
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Row(
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                OutlinedTextField(
+                    value = columns.toString(),
+                    onValueChange = { value ->
+                        value.toIntOrNull()?.let { onColumnsChange(it) }
+                    },
+                    label = { Text(stringResource(R.string.profile_editor_force_size_columns)) },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    singleLine = true,
+                    modifier = Modifier.weight(1f)
+                )
+
+                Spacer(modifier = Modifier.width(16.dp))
+
+                OutlinedTextField(
+                    value = rows.toString(),
+                    onValueChange = { value ->
+                        value.toIntOrNull()?.let { onRowsChange(it) }
+                    },
+                    label = { Text(stringResource(R.string.profile_editor_force_size_rows)) },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    singleLine = true,
+                    modifier = Modifier.weight(1f)
+                )
             }
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -505,6 +505,16 @@
 	<string name="profile_editor_font_family_title">Font Family</string>
 	<!-- Subsection title showing current font size. Parameter is the font size in points. -->
 	<string name="profile_editor_font_size_title">Font Size: %d</string>
+	<!-- Subsection title for force size settings -->
+	<string name="profile_editor_force_size_title">Force Size</string>
+	<!-- Summary text explaining what force size does -->
+	<string name="profile_editor_force_size_summary">Force the terminal to a specific size (columns x rows) instead of auto-sizing to fit the screen.</string>
+	<!-- Label for the enable force size switch -->
+	<string name="profile_editor_force_size_enable">Enable force size</string>
+	<!-- Label for the force size columns input field -->
+	<string name="profile_editor_force_size_columns">Columns</string>
+	<!-- Label for the force size rows input field -->
+	<string name="profile_editor_force_size_rows">Rows</string>
 	<!-- Dropdown option to not override host color with profile color -->
 	<string name="profile_icon_color_none">None (use host color)</string>
 
@@ -976,6 +986,8 @@
 	<string name="resize_width_label">Width (columns)</string>
 	<!-- Label for height input field in terminal resize dialog -->
 	<string name="resize_height_label">Height (rows)</string>
+	<!-- Button to disable force size and return to auto-sizing -->
+	<string name="resize_disable_force_size">Disable force size</string>
 
 	<!-- Public key editor labels -->
 	<!-- Label for key type field in the SSH pubkey editor -->


### PR DESCRIPTION
Fixes #334 and #1053.
Add persistent force size settings to terminal profiles, allowing users to configure a fixed terminal size (columns x rows) that is automatically applied when connecting to a host.

Changes:
- Add forceSizeRows and forceSizeColumns fields to Profile entity
- Add ForceSizeSelector UI in profile editor with enable toggle
- Load force size from profile in TerminalBridge
- Initialize session force size from profile in ConsoleScreen
- Add "Disable force size" button to resize dialog for session override

🤖 Generated with [Claude Code](https://claude.com/claude-code)