### PR TITLE
MINOR FIX: Show helpful message when biometric key is invalidated

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -684,6 +684,8 @@
 	<string name="terminal_auth_pubkey_specific">"Attempting 'publickey' authentication with a specific public key"</string>
 	<!-- Message shown in terminal when requesting biometric authentication to unlock a key. Parameter is the key nickname. -->
 	<string name="terminal_auth_biometric">"Requesting biometric authentication for key '%1$s'"</string>
+	<!-- Message shown when a biometric key has been invalidated due to new fingerprint enrollment. Parameter is the key nickname. -->
+	<string name="terminal_auth_biometric_invalidated">"Biometric key '%1$s' has been invalidated. This can happen when new fingerprints are enrolled on the device. Please generate a new key."</string>
 	<!-- Message shown in terminal when public key authentication fails. Parameter is the key nickname. -->
 	<string name="terminal_auth_pubkey_fail">"Authentication method 'publickey' with key '%1$s' failed"</string>
 


### PR DESCRIPTION
Fixes #1833. 
When a user enrolls a new fingerprint, Android invalidates biometric-protected keys. Previously, this resulted in a generic error message. Now users see a clear explanation that the key was invalidated due to fingerprint enrollment, and they need to generate a new key.