### PR TITLE
Revert termlib version to 0.0.18

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,7 +25,7 @@ navigationCompose = "2.9.7"
 activityCompose = "1.12.4"
 
 sshlib = "2.2.42"
-termlib = "0.0.21"
+termlib = "0.0.18"
 playServicesBasement = "18.10.0"
 conscrypt = "2.5.3"
 conscryptOpenJdk = "2.5.2"


### PR DESCRIPTION
Downgrade termlib version from 0.0.21 to 0.0.18 to fix problems with hardware keyboards. #1944