### PR TITLE
feat(shortcuts): add customization to shortcuts

### DIFF
--- a/app/src/main/java/org/connectbot/ui/ConnectBotApp.kt
+++ b/app/src/main/java/org/connectbot/ui/ConnectBotApp.kt
@@ -29,6 +29,7 @@ import org.connectbot.service.TerminalManager
 import org.connectbot.ui.navigation.ConnectBotNavHost
 import org.connectbot.ui.navigation.NavDestinations
 import org.connectbot.ui.theme.ConnectBotTheme
+import org.connectbot.util.IconStyle
 
 val LocalTerminalManager = compositionLocalOf<TerminalManager?> {
     null
@@ -40,7 +41,7 @@ fun ConnectBotApp(
     navController: NavHostController,
     makingShortcut: Boolean,
     onRetryMigration: () -> Unit,
-    onSelectShortcut: (Host) -> Unit,
+    onSelectShortcut: (Host, String?, IconStyle) -> Unit,
     onNavigateToConsole: (Host) -> Unit,
     modifier: Modifier = Modifier
 ) {

--- a/app/src/main/java/org/connectbot/ui/MainActivity.kt
+++ b/app/src/main/java/org/connectbot/ui/MainActivity.kt
@@ -44,7 +44,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.core.content.pm.ShortcutInfoCompat
 import androidx.core.content.pm.ShortcutManagerCompat
-import androidx.core.graphics.drawable.IconCompat
 import androidx.core.net.toUri
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
@@ -59,8 +58,10 @@ import org.connectbot.service.TerminalManager
 import org.connectbot.ui.components.DisconnectAllDialog
 import org.connectbot.ui.navigation.NavDestinations
 import org.connectbot.ui.theme.ConnectBotTheme
+import org.connectbot.util.IconStyle
 import org.connectbot.util.NotificationPermissionHelper
 import org.connectbot.util.PreferenceConstants
+import org.connectbot.util.ShortcutIconGenerator
 import timber.log.Timber
 
 // TODO: Move back to ComponentActivity when https://issuetracker.google.com/issues/178855209 is fixed.
@@ -291,8 +292,8 @@ class MainActivity : AppCompatActivity() {
                 navController = navController,
                 makingShortcut = makingShortcut,
                 onRetryMigration = { appViewModel.retryMigration() },
-                onSelectShortcut = { host ->
-                    createShortcutAndFinish(host)
+                onSelectShortcut = { host, color, iconStyle ->
+                    createShortcutAndFinish(host, color, iconStyle)
                 },
                 onNavigateToConsole = onNavigateToConsole
             )
@@ -363,16 +364,18 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
-    private fun createShortcutAndFinish(host: Host) {
+    private fun createShortcutAndFinish(host: Host, color: String?, iconStyle: IconStyle) {
         val uri = host.getUri()
         val intent = Intent(Intent.ACTION_VIEW, uri).apply {
             flags = Intent.FLAG_ACTIVITY_CLEAR_TOP
         }
 
+        val icon = ShortcutIconGenerator.generateShortcutIcon(this, color, iconStyle)
+
         val shortcut = ShortcutInfoCompat.Builder(this, "host-${host.id}")
             .setShortLabel(host.nickname)
             .setLongLabel(host.nickname)
-            .setIcon(IconCompat.createWithResource(this, R.mipmap.icon))
+            .setIcon(icon)
             .setIntent(intent)
             .build()
 

--- a/app/src/main/java/org/connectbot/ui/components/ShortcutCustomizationDialog.kt
+++ b/app/src/main/java/org/connectbot/ui/components/ShortcutCustomizationDialog.kt
@@ -1,0 +1,239 @@
+/*
+ * ConnectBot: simple, powerful, open-source SSH client for Android
+ * Copyright 2025 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.connectbot.ui.components
+
+import android.graphics.Bitmap
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuAnchorType
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import org.connectbot.R
+import org.connectbot.data.entity.Host
+import org.connectbot.ui.common.ColorOption
+import org.connectbot.ui.common.getIconColors
+import org.connectbot.util.IconStyle
+import org.connectbot.util.ShortcutIconGenerator
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ShortcutCustomizationDialog(
+    host: Host,
+    onDismiss: () -> Unit,
+    onConfirm: (color: String?, iconStyle: IconStyle) -> Unit
+) {
+    val context = LocalContext.current
+    val density = LocalDensity.current
+    val iconColors = getIconColors()
+
+    var useHostColor by remember { mutableStateOf(host.color != null) }
+    var selectedColor by remember { mutableStateOf(host.color ?: iconColors.first().hexValue) }
+    var selectedStyle by remember { mutableStateOf(IconStyle.TERMINAL) }
+
+    var colorDropdownExpanded by remember { mutableStateOf(false) }
+    var styleDropdownExpanded by remember { mutableStateOf(false) }
+
+    val effectiveColor = if (useHostColor && host.color != null) host.color else selectedColor
+
+    val previewSizePx = with(density) { 72.dp.toPx().toInt() }
+    val previewBitmap: Bitmap = remember(effectiveColor, selectedStyle) {
+        ShortcutIconGenerator.generatePreviewBitmap(context, effectiveColor, selectedStyle, previewSizePx)
+    }
+
+    val selectedColorDisplay = findColorDisplayName(effectiveColor, iconColors)
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.shortcut_customize_title)) },
+        text = {
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Image(
+                    bitmap = previewBitmap.asImageBitmap(),
+                    contentDescription = null,
+                    modifier = Modifier.size(72.dp)
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable(enabled = host.color != null) {
+                            useHostColor = !useHostColor
+                        }
+                ) {
+                    Checkbox(
+                        checked = useHostColor,
+                        onCheckedChange = null,
+                        enabled = host.color != null
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(
+                        text = stringResource(R.string.shortcut_use_host_color),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = if (host.color != null) {
+                            MaterialTheme.colorScheme.onSurface
+                        } else {
+                            MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
+                        }
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                ExposedDropdownMenuBox(
+                    expanded = colorDropdownExpanded,
+                    onExpandedChange = { if (!useHostColor) colorDropdownExpanded = it },
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    OutlinedTextField(
+                        value = selectedColorDisplay,
+                        onValueChange = {},
+                        readOnly = true,
+                        enabled = !useHostColor,
+                        singleLine = true,
+                        label = { Text(stringResource(R.string.shortcut_icon_color)) },
+                        trailingIcon = {
+                            ExposedDropdownMenuDefaults.TrailingIcon(expanded = colorDropdownExpanded)
+                        },
+                        colors = ExposedDropdownMenuDefaults.outlinedTextFieldColors(),
+                        modifier = Modifier
+                            .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable)
+                            .fillMaxWidth()
+                    )
+
+                    ExposedDropdownMenu(
+                        expanded = colorDropdownExpanded,
+                        onDismissRequest = { colorDropdownExpanded = false }
+                    ) {
+                        iconColors.forEach { color ->
+                            DropdownMenuItem(
+                                text = { Text(color.localizedName) },
+                                onClick = {
+                                    selectedColor = color.hexValue
+                                    colorDropdownExpanded = false
+                                },
+                                contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding
+                            )
+                        }
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                ExposedDropdownMenuBox(
+                    expanded = styleDropdownExpanded,
+                    onExpandedChange = { styleDropdownExpanded = it },
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    OutlinedTextField(
+                        value = getIconStyleDisplayName(selectedStyle),
+                        onValueChange = {},
+                        readOnly = true,
+                        singleLine = true,
+                        label = { Text(stringResource(R.string.shortcut_icon_style)) },
+                        trailingIcon = {
+                            ExposedDropdownMenuDefaults.TrailingIcon(expanded = styleDropdownExpanded)
+                        },
+                        colors = ExposedDropdownMenuDefaults.outlinedTextFieldColors(),
+                        modifier = Modifier
+                            .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable)
+                            .fillMaxWidth()
+                    )
+
+                    ExposedDropdownMenu(
+                        expanded = styleDropdownExpanded,
+                        onDismissRequest = { styleDropdownExpanded = false }
+                    ) {
+                        IconStyle.entries.forEach { style ->
+                            DropdownMenuItem(
+                                text = { Text(getIconStyleDisplayName(style)) },
+                                onClick = {
+                                    selectedStyle = style
+                                    styleDropdownExpanded = false
+                                },
+                                contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding
+                            )
+                        }
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = { onConfirm(effectiveColor, selectedStyle) }) {
+                Text(stringResource(R.string.shortcut_create))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(android.R.string.cancel))
+            }
+        }
+    )
+}
+
+@Composable
+private fun findColorDisplayName(colorValue: String?, iconColors: List<ColorOption>): String {
+    if (colorValue == null) {
+        return iconColors.first().localizedName
+    }
+    return iconColors.find { it.hexValue.equals(colorValue, ignoreCase = true) }?.localizedName
+        ?: iconColors.find { it.englishName.equals(colorValue, ignoreCase = true) }?.localizedName
+        ?: colorValue
+}
+
+@Composable
+private fun getIconStyleDisplayName(style: IconStyle): String = when (style) {
+    IconStyle.TERMINAL -> stringResource(R.string.icon_style_terminal)
+    IconStyle.SERVER -> stringResource(R.string.icon_style_server)
+    IconStyle.CLOUD -> stringResource(R.string.icon_style_cloud)
+    IconStyle.KEY -> stringResource(R.string.icon_style_key)
+}

--- a/app/src/main/java/org/connectbot/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/org/connectbot/ui/navigation/NavGraph.kt
@@ -46,6 +46,7 @@ import org.connectbot.ui.screens.profiles.ProfileListScreen
 import org.connectbot.ui.screens.pubkeyeditor.PubkeyEditorScreen
 import org.connectbot.ui.screens.pubkeylist.PubkeyListScreen
 import org.connectbot.ui.screens.settings.SettingsScreen
+import org.connectbot.util.IconStyle
 import timber.log.Timber
 
 @Composable
@@ -55,7 +56,7 @@ fun ConnectBotNavHost(
     modifier: Modifier = Modifier,
     startDestination: String = NavDestinations.HOST_LIST,
     makingShortcut: Boolean = false,
-    onSelectShortcut: (Host) -> Unit = {}
+    onSelectShortcut: (Host, String?, IconStyle) -> Unit = { _, _, _ -> }
 ) {
     NavHost(
         navController = navController,

--- a/app/src/main/java/org/connectbot/ui/screens/hostlist/HostListScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/hostlist/HostListScreen.kt
@@ -85,7 +85,9 @@ import org.connectbot.data.entity.Host
 import org.connectbot.ui.LocalTerminalManager
 import org.connectbot.ui.ScreenPreviews
 import org.connectbot.ui.components.DisconnectAllDialog
+import org.connectbot.ui.components.ShortcutCustomizationDialog
 import org.connectbot.ui.theme.ConnectBotTheme
+import org.connectbot.util.IconStyle
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -100,7 +102,7 @@ fun HostListScreen(
     onNavigateToHelp: () -> Unit,
     modifier: Modifier = Modifier,
     makingShortcut: Boolean = false,
-    onSelectShortcut: (Host) -> Unit = {},
+    onSelectShortcut: (Host, String?, IconStyle) -> Unit = { _, _, _ -> },
     viewModel: HostListViewModel = hiltViewModel()
 ) {
     val context = LocalContext.current
@@ -204,11 +206,24 @@ fun HostListScreen(
         }
     }
 
+    var shortcutHost by remember { mutableStateOf<Host?>(null) }
+
+    if (shortcutHost != null) {
+        ShortcutCustomizationDialog(
+            host = shortcutHost!!,
+            onDismiss = { shortcutHost = null },
+            onConfirm = { color, iconStyle ->
+                onSelectShortcut(shortcutHost!!, color, iconStyle)
+                shortcutHost = null
+            }
+        )
+    }
+
     HostListScreenContent(
         uiState = uiState,
         makingShortcut = makingShortcut,
         onNavigateToConsole = onNavigateToConsole,
-        onSelectShortcut = onSelectShortcut,
+        onSelectShortcut = { host -> shortcutHost = host },
         onNavigateToEditHost = onNavigateToEditHost,
         onNavigateToSettings = onNavigateToSettings,
         onNavigateToPubkeys = onNavigateToPubkeys,

--- a/app/src/main/java/org/connectbot/util/ShortcutIconGenerator.kt
+++ b/app/src/main/java/org/connectbot/util/ShortcutIconGenerator.kt
@@ -1,0 +1,138 @@
+/*
+ * ConnectBot: simple, powerful, open-source SSH client for Android
+ * Copyright 2025 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.connectbot.util
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import androidx.annotation.DrawableRes
+import androidx.core.content.ContextCompat
+import androidx.core.graphics.drawable.IconCompat
+import org.connectbot.R
+
+/**
+ * Icon styles available for shortcut customization.
+ */
+enum class IconStyle(@DrawableRes val drawableRes: Int) {
+    TERMINAL(R.drawable.ic_shortcut_foreground),
+    SERVER(R.drawable.ic_shortcut_server),
+    CLOUD(R.drawable.ic_shortcut_cloud),
+    KEY(R.drawable.ic_shortcut_key)
+}
+
+/**
+ * Generates shortcut icons with customizable colors and styles.
+ */
+object ShortcutIconGenerator {
+    private const val ADAPTIVE_ICON_SIZE = 108
+    private const val INNER_CIRCLE_SIZE = 72
+    private const val CIRCLE_OFFSET = (ADAPTIVE_ICON_SIZE - INNER_CIRCLE_SIZE) / 2f
+
+    /**
+     * Generate a shortcut icon with the specified background color and icon style.
+     *
+     * @param context The context used to access resources
+     * @param backgroundColor The background color as a hex string (e.g., "#2196F3") or null for default
+     * @param style The icon style to use
+     * @return An IconCompat suitable for use in shortcut creation
+     */
+    fun generateShortcutIcon(
+        context: Context,
+        backgroundColor: String?,
+        style: IconStyle
+    ): IconCompat {
+        val bitmap = Bitmap.createBitmap(
+            ADAPTIVE_ICON_SIZE,
+            ADAPTIVE_ICON_SIZE,
+            Bitmap.Config.ARGB_8888
+        )
+        val canvas = Canvas(bitmap)
+
+        val bgColor = try {
+            if (backgroundColor != null) {
+                Color.parseColor(backgroundColor)
+            } else {
+                ContextCompat.getColor(context, R.color.host_blue)
+            }
+        } catch (e: IllegalArgumentException) {
+            ContextCompat.getColor(context, R.color.host_blue)
+        }
+
+        val paint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = bgColor
+        }
+        canvas.drawCircle(
+            ADAPTIVE_ICON_SIZE / 2f,
+            ADAPTIVE_ICON_SIZE / 2f,
+            INNER_CIRCLE_SIZE / 2f,
+            paint
+        )
+
+        val drawable = ContextCompat.getDrawable(context, style.drawableRes)
+        drawable?.let {
+            it.setBounds(0, 0, ADAPTIVE_ICON_SIZE, ADAPTIVE_ICON_SIZE)
+            it.draw(canvas)
+        }
+
+        return IconCompat.createWithAdaptiveBitmap(bitmap)
+    }
+
+    /**
+     * Generate a preview bitmap for the customization dialog.
+     *
+     * @param context The context used to access resources
+     * @param backgroundColor The background color as a hex string (e.g., "#2196F3") or null for default
+     * @param style The icon style to use
+     * @param sizePx The desired size in pixels
+     * @return A Bitmap suitable for preview display
+     */
+    fun generatePreviewBitmap(
+        context: Context,
+        backgroundColor: String?,
+        style: IconStyle,
+        sizePx: Int
+    ): Bitmap {
+        val bitmap = Bitmap.createBitmap(sizePx, sizePx, Bitmap.Config.ARGB_8888)
+        val canvas = Canvas(bitmap)
+
+        val bgColor = try {
+            if (backgroundColor != null) {
+                Color.parseColor(backgroundColor)
+            } else {
+                ContextCompat.getColor(context, R.color.host_blue)
+            }
+        } catch (e: IllegalArgumentException) {
+            ContextCompat.getColor(context, R.color.host_blue)
+        }
+
+        val paint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = bgColor
+        }
+        canvas.drawCircle(sizePx / 2f, sizePx / 2f, sizePx / 2f, paint)
+
+        val drawable = ContextCompat.getDrawable(context, style.drawableRes)
+        drawable?.let {
+            it.setBounds(0, 0, sizePx, sizePx)
+            it.draw(canvas)
+        }
+
+        return bitmap
+    }
+}

--- a/app/src/main/res/drawable/ic_shortcut_cloud.xml
+++ b/app/src/main/res/drawable/ic_shortcut_cloud.xml
@@ -1,0 +1,20 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+  <!-- Cloud icon shadow -->
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M72,67C72,67 73,68 73,69C73,73 70,76 66,76L40,76C35,76 31,72 31,67C31,63 34,60 38,59C38,53 43,48 49,48C53,48 56,50 58,53C60,51 63,50 66,50C72,50 77,55 77,61C77,62 77,63 76,64"
+      android:strokeAlpha="0.103"
+      android:fillAlpha="0.103"/>
+  <!-- Cloud shape -->
+  <path
+      android:pathData="M70,65C70,65 71,66 71,67C71,71 68,74 64,74L38,74C33,74 29,70 29,65C29,61 32,58 36,57C36,51 41,46 47,46C51,46 54,48 56,51C58,49 61,48 64,48C70,48 75,53 75,59C75,60 75,61 74,62"
+      android:strokeWidth="3"
+      android:fillColor="#00000000"
+      android:strokeColor="#fff"
+      android:strokeLineCap="round"
+      android:strokeLineJoin="round"/>
+</vector>

--- a/app/src/main/res/drawable/ic_shortcut_foreground.xml
+++ b/app/src/main/res/drawable/ic_shortcut_foreground.xml
@@ -1,0 +1,17 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M108.001,108L76.917,108L38.317,69.071 53.577,53.81 67.046,67.247 72.972,66 108.001,101.077L108.001,108Z"
+      android:strokeAlpha="0.103"
+      android:fillAlpha="0.103"/>
+  <path
+      android:pathData="M38.839,39.124l15.232,15.232 -15.232,15.232 -3.839,-3.839L46.395,54.356 34.995,42.963Z"
+      android:fillColor="#fff"/>
+  <path
+      android:pathData="M54,66L73,66L73,70L54,70Z"
+      android:fillColor="#fff"/>
+</vector>

--- a/app/src/main/res/drawable/ic_shortcut_key.xml
+++ b/app/src/main/res/drawable/ic_shortcut_key.xml
@@ -1,0 +1,42 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+  <!-- Key icon shadow -->
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M48,42C48,47.5 43.5,52 38,52C32.5,52 28,47.5 28,42C28,36.5 32.5,32 38,32C43.5,32 48,36.5 48,42ZM46,42L78,42L78,52L72,52L72,48L66,48L66,52L60,52L60,48L46,48Z"
+      android:strokeAlpha="0.103"
+      android:fillAlpha="0.103"/>
+  <!-- Key head (circle) -->
+  <path
+      android:pathData="M46,54C46,59.5 41.5,64 36,64C30.5,64 26,59.5 26,54C26,48.5 30.5,44 36,44C41.5,44 46,48.5 46,54Z"
+      android:strokeWidth="3"
+      android:fillColor="#00000000"
+      android:strokeColor="#fff"/>
+  <!-- Key hole -->
+  <path
+      android:pathData="M36,51A3,3 0,0 1,36 57A3,3 0,0 1,36 51Z"
+      android:fillColor="#fff"/>
+  <!-- Key shaft -->
+  <path
+      android:pathData="M44,54L76,54"
+      android:strokeWidth="3"
+      android:fillColor="#00000000"
+      android:strokeColor="#fff"
+      android:strokeLineCap="round"/>
+  <!-- Key teeth -->
+  <path
+      android:pathData="M70,54L70,64"
+      android:strokeWidth="3"
+      android:fillColor="#00000000"
+      android:strokeColor="#fff"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M62,54L62,60"
+      android:strokeWidth="3"
+      android:fillColor="#00000000"
+      android:strokeColor="#fff"
+      android:strokeLineCap="round"/>
+</vector>

--- a/app/src/main/res/drawable/ic_shortcut_server.xml
+++ b/app/src/main/res/drawable/ic_shortcut_server.xml
@@ -1,0 +1,31 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+  <!-- Server icon - computer/monitor style -->
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M72,72L36,72L36,68L72,68Z"
+      android:strokeAlpha="0.103"
+      android:fillAlpha="0.103"/>
+  <!-- Monitor body -->
+  <path
+      android:pathData="M34,38L74,38A4,4 0,0 1,78 42L78,62A4,4 0,0 1,74 66L34,66A4,4 0,0 1,30 62L30,42A4,4 0,0 1,34 38Z"
+      android:strokeWidth="3"
+      android:fillColor="#00000000"
+      android:strokeColor="#fff"/>
+  <!-- Monitor screen -->
+  <path
+      android:pathData="M36,42L72,42L72,60L36,60Z"
+      android:fillColor="#fff"
+      android:fillAlpha="0.3"/>
+  <!-- Monitor stand -->
+  <path
+      android:pathData="M50,66L58,66L58,72L50,72Z"
+      android:fillColor="#fff"/>
+  <!-- Monitor base -->
+  <path
+      android:pathData="M44,72L64,72L64,74L44,74Z"
+      android:fillColor="#fff"/>
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1275,4 +1275,24 @@
 	<string name="import_hosts_failed">Failed to import hosts: %s</string>
 	<!-- Title for the export hosts file picker dialog -->
 	<string name="export_hosts_title">Export Hosts</string>
+
+	<!-- Shortcut customization dialog strings -->
+	<!-- Dialog title when customizing a shortcut icon -->
+	<string name="shortcut_customize_title">Customize Shortcut</string>
+	<!-- Label for the shortcut icon color selection dropdown -->
+	<string name="shortcut_icon_color">Icon Color</string>
+	<!-- Label for the shortcut icon style selection dropdown -->
+	<string name="shortcut_icon_style">Icon Style</string>
+	<!-- Checkbox label to use the host\'s configured color for the shortcut -->
+	<string name="shortcut_use_host_color">Use host color</string>
+	<!-- Button to create the customized shortcut -->
+	<string name="shortcut_create">Create Shortcut</string>
+	<!-- Icon style option: terminal prompt icon -->
+	<string name="icon_style_terminal">Terminal</string>
+	<!-- Icon style option: server/computer icon -->
+	<string name="icon_style_server">Server</string>
+	<!-- Icon style option: cloud icon -->
+	<string name="icon_style_cloud">Cloud</string>
+	<!-- Icon style option: key/security icon -->
+	<string name="icon_style_key">Key</string>
 </resources>


### PR DESCRIPTION
Allow the user to select from 4 different icons and the 16 different colors from the host selections.

Fixes #1177