### PR TITLE
Add "Read last output" menu item to console screen

### DIFF
--- a/app/src/main/java/org/connectbot/service/TerminalBridge.kt
+++ b/app/src/main/java/org/connectbot/service/TerminalBridge.kt
@@ -849,6 +849,14 @@ class TerminalBridge {
     }
 
     /**
+     * Get the text output of the last completed command.
+     * Delegates to the terminal emulator's semantic analysis.
+     *
+     * @return The command output text, or null if no completed command is found
+     */
+    fun getLastCommandOutput(): String? = terminalEmulator.getLastCommandOutput()
+
+    /**
      * @return whether the TerminalBridge should close
      */
     fun isAwaitingClose(): Boolean = awaitingClose

--- a/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
@@ -18,6 +18,7 @@
 package org.connectbot.ui.screens.console
 
 import android.app.Activity
+import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
 import androidx.compose.animation.AnimatedVisibility
@@ -43,6 +44,9 @@ import androidx.compose.foundation.layout.imeAnimationTarget
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.union
 import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.ContentPaste
@@ -98,6 +102,9 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -188,6 +195,8 @@ fun ConsoleScreen(
     var lastInteractionTime by remember { mutableLongStateOf(System.currentTimeMillis()) }
     var scannedUrls by remember { mutableStateOf<List<String>>(emptyList()) }
     var selectionController by remember { mutableStateOf<SelectionController?>(null) }
+    var showLastOutputDialog by remember { mutableStateOf(false) }
+    var lastOutputText by remember { mutableStateOf<String?>(null) }
     var imeVisible by remember { mutableStateOf(false) }
     var keyboardScrollInProgress by remember { mutableStateOf(false) }
 
@@ -286,6 +295,7 @@ fun ConsoleScreen(
     val connecting = currentBridge?.isConnecting == true
     val canForwardPorts = currentBridge?.canFowardPorts() == true
     val snackbarHostState = remember { SnackbarHostState() }
+    val scope = rememberCoroutineScope()
 
     // Show software keyboard when session becomes open (if no hardware keyboard)
     // Also show when switching to a different bridge that's already open
@@ -663,6 +673,27 @@ fun ConsoleScreen(
             )
         }
 
+        if (showLastOutputDialog) {
+            LastCommandOutputDialog(
+                outputText = lastOutputText,
+                onDismiss = {
+                    showLastOutputDialog = false
+                    termFocusRequester.requestFocus()
+                },
+                onCopy = { text ->
+                    val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+                    clipboard.setPrimaryClip(
+                        ClipData.newPlainText("terminal output", text)
+                    )
+                    scope.launch {
+                        snackbarHostState.showSnackbar(
+                            context.getString(R.string.console_read_last_output_copied)
+                        )
+                    }
+                }
+            )
+        }
+
         // Overlay TopAppBar - always visible when titleBarHide is false,
         // or temporarily visible when titleBarHide is true and showTitleBar is true
         if (!titleBarHide || showTitleBar) {
@@ -801,6 +832,19 @@ fun ConsoleScreen(
                                 enabled = currentBridge != null
                             )
 
+                            // Read last output
+                            DropdownMenuItem(
+                                text = { Text(stringResource(R.string.console_menu_read_last_output)) },
+                                onClick = {
+                                    showMenu = false
+                                    currentBridge?.let { bridge ->
+                                        lastOutputText = bridge.getLastCommandOutput()
+                                        showLastOutputDialog = true
+                                    }
+                                },
+                                enabled = currentBridge != null
+                            )
+
                             // Resize
                             DropdownMenuItem(
                                 text = { Text(stringResource(R.string.console_menu_resize)) },
@@ -912,6 +956,51 @@ private fun HostDisconnectDialog(
         dismissButton = {
             TextButton(onClick = onDismiss) {
                 Text(stringResource(R.string.button_no))
+            }
+        }
+    )
+}
+
+@Composable
+private fun LastCommandOutputDialog(
+    outputText: String?,
+    onDismiss: () -> Unit,
+    onCopy: (String) -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = {
+            Text(stringResource(R.string.console_read_last_output_title))
+        },
+        text = {
+            if (outputText.isNullOrEmpty()) {
+                Text(
+                    stringResource(R.string.console_read_last_output_empty),
+                    modifier = Modifier.semantics { liveRegion = LiveRegionMode.Polite }
+                )
+            } else {
+                SelectionContainer {
+                    Text(
+                        text = outputText,
+                        modifier = Modifier
+                            .verticalScroll(rememberScrollState())
+                            .semantics { liveRegion = LiveRegionMode.Polite },
+                        fontFamily = androidx.compose.ui.text.font.FontFamily.Monospace,
+                        fontSize = 13.sp
+                    )
+                }
+            }
+        },
+        confirmButton = {
+            if (!outputText.isNullOrEmpty()) {
+                TextButton(onClick = {
+                    onCopy(outputText)
+                }) {
+                    Text(stringResource(R.string.button_copy))
+                }
+            }
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.button_close))
             }
         }
     )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -582,6 +582,14 @@
 	<string name="console_menu_resize">"Force size"</string>
 	<!-- Button that brings up the list of URLs on the current screen -->
 	<string name="console_menu_urlscan">"URL scan"</string>
+	<!-- Menu item to read the last command output using shell integration -->
+	<string name="console_menu_read_last_output">Read last output</string>
+	<!-- Dialog title for displaying last command output -->
+	<string name="console_read_last_output_title">Last Command Output</string>
+	<!-- Message shown when no completed command output is found -->
+	<string name="console_read_last_output_empty">No completed command output found. Shell integration (OSC 133) may not be enabled.</string>
+	<!-- Toast message shown when output is copied to clipboard -->
+	<string name="console_read_last_output_copied">Output copied to clipboard</string>
 
 	<!-- Button label to answer "Yes" to a yes/no prompt -->
 	<string name="button_yes">"Yes"</string>
@@ -979,6 +987,8 @@
 	<string name="button_ok">OK</string>
 	<!-- Button label for closing a dialog -->
 	<string name="button_close">Close</string>
+	<!-- Button label for copying content to clipboard -->
+	<string name="button_copy">Copy</string>
 	<!-- Accessibility label for back navigation button; used for screen readers -->
 	<string name="button_back">Back</string>
 	<!-- Accessibility label for navigate up button in app bar; used for screen readers -->


### PR DESCRIPTION
This PR draft assumes connectbot/termlib#88.
Add a menu item in the console overflow menu that displays the output of the last completed command in a dialog. Uses the new public getLastCommandOutput() API from termlib, which relies on OSC 133 shell integration markers.

The dialog shows scrollable, selectable monospace text with a Copy button and uses liveRegion semantics so TalkBack automatically reads the content.

## Changes                                                                                                                                            
                                                                                                                                                     
  TerminalBridge.kt                                                                                                                                  
                                                                                                                                                     
  - Add getLastCommandOutput(): String? that delegates to terminalEmulator.getLastCommandOutput() (the new public API from termlib)                  
                                                                                                                                                     
  ConsoleScreen.kt                                                                                                                                   
                                                                                                                                                     
  - Add "Read last output" DropdownMenuItem in the overflow menu (after "URL scan")                                                                  
  - Add LastCommandOutputDialog composable:                                                                                                          
    - Scrollable, selectable monospace text displaying the command output                                                                            
    - liveRegion semantics so TalkBack automatically reads the content when the dialog opens                                                         
    - "Copy" button to copy output to clipboard (with snackbar confirmation)                                                                         
    - "Close" button to dismiss                                                                                                                      
    - Informative message when no completed command output is found (shell integration not enabled or no commands run yet)                           
  - Menu item enabled when a terminal bridge is active                                                                                               
                                                                                                                                                     
  strings.xml                                                                                                                                        
                                                                                                                                                     
  - console_menu_read_last_output — menu item label                                                                                                  
  - console_read_last_output_title — dialog title                                                                                                    
  - console_read_last_output_empty — empty state message                                                                                             
  - console_read_last_output_copied — clipboard confirmation                                                                                         
  - button_copy — generic copy button label