### PR TITLE
MINOR FIX: Fix SOCKS5 port forward save error with empty destination

### DIFF
--- a/app/src/main/java/org/connectbot/ui/screens/portforwardlist/PortForwardListViewModel.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/portforwardlist/PortForwardListViewModel.kt
@@ -33,6 +33,7 @@ import org.connectbot.data.entity.PortForward
 import org.connectbot.di.CoroutineDispatchers
 import org.connectbot.service.TerminalBridge
 import org.connectbot.service.TerminalManager
+import org.connectbot.util.HostConstants
 import timber.log.Timber
 import javax.inject.Inject
 
@@ -121,7 +122,11 @@ class PortForwardListViewModel @Inject constructor(
         viewModelScope.launch {
             try {
                 val srcPort = validatePort(sourcePort, "source")
-                val parsed = parseDestination(destination)
+                val parsed = if (type == HostConstants.PORTFORWARD_DYNAMIC5) {
+                    ParsedDestination(null, 0)
+                } else {
+                    parseDestination(destination)
+                }
 
                 val newPortForward = withContext(dispatchers.io) {
                     val portForward = PortForward(
@@ -161,7 +166,11 @@ class PortForwardListViewModel @Inject constructor(
         viewModelScope.launch {
             try {
                 val srcPort = validatePort(sourcePort, "source")
-                val parsed = parseDestination(destination)
+                val parsed = if (type == HostConstants.PORTFORWARD_DYNAMIC5) {
+                    ParsedDestination(null, 0)
+                } else {
+                    parseDestination(destination)
+                }
 
                 val updated = withContext(dispatchers.io) {
                     val updatedPf = portForward.copy(

--- a/app/src/main/java/org/connectbot/ui/screens/portforwardlist/PortForwardListViewModel.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/portforwardlist/PortForwardListViewModel.kt
@@ -284,9 +284,7 @@ class PortForwardListViewModel @Inject constructor(
         }
     }
 
-    private fun findBridgeForHost(): TerminalBridge? {
-        return _terminalManager.value?.bridgesFlow?.value?.find { it.host.id == hostId }
-    }
+    private fun findBridgeForHost(): TerminalBridge? = _terminalManager.value?.bridgesFlow?.value?.find { it.host.id == hostId }
 
     private fun validatePort(portString: String, portType: String): Int {
         val port = portString.toIntOrNull()

--- a/app/src/test/java/org/connectbot/ui/screens/portforwardlist/PortForwardListViewModelTest.kt
+++ b/app/src/test/java/org/connectbot/ui/screens/portforwardlist/PortForwardListViewModelTest.kt
@@ -121,17 +121,15 @@ class PortForwardListViewModelTest {
         sourcePort: Int = 8080,
         destAddr: String = "localhost",
         destPort: Int = 80
-    ): PortForward {
-        return PortForward(
-            id = id,
-            hostId = testHostId,
-            nickname = nickname,
-            type = type,
-            sourcePort = sourcePort,
-            destAddr = destAddr,
-            destPort = destPort
-        )
-    }
+    ): PortForward = PortForward(
+        id = id,
+        hostId = testHostId,
+        nickname = nickname,
+        type = type,
+        sourcePort = sourcePort,
+        destAddr = destAddr,
+        destPort = destPort
+    )
 
     @Test
     fun initialState_LoadsSuccessfully() = runTest {
@@ -508,7 +506,7 @@ class PortForwardListViewModelTest {
             nickname = "socks-proxy",
             type = HostConstants.PORTFORWARD_DYNAMIC5,
             sourcePort = "1080",
-            destination = ""  // Empty destination should be accepted for SOCKS5
+            destination = "" // Empty destination should be accepted for SOCKS5
         )
         advanceUntilIdle()
 
@@ -542,7 +540,7 @@ class PortForwardListViewModelTest {
             nickname = "updated-socks",
             type = HostConstants.PORTFORWARD_DYNAMIC5,
             sourcePort = "8080",
-            destination = ""  // Empty destination should be accepted for SOCKS5
+            destination = "" // Empty destination should be accepted for SOCKS5
         )
         advanceUntilIdle()
 


### PR DESCRIPTION
SOCKS5 (dynamic) port forwarding doesn't require a destination address since it routes connections based on the client's SOCKS5 protocol request. Skip destination validation for PORTFORWARD_DYNAMIC5 type. 
The current workaround without this fix is to type something as other type, then switch to SOCKS5 (changing the type will not erase the field content).