### PR TITLE
MINOR FIX: Add contact information and donation links to Help screen

### DIFF
--- a/app/src/main/java/org/connectbot/ui/ConnectBotApp.kt
+++ b/app/src/main/java/org/connectbot/ui/ConnectBotApp.kt
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+@file:Suppress("ktlint:compose:compositionlocal-allowlist")
+
 package org.connectbot.ui
 
 import androidx.compose.runtime.Composable
@@ -38,9 +40,9 @@ fun ConnectBotApp(
     navController: NavHostController,
     makingShortcut: Boolean,
     onRetryMigration: () -> Unit,
-    onShortcutSelected: (Host) -> Unit,
+    onSelectShortcut: (Host) -> Unit,
     onNavigateToConsole: (Host) -> Unit,
-    modifier: Modifier = Modifier,
+    modifier: Modifier = Modifier
 ) {
     ConnectBotTheme {
         when (appUiState) {
@@ -73,7 +75,7 @@ fun ConnectBotApp(
                         navController = navController,
                         startDestination = NavDestinations.HOST_LIST,
                         makingShortcut = makingShortcut,
-                        onShortcutSelected = onShortcutSelected,
+                        onSelectShortcut = onSelectShortcut,
                         onNavigateToConsole = onNavigateToConsole,
                         modifier = modifier
                     )

--- a/app/src/main/java/org/connectbot/ui/MainActivity.kt
+++ b/app/src/main/java/org/connectbot/ui/MainActivity.kt
@@ -125,7 +125,7 @@ class MainActivity : AppCompatActivity() {
         if (savedInstanceState == null) {
             requestedUri = intent?.data
             makingShortcut = Intent.ACTION_CREATE_SHORTCUT == intent?.action ||
-                             Intent.ACTION_PICK == intent?.action
+                Intent.ACTION_PICK == intent?.action
             Timber.d("onCreate: requestedUri=$requestedUri, makingShortcut=$makingShortcut")
             handleIntent(intent)
         } else {
@@ -291,7 +291,7 @@ class MainActivity : AppCompatActivity() {
                 navController = navController,
                 makingShortcut = makingShortcut,
                 onRetryMigration = { appViewModel.retryMigration() },
-                onShortcutSelected = { host ->
+                onSelectShortcut = { host ->
                     createShortcutAndFinish(host)
                 },
                 onNavigateToConsole = onNavigateToConsole

--- a/app/src/main/java/org/connectbot/ui/navigation/NavDestinations.kt
+++ b/app/src/main/java/org/connectbot/ui/navigation/NavDestinations.kt
@@ -34,6 +34,7 @@ object NavDestinations {
     const val HELP = "help"
     const val EULA = "eula"
     const val HINTS = "hints"
+    const val CONTACT = "contact"
 }
 
 object NavArgs {

--- a/app/src/main/java/org/connectbot/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/org/connectbot/ui/navigation/NavGraph.kt
@@ -33,6 +33,7 @@ import org.connectbot.ui.screens.colors.ColorSchemeManagerScreen
 import org.connectbot.ui.screens.colors.ColorsScreen
 import org.connectbot.ui.screens.colors.PaletteEditorScreen
 import org.connectbot.ui.screens.console.ConsoleScreen
+import org.connectbot.ui.screens.contact.ContactScreen
 import org.connectbot.ui.screens.eula.EulaScreen
 import org.connectbot.ui.screens.generatepubkey.GeneratePubkeyScreen
 import org.connectbot.ui.screens.help.HelpScreen
@@ -54,7 +55,7 @@ fun ConnectBotNavHost(
     modifier: Modifier = Modifier,
     startDestination: String = NavDestinations.HOST_LIST,
     makingShortcut: Boolean = false,
-    onShortcutSelected: (Host) -> Unit = {},
+    onSelectShortcut: (Host) -> Unit = {}
 ) {
     NavHost(
         navController = navController,
@@ -65,7 +66,7 @@ fun ConnectBotNavHost(
             HostListScreen(
                 makingShortcut = makingShortcut,
                 onNavigateToConsole = onNavigateToConsole,
-                onShortcutSelected = onShortcutSelected,
+                onSelectShortcut = onSelectShortcut,
                 onNavigateToEditHost = { host ->
                     if (host != null) {
                         navController.navigateSafely("${NavDestinations.HOST_EDITOR}?${NavArgs.HOST_ID}=${host.id}")
@@ -217,7 +218,14 @@ fun ConnectBotNavHost(
             HelpScreen(
                 onNavigateBack = { navController.safePopBackStack() },
                 onNavigateToHints = { navController.navigateSafely(NavDestinations.HINTS) },
-                onNavigateToEula = { navController.navigateSafely(NavDestinations.EULA) }
+                onNavigateToEula = { navController.navigateSafely(NavDestinations.EULA) },
+                onNavigateToContact = { navController.navigateSafely(NavDestinations.CONTACT) }
+            )
+        }
+
+        composable(NavDestinations.CONTACT) {
+            ContactScreen(
+                onNavigateBack = { navController.safePopBackStack() }
             )
         }
 
@@ -240,16 +248,14 @@ fun ConnectBotNavHost(
  *
  * This is used to de-duplicate navigation events.
  */
-private fun NavBackStackEntry?.lifecycleIsResumed() =
-    this?.lifecycle?.currentState == Lifecycle.State.RESUMED
+private fun NavBackStackEntry?.lifecycleIsResumed() = this?.lifecycle?.currentState == Lifecycle.State.RESUMED
 
 /**
  * Safely pops the back stack, preventing double navigation when the user rapidly taps
  * the back button. This checks if the current destination's lifecycle state is RESUMED
  * before allowing the navigation to proceed.
  */
-private fun NavHostController.safePopBackStack() =
-    if (currentBackStackEntry.lifecycleIsResumed()) popBackStack() else false
+private fun NavHostController.safePopBackStack() = if (currentBackStackEntry.lifecycleIsResumed()) popBackStack() else false
 
 /**
  * A more robust navigate function that avoids navigating to the

--- a/app/src/main/java/org/connectbot/ui/screens/contact/ContactScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/contact/ContactScreen.kt
@@ -1,0 +1,158 @@
+/*
+ * ConnectBot: simple, powerful, open-source SSH client for Android
+ * Copyright 2025 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.connectbot.ui.screens.contact
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import org.connectbot.R
+import org.connectbot.ui.ScreenPreviews
+import org.connectbot.ui.theme.ConnectBotTheme
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ContactScreen(
+    onNavigateBack: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val uriHandler = LocalUriHandler.current
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.title_contact)) },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
+                    }
+                }
+            )
+        },
+        modifier = modifier
+    ) { padding ->
+        LazyColumn(modifier = Modifier.padding(padding)) {
+            item {
+                Text(
+                    text = stringResource(R.string.help_section_contact),
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.padding(16.dp)
+                )
+            }
+
+            item {
+                ContactLinkItem(
+                    label = stringResource(R.string.help_website),
+                    url = stringResource(R.string.help_website_url),
+                    onClick = { uriHandler.openUri(it) }
+                )
+            }
+
+            item {
+                ContactLinkItem(
+                    label = stringResource(R.string.help_github),
+                    url = stringResource(R.string.help_github_url),
+                    onClick = { uriHandler.openUri(it) }
+                )
+            }
+
+            item {
+                ContactLinkItem(
+                    label = stringResource(R.string.help_report_bug),
+                    url = stringResource(R.string.help_report_bug_url),
+                    onClick = { uriHandler.openUri(it) }
+                )
+            }
+
+            item {
+                Text(
+                    text = stringResource(R.string.help_section_donate),
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 24.dp, bottom = 16.dp)
+                )
+            }
+
+            item {
+                ContactLinkItem(
+                    label = stringResource(R.string.help_donate_github),
+                    url = stringResource(R.string.help_donate_github_url),
+                    onClick = { uriHandler.openUri(it) }
+                )
+            }
+
+            item {
+                ContactLinkItem(
+                    label = stringResource(R.string.help_donate_coffee),
+                    url = stringResource(R.string.help_donate_coffee_url),
+                    onClick = { uriHandler.openUri(it) }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ContactLinkItem(
+    label: String,
+    url: String,
+    onClick: (String) -> Unit
+) {
+    ListItem(
+        headlineContent = {
+            Text(
+                text = label,
+                style = MaterialTheme.typography.titleMedium
+            )
+        },
+        supportingContent = {
+            Text(
+                text = url,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.primary
+            )
+        },
+        modifier = Modifier.clickable { onClick(url) }
+    )
+    HorizontalDivider()
+}
+
+@ScreenPreviews
+@Composable
+private fun ContactScreenPreview() {
+    ConnectBotTheme {
+        ContactScreen(
+            onNavigateBack = {}
+        )
+    }
+}

--- a/app/src/main/java/org/connectbot/ui/screens/help/HelpScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/help/HelpScreen.kt
@@ -70,6 +70,7 @@ fun HelpScreen(
     onNavigateBack: () -> Unit,
     onNavigateToHints: () -> Unit,
     onNavigateToEula: () -> Unit,
+    onNavigateToContact: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     var showKeyboardShortcuts by remember { mutableStateOf(false) }
@@ -153,6 +154,17 @@ fun HelpScreen(
                         .padding(vertical = 8.dp)
                 ) {
                     Text(stringResource(R.string.view_logs))
+                }
+            }
+
+            item {
+                Button(
+                    onClick = onNavigateToContact,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 8.dp)
+                ) {
+                    Text(stringResource(R.string.title_contact))
                 }
             }
 
@@ -315,7 +327,8 @@ private fun HelpScreenPreview() {
         HelpScreen(
             onNavigateBack = {},
             onNavigateToHints = {},
-            onNavigateToEula = {}
+            onNavigateToEula = {},
+            onNavigateToContact = {}
         )
     }
 }

--- a/app/src/main/java/org/connectbot/ui/screens/hostlist/HostListScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/hostlist/HostListScreen.kt
@@ -90,9 +90,7 @@ import org.connectbot.ui.theme.ConnectBotTheme
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun HostListScreen(
-    makingShortcut: Boolean = false,
     onNavigateToConsole: (Host) -> Unit,
-    onShortcutSelected: (Host) -> Unit = {},
     onNavigateToEditHost: (Host?) -> Unit,
     onNavigateToSettings: () -> Unit,
     onNavigateToPubkeys: () -> Unit,
@@ -100,11 +98,13 @@ fun HostListScreen(
     onNavigateToColors: () -> Unit,
     onNavigateToProfiles: () -> Unit,
     onNavigateToHelp: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    makingShortcut: Boolean = false,
+    onSelectShortcut: (Host) -> Unit = {},
+    viewModel: HostListViewModel = hiltViewModel()
 ) {
     val context = LocalContext.current
     val terminalManager = LocalTerminalManager.current
-    val viewModel: HostListViewModel = hiltViewModel()
 
     LaunchedEffect(terminalManager) {
         terminalManager?.let { viewModel.setTerminalManager(it) }
@@ -208,7 +208,7 @@ fun HostListScreen(
         uiState = uiState,
         makingShortcut = makingShortcut,
         onNavigateToConsole = onNavigateToConsole,
-        onShortcutSelected = onShortcutSelected,
+        onSelectShortcut = onSelectShortcut,
         onNavigateToEditHost = onNavigateToEditHost,
         onNavigateToSettings = onNavigateToSettings,
         onNavigateToPubkeys = onNavigateToPubkeys,
@@ -233,7 +233,7 @@ fun HostListScreenContent(
     uiState: HostListUiState,
     makingShortcut: Boolean = false,
     onNavigateToConsole: (Host) -> Unit,
-    onShortcutSelected: (Host) -> Unit = {},
+    onSelectShortcut: (Host) -> Unit = {},
     onNavigateToEditHost: (Host?) -> Unit,
     onNavigateToSettings: () -> Unit,
     onNavigateToPubkeys: () -> Unit,
@@ -280,10 +280,15 @@ fun HostListScreenContent(
                         ) {
                             DropdownMenuItem(
                                 text = {
-                                    Text(stringResource(
-                                        if (uiState.sortedByColor) R.string.list_menu_sortname
-                                        else R.string.list_menu_sortcolor
-                                    ))
+                                    Text(
+                                        stringResource(
+                                            if (uiState.sortedByColor) {
+                                                R.string.list_menu_sortname
+                                            } else {
+                                                R.string.list_menu_sortcolor
+                                            }
+                                        )
+                                    )
                                 },
                                 onClick = {
                                     showMenu = false
@@ -356,7 +361,7 @@ fun HostListScreenContent(
                 FloatingActionButton(
                     onClick = { onNavigateToEditHost(null) },
                     // This matches the FloatingActionButtonMenu padding
-                    modifier = Modifier.padding(end = 16.dp, bottom = 16.dp),
+                    modifier = Modifier.padding(end = 16.dp, bottom = 16.dp)
                 ) {
                     Icon(Icons.Default.Add, contentDescription = stringResource(R.string.hostpref_add_host))
                 }
@@ -375,6 +380,7 @@ fun HostListScreenContent(
                         modifier = Modifier.align(Alignment.Center)
                     )
                 }
+
                 uiState.hosts.isEmpty() -> {
                     Column(
                         modifier = Modifier.align(Alignment.Center),
@@ -399,7 +405,7 @@ fun HostListScreenContent(
                             start = 16.dp,
                             end = 16.dp,
                             top = 16.dp,
-                            bottom = 104.dp, // Extra padding to avoid FAB menu overlap (88dp + 16dp for menu padding)
+                            bottom = 104.dp // Extra padding to avoid FAB menu overlap (88dp + 16dp for menu padding)
                         ),
                         verticalArrangement = Arrangement.spacedBy(8.dp)
                     ) {
@@ -410,10 +416,9 @@ fun HostListScreenContent(
                             HostListItem(
                                 host = host,
                                 connectionState = uiState.connectionStates[host.id] ?: ConnectionState.UNKNOWN,
-                                makingShortcut = makingShortcut,
                                 onClick = {
                                     if (makingShortcut) {
-                                        onShortcutSelected(host)
+                                        onSelectShortcut(host)
                                     } else {
                                         onNavigateToConsole(host)
                                     }
@@ -422,7 +427,8 @@ fun HostListScreenContent(
                                 onPortForwards = { onNavigateToPortForwards(host) },
                                 onForgetHostKeys = { onForgetHostKeys(host) },
                                 onDisconnect = { onDisconnectHost(host) },
-                                onDelete = { onDeleteHost(host) }
+                                onDelete = { onDeleteHost(host) },
+                                makingShortcut = makingShortcut
                             )
                         }
                     }
@@ -446,14 +452,14 @@ fun HostListScreenContent(
 private fun HostListItem(
     host: Host,
     connectionState: ConnectionState,
-    makingShortcut: Boolean = false,
     onClick: () -> Unit,
     onEdit: () -> Unit,
     onPortForwards: () -> Unit,
     onForgetHostKeys: () -> Unit,
     onDisconnect: () -> Unit,
     onDelete: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    makingShortcut: Boolean = false
 ) {
     var showMenu by remember { mutableStateOf(false) }
     var showDeleteDialog by remember { mutableStateOf(false) }
@@ -462,8 +468,12 @@ private fun HostListItem(
 
     // Determine border color based on connection state
     val borderColor = when (connectionState) {
-        ConnectionState.CONNECTED -> colorResource(R.color.host_green) // Green
-        ConnectionState.DISCONNECTED -> colorResource(R.color.host_red) // Red
+        ConnectionState.CONNECTED -> colorResource(R.color.host_green)
+
+        // Green
+        ConnectionState.DISCONNECTED -> colorResource(R.color.host_red)
+
+        // Red
         ConnectionState.UNKNOWN -> Color.Transparent
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1172,6 +1172,34 @@
 	<!-- Section title for the "Help" screen showing information about the program itself. -->
 	<string name="help_section_about">About</string>
 
+	<!-- Window title for the Contact &amp; Support screen, also used as button text in Help screen. -->
+	<string name="title_contact">Contact &amp; Support</string>
+
+	<!-- Section title for the "Help" screen showing contact and support information. -->
+	<string name="help_section_contact">Contact &amp; Support</string>
+	<!-- Label for the official website link in the Help screen. -->
+	<string name="help_website">Website</string>
+	<!-- URL for the official ConnectBot website. -->
+	<string name="help_website_url" translatable="false">https://connectbot.org/</string>
+	<!-- Label for the GitHub repository link in the Help screen. -->
+	<string name="help_github">Source Code</string>
+	<!-- URL for the ConnectBot GitHub repository. -->
+	<string name="help_github_url" translatable="false">https://github.com/connectbot/connectbot</string>
+	<!-- Label for the bug report/issue tracker link in the Help screen. -->
+	<string name="help_report_bug">Report a Bug</string>
+	<!-- URL for the ConnectBot issue tracker. -->
+	<string name="help_report_bug_url" translatable="false">https://connectbot.org/bug</string>
+	<!-- Section title for the "Help" screen showing donation options. -->
+	<string name="help_section_donate">Support Development</string>
+	<!-- Label for the GitHub Sponsors donation link in the Help screen. -->
+	<string name="help_donate_github">GitHub Sponsors</string>
+	<!-- URL for the GitHub Sponsors page. -->
+	<string name="help_donate_github_url" translatable="false">https://github.com/sponsors/kruton</string>
+	<!-- Label for the Buy Me a Coffee donation link in the Help screen. -->
+	<string name="help_donate_coffee">Buy Me a Coffee</string>
+	<!-- URL for the Buy Me a Coffee page. -->
+	<string name="help_donate_coffee_url" translatable="false">https://buymeacoffee.com/kruton</string>
+
 	<!-- Built-in color scheme descriptions for terminal display -->
 	<!-- Description of the default terminal color scheme -->
 	<string name="colorscheme_default_description">Default terminal colors</string>


### PR DESCRIPTION
Fixes #1200 and #347.
Adds a "Contact & Support" button in the Help screen that navigates to a dedicated screen showing:
- Contact & Support section with website, GitHub repo, and bug report links
- Support Development section with GitHub Sponsors and Buy Me a Coffee links

Each link displays the label and URL on separate lines with proper styling and opens in the browser when tapped.