### PR TITLE
Add duplicate host option to host list context menu

### DIFF
--- a/app/src/main/java/org/connectbot/ui/screens/hostlist/HostListScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/hostlist/HostListScreen.kt
@@ -37,6 +37,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Computer
+import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Error
@@ -233,6 +234,7 @@ fun HostListScreen(
         onNavigateToHelp = onNavigateToHelp,
         onToggleSortOrder = viewModel::toggleSortOrder,
         onDeleteHost = viewModel::deleteHost,
+        onDuplicateHost = viewModel::duplicateHost,
         onForgetHostKeys = viewModel::forgetHostKeys,
         onDisconnectHost = viewModel::disconnectHost,
         onDisconnectAll = viewModel::disconnectAll,
@@ -258,6 +260,7 @@ fun HostListScreenContent(
     onNavigateToHelp: () -> Unit,
     onToggleSortOrder: () -> Unit,
     onDeleteHost: (Host) -> Unit,
+    onDuplicateHost: (Host) -> Unit,
     onForgetHostKeys: (Host) -> Unit,
     onDisconnectHost: (Host) -> Unit,
     onDisconnectAll: () -> Unit,
@@ -440,6 +443,7 @@ fun HostListScreenContent(
                                 },
                                 onEdit = { onNavigateToEditHost(host) },
                                 onPortForwards = { onNavigateToPortForwards(host) },
+                                onDuplicate = { onDuplicateHost(host) },
                                 onForgetHostKeys = { onForgetHostKeys(host) },
                                 onDisconnect = { onDisconnectHost(host) },
                                 onDelete = { onDeleteHost(host) },
@@ -470,6 +474,7 @@ private fun HostListItem(
     onClick: () -> Unit,
     onEdit: () -> Unit,
     onPortForwards: () -> Unit,
+    onDuplicate: () -> Unit,
     onForgetHostKeys: () -> Unit,
     onDisconnect: () -> Unit,
     onDelete: () -> Unit,
@@ -594,6 +599,16 @@ private fun HostListItem(
                             },
                             leadingIcon = {
                                 Icon(Icons.Default.Link, null)
+                            }
+                        )
+                        DropdownMenuItem(
+                            text = { Text(stringResource(R.string.list_host_duplicate)) },
+                            onClick = {
+                                showMenu = false
+                                onDuplicate()
+                            },
+                            leadingIcon = {
+                                Icon(Icons.Default.ContentCopy, null)
                             }
                         )
                         if (host.protocol == "ssh") {
@@ -781,6 +796,7 @@ private fun HostListScreenEmptyPreview() {
             onNavigateToHelp = {},
             onToggleSortOrder = {},
             onDeleteHost = {},
+            onDuplicateHost = {},
             onForgetHostKeys = {},
             onDisconnectHost = {},
             onDisconnectAll = {}
@@ -807,6 +823,7 @@ private fun HostListScreenLoadingPreview() {
             onNavigateToHelp = {},
             onToggleSortOrder = {},
             onDeleteHost = {},
+            onDuplicateHost = {},
             onForgetHostKeys = {},
             onDisconnectHost = {},
             onDisconnectAll = {}
@@ -834,6 +851,7 @@ private fun HostListScreenErrorPreview() {
             onNavigateToHelp = {},
             onToggleSortOrder = {},
             onDeleteHost = {},
+            onDuplicateHost = {},
             onForgetHostKeys = {},
             onDisconnectHost = {},
             onDisconnectAll = {}
@@ -893,6 +911,7 @@ private fun HostListScreenPopulatedPreview() {
             onNavigateToHelp = {},
             onToggleSortOrder = {},
             onDeleteHost = {},
+            onDuplicateHost = {},
             onForgetHostKeys = {},
             onDisconnectHost = {},
             onDisconnectAll = {}

--- a/app/src/main/java/org/connectbot/ui/screens/hostlist/HostListViewModel.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/hostlist/HostListViewModel.kt
@@ -218,6 +218,31 @@ class HostListViewModel @Inject constructor(
         }
     }
 
+    fun duplicateHost(host: Host) {
+        viewModelScope.launch {
+            try {
+                // Create new host with reset fields
+                val newHost = host.copy(
+                    id = 0L,
+                    nickname = "${host.nickname} (copy)",
+                    lastConnect = 0,
+                    hostKeyAlgo = null
+                )
+                val savedHost = repository.saveHost(newHost)
+
+                // Copy port forwards
+                val portForwards = repository.getPortForwardsForHost(host.id)
+                for (pf in portForwards) {
+                    repository.savePortForward(pf.copy(id = 0L, hostId = savedHost.id))
+                }
+            } catch (e: Exception) {
+                _uiState.update {
+                    it.copy(error = e.message ?: "Failed to duplicate host")
+                }
+            }
+        }
+    }
+
     fun forgetHostKeys(host: Host) {
         viewModelScope.launch {
             try {

--- a/app/src/main/java/org/connectbot/ui/screens/hostlist/HostListViewModel.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/hostlist/HostListViewModel.kt
@@ -224,7 +224,7 @@ class HostListViewModel @Inject constructor(
                 // Create new host with reset fields
                 val newHost = host.copy(
                     id = 0L,
-                    nickname = "${host.nickname} (copy)",
+                    nickname = context.getString(R.string.host_duplicate_nickname, host.nickname),
                     lastConnect = 0,
                     hostKeyAlgo = null
                 )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -608,6 +608,8 @@
 	<string name="list_host_portforwards">"Edit port forwards"</string>
 	<!-- Context menu action to delete the selected host -->
 	<string name="list_host_delete">"Delete host"</string>
+	<!-- Context menu action to duplicate the selected host -->
+	<string name="list_host_duplicate">"Duplicate host"</string>
 	<!-- Context menu action to forget stored host keys for the selected host -->
 	<string name="list_host_forget_keys">"Forget host keys"</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -961,6 +961,9 @@
 	<!-- Error message shown when loading a color scheme fails -->
 	<string name="error_color_scheme_load_failed">Failed to load color scheme: %s</string>
 
+	<!-- Format string for the nickname of a duplicated host -->
+	<string name="host_duplicate_nickname">%1$s (copy)</string>
+
 	<!-- Empty state messages -->
 	<!-- Message shown when no hosts have been configured yet -->
 	<string name="empty_hosts_message">No hosts configured</string>


### PR DESCRIPTION
Fix #922.
Allows users to copy an existing host's configuration, including all settings and port forwards. The duplicated host gets a "(copy)" suffix and has its connection-specific data (lastConnect, hostKeyAlgo) reset.