### PR TITLE
Add OSC8 hyperlink support

### DIFF
--- a/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
@@ -438,6 +438,14 @@ fun ConsoleScreen(
                             onTerminalTap = { handleTerminalInteraction() },
                             onImeVisibilityChanged = { visible ->
                                 imeVisible = visible
+                            },
+                            onHyperlinkClick = { url ->
+                                // Open OSC8 hyperlink in browser
+                                val intent = android.content.Intent(
+                                    android.content.Intent.ACTION_VIEW,
+                                    url.toUri()
+                                )
+                                context.startActivity(intent)
                             }
                         )
 


### PR DESCRIPTION
## Summary
  - Integrate OSC8 hyperlink support using connectbot/termlib#66
  - Clickable hyperlinks in the terminal that open in the system browser

  ## Changes
  - `settings.gradle.kts`: Add composite build for local termlib with OSC8 support
  - `ConsoleScreen.kt`: Add `onHyperlinkClick` handler to open URLs via Intent

  ## Dependencies
  - Requires connectbot/termlib#66
  - Currently using local termlib build and this is why this PR is draft