### PR TITLE
Show software keyboard when SSH session connects

### DIFF
--- a/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
@@ -271,12 +271,11 @@ fun ConsoleScreen(
     val snackbarHostState = remember { SnackbarHostState() }
 
     // Show software keyboard when session becomes open (if no hardware keyboard)
-    var previousSessionOpen by remember { mutableStateOf(false) }
-    LaunchedEffect(sessionOpen, hasHardwareKeyboard) {
-        if (!previousSessionOpen && sessionOpen && !hasHardwareKeyboard) {
+    // Also show when switching to a different bridge that's already open
+    LaunchedEffect(currentBridge, sessionOpen, hasHardwareKeyboard) {
+        if (sessionOpen && !hasHardwareKeyboard) {
             showSoftwareKeyboard = true
         }
-        previousSessionOpen = sessionOpen
     }
 
     // Initialize forceSize from profile when bridge changes


### PR DESCRIPTION
Fixes GitHub issue #1846 where the virtual keyboard no longer automatically displays when establishing an SSH connection.

Two issues were identified and fixed:

1. Added a LaunchedEffect that monitors the session state and shows the software keyboard when the session becomes open (if no hardware keyboard is connected).

2. Fixed the IME sync logic that was canceling keyboard show requests before the keyboard had a chance to appear. The sync now only triggers after the keyboard has been visible at least once, which prevents it from interfering with the initial show.

Also fixes pre-existing ktlint compose rule violations:
- Added modifier parameter to ConsoleScreen
- Added viewModel as default parameter per compose best practices
- Used rememberUpdatedState for navigation callback in LaunchedEffect