### PR TITLE
Dismiss disconnect dialog after confirm

### DIFF
--- a/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
@@ -533,6 +533,7 @@ fun ConsoleScreen(
                 host = currentBridge.host,
                 onDismiss = { showDisconnectDialog = false },
                 onConfirm = {
+                    showDisconnectDialog = false
                     currentBridge.dispatchDisconnect(true)
                 }
             )


### PR DESCRIPTION
When multiple sessions are connected, disconnecting one won't dismiss the dialog. It will just offer to disconnect the next host until you tell it no.

Fixes #1847