### PR TITLE
Revert "Bump org.connectbot:sshlib from 2.2.37 to 2.2.38"

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,7 +24,7 @@ lifecycleViewModel = "2.10.0"
 navigationCompose = "2.9.6"
 activityCompose = "1.12.2"
 
-sshlib = "2.2.38"
+sshlib = "2.2.37"
 termlib = "0.0.17"
 playServicesBasement = "18.10.0"
 conscrypt = "2.5.3"


### PR DESCRIPTION
This reverts commit b8274c5cf1d1cdf289fa6c881f5700bf6d67b1ca.

Fixes #1872