### PR TITLE
Add save login password for each host

### DIFF
--- a/app/src/main/java/org/connectbot/service/BackupAgent.kt
+++ b/app/src/main/java/org/connectbot/service/BackupAgent.kt
@@ -113,7 +113,8 @@ class BackupAgent : BackupAgentHelper() {
             DATABASE_NAME
         ).build()
         val dispatchers = CoroutineDispatchers(default = Dispatchers.Default, io = Dispatchers.IO, main = Dispatchers.Main)
-        val hostRepository = HostRepository(applicationContext, database, database.hostDao(), database.portForwardDao(), database.knownHostDao())
+        val securePasswordStorage = org.connectbot.util.SecurePasswordStorage(applicationContext)
+        val hostRepository = HostRepository(applicationContext, database, database.hostDao(), database.portForwardDao(), database.knownHostDao(), securePasswordStorage)
         val colorSchemeRepository = ColorSchemeRepository(database.colorSchemeDao(), dispatchers = dispatchers)
         val pubkeyRepository = PubkeyRepository(database.pubkeyDao())
 
@@ -128,7 +129,6 @@ class BackupAgent : BackupAgentHelper() {
             // Step 2: Back up the filtered database
             Timber.d("Backing up filtered database")
             backupFile(tempDbFile, DATABASE_NAME, data)
-
         } catch (e: Exception) {
             Timber.e(e, "Error during database backup with filtering")
             throw e

--- a/app/src/main/java/org/connectbot/service/TerminalManager.kt
+++ b/app/src/main/java/org/connectbot/service/TerminalManager.kt
@@ -143,6 +143,9 @@ class TerminalManager :
     @Inject
     internal lateinit var dispatchers: CoroutineDispatchers
 
+    @Inject
+    internal lateinit var securePasswordStorage: org.connectbot.util.SecurePasswordStorage
+
     private val binder: IBinder = TerminalBinder()
 
     internal lateinit var connectivityMonitor: ConnectivityMonitor

--- a/app/src/main/java/org/connectbot/ui/screens/hosteditor/HostEditorScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/hosteditor/HostEditorScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -48,6 +49,8 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -105,6 +108,8 @@ fun HostEditorScreen(
         onPostLoginChange = viewModel::updatePostLogin,
         onJumpHostChange = viewModel::updateJumpHostId,
         onIpVersionChange = viewModel::updateIpVersion,
+        onPasswordChange = viewModel::updatePassword,
+        onClearPassword = viewModel::clearSavedPassword,
         onSaveHost = { expandedMode -> viewModel.saveHost(expandedMode) },
         modifier = modifier
     )
@@ -133,6 +138,8 @@ fun HostEditorScreenContent(
     onPostLoginChange: (String) -> Unit,
     onJumpHostChange: (Long?) -> Unit,
     onIpVersionChange: (String) -> Unit,
+    onPasswordChange: (String) -> Unit,
+    onClearPassword: () -> Unit,
     onSaveHost: (Boolean) -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -334,6 +341,40 @@ fun HostEditorScreenContent(
                         onIpVersionSelect = onIpVersionChange,
                         modifier = Modifier.padding(top = 8.dp)
                     )
+
+                    // Save password section (SSH only)
+                    if (uiState.protocol == "ssh") {
+                        HorizontalDivider(modifier = Modifier.padding(vertical = 16.dp))
+                        OutlinedTextField(
+                            value = uiState.password,
+                            onValueChange = onPasswordChange,
+                            label = {
+                                Text(
+                                    if (uiState.hasExistingPassword && uiState.password.isEmpty()) {
+                                        stringResource(R.string.hostpref_password_unchanged)
+                                    } else {
+                                        stringResource(R.string.hostpref_password_title)
+                                    }
+                                )
+                            },
+                            supportingText = {
+                                Text(stringResource(R.string.hostpref_save_password_summary))
+                            },
+                            visualTransformation = PasswordVisualTransformation(),
+                            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+                            modifier = Modifier.fillMaxWidth(),
+                            singleLine = true
+                        )
+
+                        if (uiState.hasExistingPassword) {
+                            TextButton(
+                                onClick = onClearPassword,
+                                modifier = Modifier.padding(top = 4.dp)
+                            ) {
+                                Text(stringResource(R.string.hostpref_clear_password))
+                            }
+                        }
+                    }
                 }
             }
 
@@ -1232,6 +1273,8 @@ private fun HostEditorScreenPreview() {
             onPostLoginChange = {},
             onJumpHostChange = {},
             onIpVersionChange = {},
+            onPasswordChange = {},
+            onClearPassword = {},
             onSaveHost = {}
         )
     }

--- a/app/src/main/java/org/connectbot/ui/screens/hosteditor/HostEditorScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/hosteditor/HostEditorScreen.kt
@@ -49,8 +49,6 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
-import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -61,6 +59,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import org.connectbot.BuildConfig

--- a/app/src/main/java/org/connectbot/util/SecurePasswordStorage.kt
+++ b/app/src/main/java/org/connectbot/util/SecurePasswordStorage.kt
@@ -1,0 +1,178 @@
+/*
+ * ConnectBot: simple, powerful, open-source SSH client for Android
+ * Copyright 2025 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.connectbot.util
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import android.util.Base64
+import dagger.hilt.android.qualifiers.ApplicationContext
+import timber.log.Timber
+import java.security.KeyStore
+import javax.crypto.Cipher
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+import javax.crypto.spec.GCMParameterSpec
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Secure storage for host login passwords using Android Keystore.
+ *
+ * Passwords are stored encrypted and keyed by host ID. They are completely
+ * separate from the database and will NOT be included in JSON exports.
+ */
+@Singleton
+class SecurePasswordStorage @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
+    private val prefs: SharedPreferences by lazy {
+        context.getSharedPreferences(PREFS_FILE_NAME, Context.MODE_PRIVATE)
+    }
+
+    private val keyStore: KeyStore by lazy {
+        KeyStore.getInstance(ANDROID_KEYSTORE).apply {
+            load(null)
+        }
+    }
+
+    private fun getOrCreateSecretKey(): SecretKey {
+        val existingKey = keyStore.getEntry(KEY_ALIAS, null) as? KeyStore.SecretKeyEntry
+        if (existingKey != null) {
+            return existingKey.secretKey
+        }
+
+        val keyGenerator = KeyGenerator.getInstance(
+            KeyProperties.KEY_ALGORITHM_AES,
+            ANDROID_KEYSTORE
+        )
+
+        keyGenerator.init(
+            KeyGenParameterSpec.Builder(
+                KEY_ALIAS,
+                KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
+            )
+                .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+                .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+                .setKeySize(256)
+                .build()
+        )
+
+        return keyGenerator.generateKey()
+    }
+
+    private fun encrypt(plaintext: String): String? {
+        return try {
+            val secretKey = getOrCreateSecretKey()
+            val cipher = Cipher.getInstance(TRANSFORMATION)
+            cipher.init(Cipher.ENCRYPT_MODE, secretKey)
+
+            val iv = cipher.iv
+            val encryptedBytes = cipher.doFinal(plaintext.toByteArray(Charsets.UTF_8))
+
+            // Combine IV and encrypted data
+            val combined = ByteArray(iv.size + encryptedBytes.size)
+            System.arraycopy(iv, 0, combined, 0, iv.size)
+            System.arraycopy(encryptedBytes, 0, combined, iv.size, encryptedBytes.size)
+
+            Base64.encodeToString(combined, Base64.NO_WRAP)
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to encrypt password")
+            null
+        }
+    }
+
+    private fun decrypt(encryptedData: String): String? {
+        return try {
+            val secretKey = getOrCreateSecretKey()
+            val combined = Base64.decode(encryptedData, Base64.NO_WRAP)
+
+            // Extract IV and encrypted data
+            val iv = combined.copyOfRange(0, GCM_IV_LENGTH)
+            val encryptedBytes = combined.copyOfRange(GCM_IV_LENGTH, combined.size)
+
+            val cipher = Cipher.getInstance(TRANSFORMATION)
+            cipher.init(Cipher.DECRYPT_MODE, secretKey, GCMParameterSpec(GCM_TAG_LENGTH, iv))
+
+            String(cipher.doFinal(encryptedBytes), Charsets.UTF_8)
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to decrypt password")
+            null
+        }
+    }
+
+    /**
+     * Save a password for a host.
+     *
+     * @param hostId The unique host ID
+     * @param password The password to save (null or empty to clear)
+     */
+    fun savePassword(hostId: Long, password: String?) {
+        val key = getPasswordKey(hostId)
+        if (password.isNullOrEmpty()) {
+            prefs.edit().remove(key).apply()
+        } else {
+            val encrypted = encrypt(password)
+            if (encrypted != null) {
+                prefs.edit().putString(key, encrypted).apply()
+            }
+        }
+    }
+
+    /**
+     * Get the saved password for a host.
+     *
+     * @param hostId The unique host ID
+     * @return The saved password, or null if none saved
+     */
+    fun getPassword(hostId: Long): String? {
+        val encrypted = prefs.getString(getPasswordKey(hostId), null) ?: return null
+        return decrypt(encrypted)
+    }
+
+    /**
+     * Check if a password is saved for a host.
+     *
+     * @param hostId The unique host ID
+     * @return true if a password is saved
+     */
+    fun hasPassword(hostId: Long): Boolean = prefs.contains(getPasswordKey(hostId))
+
+    /**
+     * Delete the saved password for a host.
+     * Should be called when a host is deleted.
+     *
+     * @param hostId The unique host ID
+     */
+    fun deletePassword(hostId: Long) {
+        prefs.edit().remove(getPasswordKey(hostId)).apply()
+    }
+
+    private fun getPasswordKey(hostId: Long): String = "$KEY_PREFIX$hostId"
+
+    companion object {
+        private const val PREFS_FILE_NAME = "secure_host_passwords"
+        private const val KEY_PREFIX = "password_"
+        private const val ANDROID_KEYSTORE = "AndroidKeyStore"
+        private const val KEY_ALIAS = "connectbot_password_key"
+        private const val TRANSFORMATION = "AES/GCM/NoPadding"
+        private const val GCM_IV_LENGTH = 12
+        private const val GCM_TAG_LENGTH = 128
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -461,6 +461,15 @@
 	<!-- Username field title for host editor preference -->
 	<string name="hostpref_username_title">"Username"</string>
 
+	<!-- Password field supporting text in host editor -->
+	<string name="hostpref_save_password_summary">"Store login password securely for automatic authentication"</string>
+	<!-- Password field title in host editor -->
+	<string name="hostpref_password_title">"Password"</string>
+	<!-- Password field label when there is an existing password saved -->
+	<string name="hostpref_password_unchanged">"Password (unchanged)"</string>
+	<!-- Button to clear a saved password -->
+	<string name="hostpref_clear_password">"Clear saved password"</string>
+
 	<!-- Hostname field title for host editor preference -->
 	<string name="hostpref_hostname_title">"Host"</string>
 
@@ -675,6 +684,10 @@
 	<string name="terminal_auth_pass">"Attempting 'password' authentication"</string>
 	<!-- Message shown in terminal when password authentication fails -->
 	<string name="terminal_auth_pass_fail">"Authentication method 'password' failed"</string>
+	<!-- Message shown in terminal when attempting saved password authentication -->
+	<string name="terminal_auth_saved_password">"Trying saved password…"</string>
+	<!-- Message shown in terminal when saved password authentication fails -->
+	<string name="terminal_auth_saved_password_fail">"Saved password authentication failed"</string>
 
 	<!-- Message shown in terminal when trying public key authentication with any available key -->
 	<string name="terminal_auth_pubkey_any">"Attempting 'publickey' authentication with any in-memory public keys"</string>


### PR DESCRIPTION
Fix #1369 and #668. If you are willing to resolve them, I strongly recommend merging this PR instead of #1489. This PR uses Android Keystore to (relatively) securely handle the password, while #1489 stores it in the app-side database. 
- Passwords stored securely using Android Keystore (AES-256-GCM)
- Saved passwords are tried automatically during keyboard-interactive and password authentication
- Password field in host editor with a clear button for existing passwords
- Passwords cleaned up when hosts are deleted
- Passwords NOT included in JSON export (stored separately from database)