### PR TITLE
[MINOR FIX] Apply spotless formatting to all source files

### DIFF
--- a/app/src/androidTest/java/org/connectbot/HiltTestRunner.kt
+++ b/app/src/androidTest/java/org/connectbot/HiltTestRunner.kt
@@ -27,7 +27,5 @@ class HiltTestRunner : AndroidJUnitRunner() {
         cl: ClassLoader?,
         className: String?,
         context: Context?
-    ): Application {
-        return super.newApplication(cl, HiltTestApplication::class.java.name, context)
-    }
+    ): Application = super.newApplication(cl, HiltTestApplication::class.java.name, context)
 }

--- a/app/src/androidTest/java/org/connectbot/data/migration/LegacyDatabaseMigrationIntegrationTest.kt
+++ b/app/src/androidTest/java/org/connectbot/data/migration/LegacyDatabaseMigrationIntegrationTest.kt
@@ -30,9 +30,9 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import timber.log.Timber
-import javax.inject.Inject
 import java.io.File
 import java.io.FileOutputStream
+import javax.inject.Inject
 
 @HiltAndroidTest
 class LegacyDatabaseMigrationIntegrationTest {

--- a/app/src/androidTest/java/org/connectbot/data/migration/ProfileConflictMigrationTest.kt
+++ b/app/src/androidTest/java/org/connectbot/data/migration/ProfileConflictMigrationTest.kt
@@ -155,7 +155,6 @@ class ProfileConflictMigrationTest {
                 assertThat(success.hostsMigrated).isEqualTo(0)
                 assertThat(success.pubkeysMigrated).isEqualTo(0)
                 Timber.d("Migration correctly skipped - 0 items migrated")
-
             } catch (e: Exception) {
                 Timber.e(e, "Test failed with exception")
                 e.printStackTrace()
@@ -175,7 +174,8 @@ class ProfileConflictMigrationTest {
         val db = SQLiteDatabase.openOrCreateDatabase(dbFile, null)
         try {
             // Create hosts table with legacy schema
-            db.execSQL("""
+            db.execSQL(
+                """
                 CREATE TABLE IF NOT EXISTS hosts (
                     _id INTEGER PRIMARY KEY AUTOINCREMENT,
                     nickname TEXT NOT NULL,
@@ -201,10 +201,12 @@ class ProfileConflictMigrationTest {
                     scrollbacklines INTEGER DEFAULT 140,
                     usectrlaltasmeta TEXT DEFAULT 'false'
                 )
-            """.trimIndent())
+                """.trimIndent()
+            )
 
             // Create portforwards table
-            db.execSQL("""
+            db.execSQL(
+                """
                 CREATE TABLE IF NOT EXISTS portforwards (
                     _id INTEGER PRIMARY KEY AUTOINCREMENT,
                     hostid INTEGER NOT NULL,
@@ -214,36 +216,43 @@ class ProfileConflictMigrationTest {
                     destaddr TEXT NOT NULL,
                     destport INTEGER NOT NULL
                 )
-            """.trimIndent())
+                """.trimIndent()
+            )
 
             // Create knownhosts table
-            db.execSQL("""
+            db.execSQL(
+                """
                 CREATE TABLE IF NOT EXISTS knownhosts (
                     _id INTEGER PRIMARY KEY AUTOINCREMENT,
                     hostid INTEGER NOT NULL,
                     hostkeyalgo TEXT NOT NULL,
                     hostkey BLOB NOT NULL
                 )
-            """.trimIndent())
+                """.trimIndent()
+            )
 
             // Create colorSchemes table
-            db.execSQL("""
+            db.execSQL(
+                """
                 CREATE TABLE IF NOT EXISTS colorSchemes (
                     _id INTEGER PRIMARY KEY AUTOINCREMENT,
                     name TEXT NOT NULL,
                     description TEXT
                 )
-            """.trimIndent())
+                """.trimIndent()
+            )
 
             // Create colors table (color palette)
-            db.execSQL("""
+            db.execSQL(
+                """
                 CREATE TABLE IF NOT EXISTS colors (
                     _id INTEGER PRIMARY KEY AUTOINCREMENT,
                     scheme INTEGER NOT NULL,
                     number INTEGER NOT NULL,
                     value INTEGER NOT NULL
                 )
-            """.trimIndent())
+                """.trimIndent()
+            )
 
             Timber.d("Created empty legacy hosts database at: ${dbFile.absolutePath}")
         } finally {
@@ -262,7 +271,8 @@ class ProfileConflictMigrationTest {
         val db = SQLiteDatabase.openOrCreateDatabase(dbFile, null)
         try {
             // Create pubkeys table with legacy schema
-            db.execSQL("""
+            db.execSQL(
+                """
                 CREATE TABLE IF NOT EXISTS pubkeys (
                     _id INTEGER PRIMARY KEY AUTOINCREMENT,
                     nickname TEXT NOT NULL,
@@ -274,7 +284,8 @@ class ProfileConflictMigrationTest {
                     confirmuse INTEGER NOT NULL DEFAULT 0,
                     lifetime INTEGER NOT NULL DEFAULT 0
                 )
-            """.trimIndent())
+                """.trimIndent()
+            )
 
             Timber.d("Created empty legacy pubkeys database at: ${dbFile.absolutePath}")
         } finally {

--- a/app/src/androidTest/java/org/connectbot/di/TestDatabaseModule.kt
+++ b/app/src/androidTest/java/org/connectbot/di/TestDatabaseModule.kt
@@ -26,8 +26,8 @@ import dagger.Provides
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import dagger.hilt.testing.TestInstallIn
-import javax.inject.Singleton
 import org.connectbot.data.ConnectBotDatabase
+import javax.inject.Singleton
 
 @Module
 @TestInstallIn(
@@ -39,26 +39,26 @@ object TestDatabaseModule {
 
     @Provides
     @Singleton
-    fun provideConnectBotDatabase(@ApplicationContext context: Context): ConnectBotDatabase {
-        return Room.databaseBuilder(
-            context,
-            ConnectBotDatabase::class.java,
-            TEST_DATABASE_NAME
-        )
-            .addMigrations(ConnectBotDatabase.MIGRATION_4_5)
-            .addCallback(object : RoomDatabase.Callback() {
-                override fun onCreate(db: SupportSQLiteDatabase) {
-                    super.onCreate(db)
-                    // Create default profile on fresh database creation
-                    db.execSQL("""
+    fun provideConnectBotDatabase(@ApplicationContext context: Context): ConnectBotDatabase = Room.databaseBuilder(
+        context,
+        ConnectBotDatabase::class.java,
+        TEST_DATABASE_NAME
+    )
+        .addMigrations(ConnectBotDatabase.MIGRATION_4_5)
+        .addCallback(object : RoomDatabase.Callback() {
+            override fun onCreate(db: SupportSQLiteDatabase) {
+                super.onCreate(db)
+                // Create default profile on fresh database creation
+                db.execSQL(
+                    """
                         INSERT INTO profiles (name, color_scheme_id, font_size, del_key, encoding, emulation)
                         VALUES ('Default', -1, 10, 'del', 'UTF-8', 'xterm-256color')
-                    """.trimIndent())
-                }
-            })
-            .allowMainThreadQueries()
-            .build()
-    }
+                    """.trimIndent()
+                )
+            }
+        })
+        .allowMainThreadQueries()
+        .build()
 
     @Provides
     fun provideHostDao(database: ConnectBotDatabase) = database.hostDao()

--- a/app/src/androidTest/java/org/connectbot/util/TestExtensions.kt
+++ b/app/src/androidTest/java/org/connectbot/util/TestExtensions.kt
@@ -49,15 +49,13 @@ suspend fun MainActivity.waitUntilServiceBound(
 suspend fun TerminalManager.waitForBridge(
     predicate: (TerminalBridge) -> Boolean,
     timeoutMillis: Long = 5000
-): TerminalBridge {
-    return withTimeout(timeoutMillis) {
-        var foundBridge: TerminalBridge? = null
-        while (foundBridge == null) {
-            foundBridge = bridgesFlow.value.firstOrNull(predicate)
-            if (foundBridge == null) delay(100)
-        }
-        foundBridge
+): TerminalBridge = withTimeout(timeoutMillis) {
+    var foundBridge: TerminalBridge? = null
+    while (foundBridge == null) {
+        foundBridge = bridgesFlow.value.firstOrNull(predicate)
+        if (foundBridge == null) delay(100)
     }
+    foundBridge
 }
 
 /**
@@ -66,6 +64,4 @@ suspend fun TerminalManager.waitForBridge(
 suspend fun TerminalManager.waitForBridgeByNickname(
     nickname: String,
     timeoutMillis: Long = 5000
-): TerminalBridge {
-    return waitForBridge({ it.host.nickname == nickname }, timeoutMillis)
-}
+): TerminalBridge = waitForBridge({ it.host.nickname == nickname }, timeoutMillis)

--- a/app/src/google/java/org/connectbot/util/ProviderLoader.kt
+++ b/app/src/google/java/org/connectbot/util/ProviderLoader.kt
@@ -30,8 +30,7 @@ object ProviderLoader {
         ProviderInstaller.installIfNeededAsync(context, ProviderInstallListenerWrapper(listener))
     }
 
-    private class ProviderInstallListenerWrapper(private val mListener: ProviderLoaderListener) :
-        ProviderInstallListener {
+    private class ProviderInstallListenerWrapper(private val mListener: ProviderLoaderListener) : ProviderInstallListener {
         override fun onProviderInstalled() {
             mListener.onProviderLoaderSuccess()
         }

--- a/app/src/main/java/org/connectbot/data/ColorSchemeJson.kt
+++ b/app/src/main/java/org/connectbot/data/ColorSchemeJson.kt
@@ -99,7 +99,7 @@ data class ColorSchemeJson(
         private fun isValidHexColor(hex: String): Boolean {
             val cleaned = hex.removePrefix("#")
             return cleaned.length in listOf(3, 6) &&
-                   cleaned.all { it in "0123456789ABCDEFabcdef" }
+                cleaned.all { it in "0123456789ABCDEFabcdef" }
         }
     }
 
@@ -158,7 +158,9 @@ data class ColorSchemeJson(
                 val b = cleaned[2].toString().repeat(2)
                 (r + g + b).toInt(16)
             }
+
             6 -> cleaned.toInt(16)
+
             else -> throw IllegalArgumentException("Invalid hex color: $hex")
         }
 

--- a/app/src/main/java/org/connectbot/data/ColorSchemePresets.kt
+++ b/app/src/main/java/org/connectbot/data/ColorSchemePresets.kt
@@ -47,7 +47,7 @@ object ColorSchemePresets {
             0xff4444ff.toInt(), // light blue
             0xffff44ff.toInt(), // light purple
             0xff44ffff.toInt(), // light cyan
-            0xffffffff.toInt(), // white
+            0xffffffff.toInt() // white
         )
     )
 
@@ -59,7 +59,7 @@ object ColorSchemePresets {
         name = "Solarized Dark",
         description = "Precision colors for machines and people",
         defaultFg = 12, // base0 (#839496)
-        defaultBg = 8,  // base03 (#002b36)
+        defaultBg = 8, // base03 (#002b36)
         colors = intArrayOf(
             // ANSI colors (0-15) - Official Solarized Dark mapping
             0xff073642.toInt(), // black: base02
@@ -77,7 +77,7 @@ object ColorSchemePresets {
             0xff839496.toInt(), // bright blue: base0
             0xff6c71c4.toInt(), // bright magenta: violet
             0xff93a1a1.toInt(), // bright cyan: base1
-            0xfffdf6e3.toInt()  // bright white: base3
+            0xfffdf6e3.toInt() // bright white: base3
         )
     )
 
@@ -108,7 +108,7 @@ object ColorSchemePresets {
             0xff839496.toInt(), // bright blue: base0
             0xff6c71c4.toInt(), // bright magenta: violet
             0xff93a1a1.toInt(), // bright cyan: base1
-            0xfffdf6e3.toInt()  // bright white: base3
+            0xfffdf6e3.toInt() // bright white: base3
         )
     )
 
@@ -136,7 +136,7 @@ object ColorSchemePresets {
             0xffd6acff.toInt(), // bright purple
             0xffff92df.toInt(), // bright pink
             0xffa4ffff.toInt(), // bright cyan
-            0xffffffff.toInt()  // bright white
+            0xffffffff.toInt() // bright white
         )
     )
 
@@ -164,7 +164,7 @@ object ColorSchemePresets {
             0xff81a1c1.toInt(), // bright blue
             0xffb48ead.toInt(), // bright purple
             0xff8fbcbb.toInt(), // bright cyan
-            0xffeceff4.toInt()  // bright white
+            0xffeceff4.toInt() // bright white
         )
     )
 
@@ -192,7 +192,7 @@ object ColorSchemePresets {
             0xff83a598.toInt(), // bright blue
             0xffd3869b.toInt(), // bright purple
             0xff8ec07c.toInt(), // bright aqua
-            0xffebdbb2.toInt()  // light
+            0xffebdbb2.toInt() // light
         )
     )
 
@@ -220,7 +220,7 @@ object ColorSchemePresets {
             0xff66d9ef.toInt(), // bright blue
             0xffae81ff.toInt(), // bright purple
             0xffa1efe4.toInt(), // bright cyan
-            0xfff9f8f5.toInt()  // bright white
+            0xfff9f8f5.toInt() // bright white
         )
     )
 
@@ -248,7 +248,7 @@ object ColorSchemePresets {
             0xff81a2be.toInt(), // bright blue
             0xffb294bb.toInt(), // bright purple
             0xff8abeb7.toInt(), // bright cyan
-            0xffffffff.toInt()  // bright white
+            0xffffffff.toInt() // bright white
         )
     )
 
@@ -274,7 +274,7 @@ object ColorSchemePresets {
         val description: String,
         val defaultFg: Int,
         val defaultBg: Int,
-        val colors: IntArray,
+        val colors: IntArray
     ) {
         override fun equals(other: Any?): Boolean {
             if (this === other) return true

--- a/app/src/main/java/org/connectbot/data/Converters.kt
+++ b/app/src/main/java/org/connectbot/data/Converters.kt
@@ -25,12 +25,8 @@ import org.connectbot.data.entity.KeyStorageType
  */
 class Converters {
     @TypeConverter
-    fun fromKeyStorageType(value: KeyStorageType): String {
-        return value.name
-    }
+    fun fromKeyStorageType(value: KeyStorageType): String = value.name
 
     @TypeConverter
-    fun toKeyStorageType(value: String): KeyStorageType {
-        return KeyStorageType.valueOf(value)
-    }
+    fun toKeyStorageType(value: String): KeyStorageType = KeyStorageType.valueOf(value)
 }

--- a/app/src/main/java/org/connectbot/data/DatabaseSchema.kt
+++ b/app/src/main/java/org/connectbot/data/DatabaseSchema.kt
@@ -88,9 +88,7 @@ data class EntitySchema(
     /**
      * Get the unique index columns for conflict detection (e.g., "nickname" for hosts).
      */
-    fun getUniqueConstraintFields(): List<String> {
-        return uniqueIndices.flatMap { it.columnNames }
-    }
+    fun getUniqueConstraintFields(): List<String> = uniqueIndices.flatMap { it.columnNames }
 
     companion object {
         fun fromJson(json: JSONObject): EntitySchema {
@@ -142,22 +140,24 @@ data class EntitySchema(
  * Schema definition for a single field (column).
  */
 data class FieldSchema(
-    val fieldPath: String,      // Kotlin property name (e.g., "jumpHostId")
-    val columnName: String,     // Database column name (e.g., "jump_host_id")
-    val affinity: String,       // SQLite type affinity (INTEGER, TEXT, BLOB, REAL)
+    // Kotlin property name (e.g., "jumpHostId")
+    val fieldPath: String,
+    // Database column name (e.g., "jump_host_id")
+    val columnName: String,
+    // SQLite type affinity (INTEGER, TEXT, BLOB, REAL)
+    val affinity: String,
     val notNull: Boolean,
-    val excluded: Boolean       // True if field should be excluded from export (e.g., runtime state)
+    // True if field should be excluded from export (e.g., runtime state)
+    val excluded: Boolean
 ) {
     companion object {
-        fun fromJson(json: JSONObject): FieldSchema {
-            return FieldSchema(
-                fieldPath = json.getString("fieldPath"),
-                columnName = json.getString("columnName"),
-                affinity = json.getString("affinity"),
-                notNull = json.optBoolean("notNull", false),
-                excluded = json.optBoolean("excluded", false)
-            )
-        }
+        fun fromJson(json: JSONObject): FieldSchema = FieldSchema(
+            fieldPath = json.getString("fieldPath"),
+            columnName = json.getString("columnName"),
+            affinity = json.getString("affinity"),
+            notNull = json.optBoolean("notNull", false),
+            excluded = json.optBoolean("excluded", false)
+        )
     }
 }
 
@@ -173,24 +173,22 @@ data class PrimaryKeySchema(
  * Schema definition for a foreign key relationship.
  */
 data class ForeignKeySchema(
-    val table: String,              // Referenced table name
-    val columns: List<String>,      // Local column names
-    val referencedColumns: List<String>,  // Referenced column names
+    val table: String, // Referenced table name
+    val columns: List<String>, // Local column names
+    val referencedColumns: List<String>, // Referenced column names
     val onDelete: String
 ) {
     companion object {
-        fun fromJson(json: JSONObject): ForeignKeySchema {
-            return ForeignKeySchema(
-                table = json.getString("table"),
-                columns = json.getJSONArray("columns").let { arr ->
-                    (0 until arr.length()).map { arr.getString(it) }
-                },
-                referencedColumns = json.getJSONArray("referencedColumns").let { arr ->
-                    (0 until arr.length()).map { arr.getString(it) }
-                },
-                onDelete = json.getString("onDelete")
-            )
-        }
+        fun fromJson(json: JSONObject): ForeignKeySchema = ForeignKeySchema(
+            table = json.getString("table"),
+            columns = json.getJSONArray("columns").let { arr ->
+                (0 until arr.length()).map { arr.getString(it) }
+            },
+            referencedColumns = json.getJSONArray("referencedColumns").let { arr ->
+                (0 until arr.length()).map { arr.getString(it) }
+            },
+            onDelete = json.getString("onDelete")
+        )
     }
 }
 
@@ -202,13 +200,11 @@ data class UniqueIndexSchema(
     val columnNames: List<String>
 ) {
     companion object {
-        fun fromJson(json: JSONObject): UniqueIndexSchema {
-            return UniqueIndexSchema(
-                name = json.getString("name"),
-                columnNames = json.getJSONArray("columnNames").let { arr ->
-                    (0 until arr.length()).map { arr.getString(it) }
-                }
-            )
-        }
+        fun fromJson(json: JSONObject): UniqueIndexSchema = UniqueIndexSchema(
+            name = json.getString("name"),
+            columnNames = json.getJSONArray("columnNames").let { arr ->
+                (0 until arr.length()).map { arr.getString(it) }
+            }
+        )
     }
 }

--- a/app/src/main/java/org/connectbot/data/ProfileRepository.kt
+++ b/app/src/main/java/org/connectbot/data/ProfileRepository.kt
@@ -130,10 +130,9 @@ class ProfileRepository @Inject constructor(
      * @param excludeProfileId Optional profile ID to exclude from the check (for renames)
      * @return true if the name exists, false otherwise
      */
-    suspend fun nameExists(name: String, excludeProfileId: Long? = null): Boolean =
-        withContext(dispatchers.io) {
-            profileDao.nameExists(name, excludeProfileId)
-        }
+    suspend fun nameExists(name: String, excludeProfileId: Long? = null): Boolean = withContext(dispatchers.io) {
+        profileDao.nameExists(name, excludeProfileId)
+    }
 
     /**
      * Get the count of hosts using a specific profile.
@@ -168,13 +167,12 @@ class ProfileRepository @Inject constructor(
      * @param newName The name for the duplicated profile
      * @return The ID of the newly created profile
      */
-    suspend fun duplicate(sourceProfileId: Long, newName: String): Long =
-        withContext(dispatchers.io) {
-            val source = profileDao.getById(sourceProfileId) ?: Profile.createDefault()
-            val newProfile = source.copy(
-                id = 0,
-                name = newName
-            )
-            profileDao.insert(newProfile)
-        }
+    suspend fun duplicate(sourceProfileId: Long, newName: String): Long = withContext(dispatchers.io) {
+        val source = profileDao.getById(sourceProfileId) ?: Profile.createDefault()
+        val newProfile = source.copy(
+            id = 0,
+            name = newName
+        )
+        profileDao.insert(newProfile)
+    }
 }

--- a/app/src/main/java/org/connectbot/data/PubkeyRepository.kt
+++ b/app/src/main/java/org/connectbot/data/PubkeyRepository.kt
@@ -54,8 +54,7 @@ class PubkeyRepository @Inject constructor(
      * @param type The storage type (EXPORTABLE or ANDROID_KEYSTORE)
      * @return Flow of pubkey list filtered by type
      */
-    fun observeByStorageType(type: KeyStorageType): Flow<List<Pubkey>> =
-        pubkeyDao.observeByStorageType(type)
+    fun observeByStorageType(type: KeyStorageType): Flow<List<Pubkey>> = pubkeyDao.observeByStorageType(type)
 
     /**
      * Observe a specific pubkey reactively.
@@ -97,8 +96,7 @@ class PubkeyRepository @Inject constructor(
      * @param nickname The pubkey nickname
      * @return The pubkey, or null if not found
      */
-    suspend fun getByNickname(nickname: String): Pubkey? =
-        pubkeyDao.getByNickname(nickname)
+    suspend fun getByNickname(nickname: String): Pubkey? = pubkeyDao.getByNickname(nickname)
 
     /**
      * Get all pubkeys that allow backup.
@@ -137,16 +135,14 @@ class PubkeyRepository @Inject constructor(
      * @param pubkey The pubkey to save
      * @return The saved pubkey with updated ID
      */
-    suspend fun save(pubkey: Pubkey): Pubkey {
-        return if (pubkey.id == 0L) {
-            // New pubkey - insert
-            val newId = pubkeyDao.insert(pubkey)
-            pubkey.copy(id = newId)
-        } else {
-            // Existing pubkey - update
-            pubkeyDao.update(pubkey)
-            pubkey
-        }
+    suspend fun save(pubkey: Pubkey): Pubkey = if (pubkey.id == 0L) {
+        // New pubkey - insert
+        val newId = pubkeyDao.insert(pubkey)
+        pubkey.copy(id = newId)
+    } else {
+        // Existing pubkey - update
+        pubkeyDao.update(pubkey)
+        pubkey
     }
 
     /**

--- a/app/src/main/java/org/connectbot/data/SchemaBasedExporter.kt
+++ b/app/src/main/java/org/connectbot/data/SchemaBasedExporter.kt
@@ -368,8 +368,11 @@ class SchemaBasedExporter(
 
             when (field.affinity) {
                 "INTEGER" -> values.put(field.columnName, row.getLong(field.fieldPath))
+
                 "TEXT" -> values.put(field.columnName, row.getString(field.fieldPath))
+
                 "REAL" -> values.put(field.columnName, row.getDouble(field.fieldPath))
+
                 "BLOB" -> {
                     val base64 = row.getString(field.fieldPath)
                     values.put(field.columnName, Base64.decode(base64, Base64.NO_WRAP))

--- a/app/src/main/java/org/connectbot/data/dao/HostDao.kt
+++ b/app/src/main/java/org/connectbot/data/dao/HostDao.kt
@@ -96,11 +96,13 @@ interface HostDao {
     /**
      * Find host associated with a known host entry.
      */
-    @Query("""
+    @Query(
+        """
         SELECT h.* FROM hosts h
         JOIN known_hosts kh ON h.id = kh.host_id
         WHERE kh.hostname = :hostname AND kh.port = :port
-    """)
+    """
+    )
     suspend fun findByKnownHost(hostname: String, port: Int): Host?
 
     /**

--- a/app/src/main/java/org/connectbot/data/entity/ColorScheme.kt
+++ b/app/src/main/java/org/connectbot/data/entity/ColorScheme.kt
@@ -42,5 +42,5 @@ data class ColorScheme(
     val isBuiltIn: Boolean,
     val description: String = "",
     val foreground: Int = 7,
-    val background: Int = 0,
+    val background: Int = 0
 )

--- a/app/src/main/java/org/connectbot/data/entity/PortForward.kt
+++ b/app/src/main/java/org/connectbot/data/entity/PortForward.kt
@@ -69,9 +69,7 @@ data class PortForward(
     /**
      * Get a human-readable description of this port forward (Java interop helper).
      */
-    fun getDescription(): String {
-        return "$nickname ($type)"
-    }
+    fun getDescription(): String = "$nickname ($type)"
 
     /**
      * Check if this port forward is currently enabled (Java interop helper).

--- a/app/src/main/java/org/connectbot/data/entity/Pubkey.kt
+++ b/app/src/main/java/org/connectbot/data/entity/Pubkey.kt
@@ -89,7 +89,9 @@ data class Pubkey(
         if (privateKey != null) {
             if (other.privateKey == null) return false
             if (!privateKey.contentEquals(other.privateKey)) return false
-        } else if (other.privateKey != null) return false
+        } else if (other.privateKey != null) {
+            return false
+        }
         if (!publicKey.contentEquals(other.publicKey)) return false
         if (encrypted != other.encrypted) return false
         if (startup != other.startup) return false

--- a/app/src/main/java/org/connectbot/data/migration/LegacyHostDatabaseReader.kt
+++ b/app/src/main/java/org/connectbot/data/migration/LegacyHostDatabaseReader.kt
@@ -20,11 +20,11 @@ package org.connectbot.data.migration
 import android.content.Context
 import android.database.Cursor
 import android.database.sqlite.SQLiteDatabase
-import timber.log.Timber
 import org.connectbot.data.entity.ColorPalette
 import org.connectbot.data.entity.ColorScheme
 import org.connectbot.data.entity.KnownHost
 import org.connectbot.data.entity.PortForward
+import timber.log.Timber
 
 /**
  * Data class for hosts from the legacy database that includes
@@ -375,7 +375,5 @@ class LegacyHostDatabaseReader(private val context: Context) {
         return value.equals("true", ignoreCase = true)
     }
 
-    private fun Cursor.getStringOrNull(columnIndex: Int): String? {
-        return if (isNull(columnIndex)) null else getString(columnIndex)
-    }
+    private fun Cursor.getStringOrNull(columnIndex: Int): String? = if (isNull(columnIndex)) null else getString(columnIndex)
 }

--- a/app/src/main/java/org/connectbot/data/migration/LegacyPubkeyDatabaseReader.kt
+++ b/app/src/main/java/org/connectbot/data/migration/LegacyPubkeyDatabaseReader.kt
@@ -20,9 +20,9 @@ package org.connectbot.data.migration
 import android.content.Context
 import android.database.Cursor
 import android.database.sqlite.SQLiteDatabase
-import timber.log.Timber
 import org.connectbot.data.entity.KeyStorageType
 import org.connectbot.data.entity.Pubkey
+import timber.log.Timber
 
 /**
  * Reads data from the legacy PubkeyDatabase (version 2).

--- a/app/src/main/java/org/connectbot/di/AppModule.kt
+++ b/app/src/main/java/org/connectbot/di/AppModule.kt
@@ -33,7 +33,5 @@ object AppModule {
 
     @Provides
     @Singleton
-    fun provideSharedPreferences(@ApplicationContext context: Context): SharedPreferences {
-        return PreferenceManager.getDefaultSharedPreferences(context)
-    }
+    fun provideSharedPreferences(@ApplicationContext context: Context): SharedPreferences = PreferenceManager.getDefaultSharedPreferences(context)
 }

--- a/app/src/main/java/org/connectbot/di/DatabaseModule.kt
+++ b/app/src/main/java/org/connectbot/di/DatabaseModule.kt
@@ -36,25 +36,25 @@ object DatabaseModule {
 
     @Provides
     @Singleton
-    fun provideConnectBotDatabase(@ApplicationContext context: Context): ConnectBotDatabase {
-        return Room.databaseBuilder(
-            context,
-            ConnectBotDatabase::class.java,
-            DATABASE_NAME
-        )
-            .addMigrations(ConnectBotDatabase.MIGRATION_4_5)
-            .addCallback(object : RoomDatabase.Callback() {
-                override fun onCreate(db: SupportSQLiteDatabase) {
-                    super.onCreate(db)
-                    // Create default profile on fresh database creation
-                    db.execSQL("""
+    fun provideConnectBotDatabase(@ApplicationContext context: Context): ConnectBotDatabase = Room.databaseBuilder(
+        context,
+        ConnectBotDatabase::class.java,
+        DATABASE_NAME
+    )
+        .addMigrations(ConnectBotDatabase.MIGRATION_4_5)
+        .addCallback(object : RoomDatabase.Callback() {
+            override fun onCreate(db: SupportSQLiteDatabase) {
+                super.onCreate(db)
+                // Create default profile on fresh database creation
+                db.execSQL(
+                    """
                         INSERT INTO profiles (name, color_scheme_id, font_size, del_key, encoding, emulation)
                         VALUES ('Default', -1, 10, 'del', 'UTF-8', 'xterm-256color')
-                    """.trimIndent())
-                }
-            })
-            .build()
-    }
+                    """.trimIndent()
+                )
+            }
+        })
+        .build()
 
     @Provides
     fun provideHostDao(database: ConnectBotDatabase) = database.hostDao()

--- a/app/src/main/java/org/connectbot/di/MigrationModule.kt
+++ b/app/src/main/java/org/connectbot/di/MigrationModule.kt
@@ -33,13 +33,9 @@ object MigrationModule {
 
     @Provides
     @Singleton
-    fun provideLegacyHostDatabaseReader(@ApplicationContext context: Context): LegacyHostDatabaseReader {
-        return LegacyHostDatabaseReader(context)
-    }
+    fun provideLegacyHostDatabaseReader(@ApplicationContext context: Context): LegacyHostDatabaseReader = LegacyHostDatabaseReader(context)
 
     @Provides
     @Singleton
-    fun provideLegacyPubkeyDatabaseReader(@ApplicationContext context: Context): LegacyPubkeyDatabaseReader {
-        return LegacyPubkeyDatabaseReader(context)
-    }
+    fun provideLegacyPubkeyDatabaseReader(@ApplicationContext context: Context): LegacyPubkeyDatabaseReader = LegacyPubkeyDatabaseReader(context)
 }

--- a/app/src/main/java/org/connectbot/service/BackupFilter.kt
+++ b/app/src/main/java/org/connectbot/service/BackupFilter.kt
@@ -120,18 +120,17 @@ class BackupFilter(
      * @param pubkeys The list of pubkeys to filter
      * @return The list of backupable pubkeys
      */
-    fun filterBackupablePubkeys(pubkeys: List<org.connectbot.data.entity.Pubkey>):
-            List<org.connectbot.data.entity.Pubkey> {
-        return pubkeys.filter { pubkey ->
-            val isBackupable = pubkey.allowBackup && pubkey.storageType != KeyStorageType.ANDROID_KEYSTORE
+    fun filterBackupablePubkeys(pubkeys: List<org.connectbot.data.entity.Pubkey>): List<org.connectbot.data.entity.Pubkey> = pubkeys.filter { pubkey ->
+        val isBackupable = pubkey.allowBackup && pubkey.storageType != KeyStorageType.ANDROID_KEYSTORE
 
-            if (!isBackupable) {
-                Timber.d("Filtering out pubkey: ${pubkey.nickname} " +
-                        "(allowBackup=${pubkey.allowBackup}, storageType=${pubkey.storageType})")
-            }
-
-            isBackupable
+        if (!isBackupable) {
+            Timber.d(
+                "Filtering out pubkey: ${pubkey.nickname} " +
+                    "(allowBackup=${pubkey.allowBackup}, storageType=${pubkey.storageType})"
+            )
         }
+
+        isBackupable
     }
 
     /**

--- a/app/src/main/java/org/connectbot/service/ConnectionNotifier.kt
+++ b/app/src/main/java/org/connectbot/service/ConnectionNotifier.kt
@@ -33,7 +33,6 @@ import org.connectbot.R
 import org.connectbot.data.entity.Host
 import org.connectbot.ui.MainActivity
 import org.connectbot.util.HostConstants
-
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -52,8 +51,7 @@ class ConnectionNotifier @Inject constructor() {
         PendingIntent.FLAG_UPDATE_CURRENT
     }
 
-    private fun getNotificationManager(context: Context): NotificationManager =
-        context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+    private fun getNotificationManager(context: Context): NotificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
 
     private fun newNotificationBuilder(context: Context, id: String): NotificationCompat.Builder {
         val builder = NotificationCompat.Builder(context, id)

--- a/app/src/main/java/org/connectbot/service/ConnectivityMonitor.kt
+++ b/app/src/main/java/org/connectbot/service/ConnectivityMonitor.kt
@@ -165,27 +165,27 @@ class ConnectivityMonitor(
     /**
      * Extract IP addresses from LinkProperties.
      */
-    private fun extractIpAddresses(linkProperties: LinkProperties): Set<String> {
-        return linkProperties.linkAddresses
-            .mapNotNull { it.address.hostAddress }
-            .toSet()
-    }
+    private fun extractIpAddresses(linkProperties: LinkProperties): Set<String> = linkProperties.linkAddresses
+        .mapNotNull { it.address.hostAddress }
+        .toSet()
 
     /**
      * Determine network type from NetworkCapabilities.
      */
-    private fun getNetworkType(capabilities: NetworkCapabilities): Int {
-        return when {
-            capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) ->
-                NetworkCapabilities.TRANSPORT_WIFI
-            capabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) ->
-                NetworkCapabilities.TRANSPORT_CELLULAR
-            capabilities.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET) ->
-                NetworkCapabilities.TRANSPORT_ETHERNET
-            capabilities.hasTransport(NetworkCapabilities.TRANSPORT_VPN) ->
-                NetworkCapabilities.TRANSPORT_VPN
-            else -> -1
-        }
+    private fun getNetworkType(capabilities: NetworkCapabilities): Int = when {
+        capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) ->
+            NetworkCapabilities.TRANSPORT_WIFI
+
+        capabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) ->
+            NetworkCapabilities.TRANSPORT_CELLULAR
+
+        capabilities.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET) ->
+            NetworkCapabilities.TRANSPORT_ETHERNET
+
+        capabilities.hasTransport(NetworkCapabilities.TRANSPORT_VPN) ->
+            NetworkCapabilities.TRANSPORT_VPN
+
+        else -> -1
     }
 
     /**

--- a/app/src/main/java/org/connectbot/service/Relay.kt
+++ b/app/src/main/java/org/connectbot/service/Relay.kt
@@ -151,7 +151,9 @@ class Relay(
                                 destBuffer.flip()
                                 if (destBuffer.hasRemaining()) {
                                     bridge.terminalEmulator.writeInput(
-                                        destBuffer.array(), 0, destBuffer.limit()
+                                        destBuffer.array(),
+                                        0,
+                                        destBuffer.limit()
                                     )
                                 }
                                 destBuffer.clear()

--- a/app/src/main/java/org/connectbot/service/TerminalBridgePrompts.kt
+++ b/app/src/main/java/org/connectbot/service/TerminalBridgePrompts.kt
@@ -37,7 +37,7 @@ import timber.log.Timber
  */
 fun TerminalBridge.requestBooleanPrompt(
     instructions: String?,
-    message: String,
+    message: String
 ): Boolean? {
     return try {
         runBlocking {
@@ -62,7 +62,7 @@ fun TerminalBridge.requestBooleanPrompt(
 fun TerminalBridge.requestStringPrompt(
     instructions: String?,
     hint: String?,
-    isPassword: Boolean = false,
+    isPassword: Boolean = false
 ): String? {
     return try {
         runBlocking {
@@ -123,8 +123,14 @@ fun TerminalBridge.requestHostKeyFingerprintPrompt(
     return try {
         runBlocking {
             promptManager.requestHostKeyFingerprintPrompt(
-                hostname, keyType, keySize, serverHostKey,
-                randomArt, bubblebabble, sha256, md5
+                hostname,
+                keyType,
+                keySize,
+                serverHostKey,
+                randomArt,
+                bubblebabble,
+                sha256,
+                md5
             )
         }
     } catch (e: CancellationException) {

--- a/app/src/main/java/org/connectbot/transport/AbsTransport.kt
+++ b/app/src/main/java/org/connectbot/transport/AbsTransport.kt
@@ -31,8 +31,10 @@ import java.io.IOException
 abstract class AbsTransport {
     @JvmField
     var host: Host? = null
+
     @JvmField
     var bridge: TerminalBridge? = null
+
     @JvmField
     var manager: TerminalManager? = null
 

--- a/app/src/main/java/org/connectbot/transport/Local.kt
+++ b/app/src/main/java/org/connectbot/transport/Local.kt
@@ -19,16 +19,16 @@ package org.connectbot.transport
 
 import android.content.Context
 import android.net.Uri
-import timber.log.Timber
 import androidx.annotation.VisibleForTesting
+import androidx.core.net.toUri
 import com.google.ase.Exec
 import org.connectbot.R
 import org.connectbot.data.entity.Host
+import timber.log.Timber
 import java.io.FileDescriptor
 import java.io.FileInputStream
 import java.io.FileOutputStream
 import java.io.IOException
-import androidx.core.net.toUri
 
 /**
  * @author Kenny Root
@@ -88,8 +88,7 @@ class Local @VisibleForTesting constructor(private val killer: Killer) : AbsTran
         os?.flush()
     }
 
-    override fun getDefaultNickname(username: String?, hostname: String?, port: Int): String =
-        DEFAULT_URI
+    override fun getDefaultNickname(username: String?, hostname: String?, port: Int): String = DEFAULT_URI
 
     override fun getDefaultPort(): Int = 0
 
@@ -172,7 +171,6 @@ class Local @VisibleForTesting constructor(private val killer: Killer) : AbsTran
         }
 
         @JvmStatic
-        fun getFormatHint(context: Context): String =
-            context.getString(R.string.hostpref_nickname_title)
+        fun getFormatHint(context: Context): String = context.getString(R.string.hostpref_nickname_title)
     }
 }

--- a/app/src/main/java/org/connectbot/transport/StreamSocket.kt
+++ b/app/src/main/java/org/connectbot/transport/StreamSocket.kt
@@ -76,12 +76,10 @@ class StreamSocket(
 
     override fun isOutputShutdown(): Boolean = closed
 
-    override fun getInetAddress(): InetAddress? {
-        return try {
-            InetAddress.getByName(remoteHost)
-        } catch (e: Exception) {
-            null
-        }
+    override fun getInetAddress(): InetAddress? = try {
+        InetAddress.getByName(remoteHost)
+    } catch (e: Exception) {
+        null
     }
 
     override fun getPort(): Int = remotePort

--- a/app/src/main/java/org/connectbot/transport/Transport.kt
+++ b/app/src/main/java/org/connectbot/transport/Transport.kt
@@ -66,8 +66,7 @@ sealed class Transport {
         override val defaultPort = 22
         override val usesNetwork = true
 
-        override fun getFormatHint(context: Context): String =
-            SSH.getFormatHint(context)
+        override fun getFormatHint(context: Context): String = SSH.getFormatHint(context)
 
         override fun createInstance(): AbsTransport = SSH()
 
@@ -82,13 +81,11 @@ sealed class Transport {
         override val defaultPort = 23
         override val usesNetwork = true
 
-        override fun getFormatHint(context: Context): String =
-            org.connectbot.transport.Telnet.getFormatHint(context)
+        override fun getFormatHint(context: Context): String = org.connectbot.transport.Telnet.getFormatHint(context)
 
         override fun createInstance(): AbsTransport = org.connectbot.transport.Telnet()
 
-        override fun parseUri(input: String): Uri? =
-            org.connectbot.transport.Telnet.getUri(input)
+        override fun parseUri(input: String): Uri? = org.connectbot.transport.Telnet.getUri(input)
     }
 
     /**
@@ -99,13 +96,11 @@ sealed class Transport {
         override val defaultPort = 0
         override val usesNetwork = false
 
-        override fun getFormatHint(context: Context): String =
-            org.connectbot.transport.Local.getFormatHint(context)
+        override fun getFormatHint(context: Context): String = org.connectbot.transport.Local.getFormatHint(context)
 
         override fun createInstance(): AbsTransport = org.connectbot.transport.Local()
 
-        override fun parseUri(input: String): Uri? =
-            org.connectbot.transport.Local.getUri(input)
+        override fun parseUri(input: String): Uri? = org.connectbot.transport.Local.getUri(input)
     }
 
     companion object {

--- a/app/src/main/java/org/connectbot/transport/TransportFactory.kt
+++ b/app/src/main/java/org/connectbot/transport/TransportFactory.kt
@@ -19,9 +19,9 @@ package org.connectbot.transport
 
 import android.content.Context
 import android.net.Uri
-import timber.log.Timber
 import org.connectbot.data.HostRepository
 import org.connectbot.data.entity.Host
+import timber.log.Timber
 
 /**
  * Factory for creating and managing transport instances.
@@ -36,9 +36,7 @@ object TransportFactory {
      * @param protocol The protocol name (e.g., "ssh", "telnet", "local")
      * @return Transport instance or null if protocol is not recognized
      */
-    fun getTransport(protocol: String?): AbsTransport? {
-        return Transport.fromProtocol(protocol)?.createInstance()
-    }
+    fun getTransport(protocol: String?): AbsTransport? = Transport.fromProtocol(protocol)?.createInstance()
 
     /**
      * Parse a URI string for a given scheme.
@@ -59,9 +57,7 @@ object TransportFactory {
      * Get all available transport protocol names.
      * @return Array of protocol names
      */
-    fun getTransportNames(): Array<String> {
-        return Transport.allTransports().map { it.protocolName }.toTypedArray()
-    }
+    fun getTransportNames(): Array<String> = Transport.allTransports().map { it.protocolName }.toTypedArray()
 
     /**
      * Check if two transports are of the same type.
@@ -91,9 +87,7 @@ object TransportFactory {
      * @param context Android context for accessing resources
      * @return Format hint string
      */
-    fun getFormatHint(protocol: String, context: Context): String {
-        return Transport.fromProtocol(protocol)?.getFormatHint(context) ?: "???"
-    }
+    fun getFormatHint(protocol: String, context: Context): String = Transport.fromProtocol(protocol)?.getFormatHint(context) ?: "???"
 
     /**
      * Find a host in the repository that matches the given URI.

--- a/app/src/main/java/org/connectbot/ui/MigrationScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/MigrationScreen.kt
@@ -75,7 +75,7 @@ fun MigrationScreen(
         color = MaterialTheme.colorScheme.background // Surface uses this by default
     ) {
         Column(
-            modifier = modifier
+            modifier = Modifier
                 .fillMaxSize()
                 .padding(32.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
@@ -108,19 +108,21 @@ fun MigrationScreen(
 
 @Composable
 private fun CheckingMigrationContent() {
-    CircularProgressIndicator(
-        modifier = Modifier
-            .size(48.dp)
-            .semantics {
-                contentDescription = "Checking database migration status"
-            }
-    )
-    Spacer(modifier = Modifier.height(16.dp))
-    Text(
-        text = stringResource(R.string.migration_checking),
-        style = MaterialTheme.typography.bodyLarge,
-        textAlign = TextAlign.Center
-    )
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        CircularProgressIndicator(
+            modifier = Modifier
+                .size(48.dp)
+                .semantics {
+                    contentDescription = "Checking database migration status"
+                }
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        Text(
+            text = stringResource(R.string.migration_checking),
+            style = MaterialTheme.typography.bodyLarge,
+            textAlign = TextAlign.Center
+        )
+    }
 }
 
 @Composable
@@ -357,26 +359,26 @@ private fun MigrationFailedContent(
 
         val annotatedString = buildAnnotatedString {
             val url = "https://github.com/connectbot/connectbot/issues"
-			val fullText = stringResource(id = R.string.migration_failed_help)
-			val startIndex = fullText.indexOf($$"%1$s")
-			if (startIndex != -1) {
-				append(fullText.take(startIndex))
+            val fullText = stringResource(id = R.string.migration_failed_help)
+            val startIndex = fullText.indexOf($$"%1$s")
+            if (startIndex != -1) {
+                append(fullText.take(startIndex))
                 withLink(LinkAnnotation.Url(url)) { append(url) }
-				append(fullText.substring(startIndex + $$"%1$s".length))
-			} else {
-				append(fullText)
-			}
-		}
+                append(fullText.substring(startIndex + $$"%1$s".length))
+            } else {
+                append(fullText)
+            }
+        }
         Text(
             text = annotatedString,
             style = MaterialTheme.typography.bodySmall,
             textAlign = TextAlign.Center,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
         )
     }
 }
 
-@ScreenPreviews
+@PreviewScreen
 @Composable
 private fun MigrationScreenCheckingPreview() {
     ConnectBotTheme {
@@ -387,7 +389,7 @@ private fun MigrationScreenCheckingPreview() {
     }
 }
 
-@ScreenPreviews
+@PreviewScreen
 @Composable
 private fun MigrationScreenInProgressPreview() {
     ConnectBotTheme {
@@ -412,7 +414,7 @@ private fun MigrationScreenInProgressPreview() {
     }
 }
 
-@ScreenPreviews
+@PreviewScreen
 @Composable
 private fun MigrationScreenInProgressEmptyPreview() {
     ConnectBotTheme {
@@ -433,7 +435,7 @@ private fun MigrationScreenInProgressEmptyPreview() {
     }
 }
 
-@ScreenPreviews
+@PreviewScreen
 @Composable
 private fun MigrationScreenFailedPreview() {
     ConnectBotTheme {

--- a/app/src/main/java/org/connectbot/ui/PermissionLifecycleObserver.kt
+++ b/app/src/main/java/org/connectbot/ui/PermissionLifecycleObserver.kt
@@ -19,6 +19,8 @@ package org.connectbot.ui
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.lifecycle.Lifecycle
@@ -29,19 +31,20 @@ import org.connectbot.util.NotificationPermissionHelper
  * Observes lifecycle events and re-checks notification permission status when the screen resumes.
  * This handles cases where the user grants or revokes permission in Settings and returns to the app.
  *
- * @param onPermissionChanged Callback invoked with the current permission state when screen resumes
+ * @param onPermissionChange Callback invoked with the current permission state when screen resumes
  */
 @Composable
-fun ObservePermissionOnResume(onPermissionChanged: (Boolean) -> Unit) {
+fun ObservePermissionOnResume(onPermissionChange: (Boolean) -> Unit) {
     val context = LocalContext.current
     val lifecycleOwner = LocalLifecycleOwner.current
+    val currentOnPermissionChanged by rememberUpdatedState(onPermissionChange)
 
     DisposableEffect(lifecycleOwner) {
         val observer = LifecycleEventObserver { _, event ->
             if (event == Lifecycle.Event.ON_RESUME) {
                 // Check current permission status - may have changed while user was away
                 val isGranted = NotificationPermissionHelper.isNotificationPermissionGranted(context)
-                onPermissionChanged(isGranted)
+                currentOnPermissionChanged(isGranted)
             }
         }
         lifecycleOwner.lifecycle.addObserver(observer)

--- a/app/src/main/java/org/connectbot/ui/Previews.kt
+++ b/app/src/main/java/org/connectbot/ui/Previews.kt
@@ -27,4 +27,4 @@ import androidx.compose.ui.tooling.preview.PreviewScreenSizes
 @PreviewScreenSizes
 @PreviewLightDark
 @PreviewDynamicColors
-annotation class ScreenPreviews
+annotation class PreviewScreen

--- a/app/src/main/java/org/connectbot/ui/components/BiometricPromptHelper.kt
+++ b/app/src/main/java/org/connectbot/ui/components/BiometricPromptHelper.kt
@@ -42,7 +42,7 @@ class BiometricPromptState(
     private val activity: FragmentActivity,
     private val onSuccess: (BiometricPrompt.AuthenticationResult) -> Unit,
     private val onError: (Int, CharSequence) -> Unit,
-    private val onFailed: () -> Unit
+    private val onFail: () -> Unit
 ) {
     private var biometricPrompt: BiometricPrompt? = null
     var isAuthenticating by mutableStateOf(false)
@@ -64,7 +64,7 @@ class BiometricPromptState(
         override fun onAuthenticationFailed() {
             Timber.w("Authentication failed")
             // Don't set isAuthenticating to false here - user can retry
-            onFailed()
+            onFail()
         }
     }
 
@@ -123,7 +123,7 @@ class BiometricPromptState(
  *                  the CryptoObject (if provided) with an authenticated Signature.
  * @param onError Called when authentication fails with an error.
  *                The error code can be one of BiometricPrompt.ERROR_* constants.
- * @param onFailed Called when a biometric is recognized but not valid (wrong finger).
+ * @param onFail Called when a biometric is recognized but not valid (wrong finger).
  *                 The prompt remains visible for retry.
  * @return BiometricPromptState, or null if FragmentActivity context is not available
  */
@@ -131,7 +131,7 @@ class BiometricPromptState(
 fun rememberBiometricPromptState(
     onSuccess: (BiometricPrompt.AuthenticationResult) -> Unit,
     onError: (Int, CharSequence) -> Unit,
-    onFailed: () -> Unit = {}
+    onFail: () -> Unit = {}
 ): BiometricPromptState? {
     val context = LocalContext.current
     val activity = context.findFragmentActivity()
@@ -146,7 +146,7 @@ fun rememberBiometricPromptState(
             activity = activity,
             onSuccess = onSuccess,
             onError = onError,
-            onFailed = onFailed
+            onFail = onFail
         )
     }
 

--- a/app/src/main/java/org/connectbot/ui/components/ColorPickerDialog.kt
+++ b/app/src/main/java/org/connectbot/ui/components/ColorPickerDialog.kt
@@ -48,16 +48,16 @@ import org.connectbot.data.ColorSchemePresets
  * @param title The title of the dialog
  * @param selectedColorIndex The currently selected color index (0-15)
  * @param palette The current color palette (16 ARGB values)
- * @param onColorSelected Callback when a color is selected
+ * @param onSelectColor Callback when a color is selected
  * @param onDismiss Callback when dialog is dismissed
  */
 @Composable
 fun ColorPickerDialog(
     title: String,
     selectedColorIndex: Int,
-    palette: IntArray = ColorSchemePresets.default.colors,
-    onColorSelected: (Int) -> Unit,
-    onDismiss: () -> Unit
+    onSelectColor: (Int) -> Unit,
+    onDismiss: () -> Unit,
+    palette: IntArray = ColorSchemePresets.default.colors
 ) {
     AlertDialog(
         onDismissRequest = onDismiss,
@@ -98,7 +98,7 @@ fun ColorPickerDialog(
                                     shape = RoundedCornerShape(4.dp)
                                 )
                                 .clickable {
-                                    onColorSelected(index)
+                                    onSelectColor(index)
                                     onDismiss()
                                 },
                             contentAlignment = Alignment.Center

--- a/app/src/main/java/org/connectbot/ui/components/EntropyGatherer.kt
+++ b/app/src/main/java/org/connectbot/ui/components/EntropyGatherer.kt
@@ -45,8 +45,8 @@ private const val MILLIS_BETWEEN_INPUTS = 50L
  */
 @Composable
 fun EntropyGatherer(
-    onEntropyGathered: (ByteArray) -> Unit,
-    onProgressUpdated: (Int) -> Unit = {},
+    onGatherEntropy: (ByteArray) -> Unit,
+    onProgressUpdate: (Int) -> Unit = {},
     modifier: Modifier = Modifier
 ) {
     val entropyGenerator = remember { DragEntropyGenerator() }
@@ -68,12 +68,12 @@ fun EntropyGatherer(
                     val wasAdded = entropyGenerator.addDragInput(x, y, now, MILLIS_BETWEEN_INPUTS)
 
                     if (wasAdded) {
-                        onProgressUpdated(entropyGenerator.getProgress())
+                        onProgressUpdate(entropyGenerator.getProgress())
                     }
 
                     if (entropyGenerator.isEntropyComplete()) {
                         val finalEntropy = entropyGenerator.getEntropy()
-                        onEntropyGathered(finalEntropy)
+                        onGatherEntropy(finalEntropy)
                     }
                 }
             }
@@ -153,6 +153,7 @@ class DragEntropyGenerator(private val entropyCapacity: Int = SHA1_MAX_BYTES) {
                     entropy[entropyByteIndex] = ((entropy[entropyByteIndex].toInt() shl 1) or 1).toByte()
                     entropyBitIndex++
                 }
+
                 0x2 -> {
                     // Shift left and set bit to 0
                     entropy[entropyByteIndex] = (entropy[entropyByteIndex].toInt() shl 1).toByte()
@@ -171,14 +172,9 @@ class DragEntropyGenerator(private val entropyCapacity: Int = SHA1_MAX_BYTES) {
         return true
     }
 
-    fun getProgress(): Int =
-        (entropyByteIndex * 100 / SHA1_MAX_BYTES) + (entropyBitIndex * 5 / 8)
+    fun getProgress(): Int = (entropyByteIndex * 100 / SHA1_MAX_BYTES) + (entropyBitIndex * 5 / 8)
 
-    fun getEntropy(): ByteArray {
-        return entropy.copyOfRange(0, entropyByteIndex)
-    }
+    fun getEntropy(): ByteArray = entropy.copyOfRange(0, entropyByteIndex)
 
-    fun isEntropyComplete(): Boolean {
-        return entropyByteIndex >= entropyCapacity
-    }
+    fun isEntropyComplete(): Boolean = entropyByteIndex >= entropyCapacity
 }

--- a/app/src/main/java/org/connectbot/ui/components/FloatingTextInputDialog.kt
+++ b/app/src/main/java/org/connectbot/ui/components/FloatingTextInputDialog.kt
@@ -75,7 +75,7 @@ import kotlin.math.roundToInt
 private const val PREF_FLOATING_INPUT_X = "floating_input_x"
 private const val PREF_FLOATING_INPUT_Y = "floating_input_y"
 private const val DEFAULT_X_RATIO = 0.05f // 5% from left
-private const val DEFAULT_Y_RATIO = 0.3f  // 30% from top
+private const val DEFAULT_Y_RATIO = 0.3f // 30% from top
 
 /**
  * Floating, draggable text input dialog with Compose TextField for full IME support.
@@ -88,176 +88,176 @@ private const val DEFAULT_Y_RATIO = 0.3f  // 30% from top
  */
 @Composable
 fun FloatingTextInputDialog(
-	bridge: TerminalBridge,
-	initialText: String = "",
-	onDismiss: () -> Unit
+    bridge: TerminalBridge,
+    initialText: String = "",
+    onDismiss: () -> Unit
 ) {
-	val context = LocalContext.current
-	val prefs = remember { PreferenceManager.getDefaultSharedPreferences(context) }
-	val configuration = LocalConfiguration.current
-	val density = LocalDensity.current
+    val context = LocalContext.current
+    val prefs = remember { PreferenceManager.getDefaultSharedPreferences(context) }
+    val configuration = LocalConfiguration.current
+    val density = LocalDensity.current
 
-	// Calculate screen dimensions
-	val screenWidthPx = with(density) { configuration.screenWidthDp.dp.toPx() }
-	val screenHeightPx = with(density) { configuration.screenHeightDp.dp.toPx() }
+    // Calculate screen dimensions
+    val screenWidthPx = with(density) { configuration.screenWidthDp.dp.toPx() }
+    val screenHeightPx = with(density) { configuration.screenHeightDp.dp.toPx() }
 
-	// Window dimensions (90% of screen width)
-	val windowWidthDp = configuration.screenWidthDp * 0.9f
-	val windowWidthPx = with(density) { windowWidthDp.dp.toPx() }
+    // Window dimensions (90% of screen width)
+    val windowWidthDp = configuration.screenWidthDp * 0.9f
+    val windowWidthPx = with(density) { windowWidthDp.dp.toPx() }
 
-	// Load saved position or use defaults
-	val savedX = prefs.getFloat(PREF_FLOATING_INPUT_X, DEFAULT_X_RATIO)
-	val savedY = prefs.getFloat(PREF_FLOATING_INPUT_Y, DEFAULT_Y_RATIO)
+    // Load saved position or use defaults
+    val savedX = prefs.getFloat(PREF_FLOATING_INPUT_X, DEFAULT_X_RATIO)
+    val savedY = prefs.getFloat(PREF_FLOATING_INPUT_Y, DEFAULT_Y_RATIO)
 
-	// Current position in pixels
-	var offsetX by remember { mutableFloatStateOf(screenWidthPx * savedX) }
-	var offsetY by remember { mutableFloatStateOf(screenHeightPx * savedY) }
+    // Current position in pixels
+    var offsetX by remember { mutableFloatStateOf(screenWidthPx * savedX) }
+    var offsetY by remember { mutableFloatStateOf(screenHeightPx * savedY) }
 
-	// Text state and focus
-	var text by remember { mutableStateOf(initialText) }
-	val focusRequester = remember { FocusRequester() }
+    // Text state and focus
+    var text by remember { mutableStateOf(initialText) }
+    val focusRequester = remember { FocusRequester() }
 
-	// Request focus when shown
-	LaunchedEffect(Unit) {
-		focusRequester.requestFocus()
-	}
+    // Request focus when shown
+    LaunchedEffect(Unit) {
+        focusRequester.requestFocus()
+    }
 
-	// Save position when dialog closes
-	DisposableEffect(Unit) {
-		onDispose {
-			// Save position as ratio of screen size for orientation change support
-			prefs.edit {
-				putFloat(PREF_FLOATING_INPUT_X, offsetX / screenWidthPx)
-				putFloat(PREF_FLOATING_INPUT_Y, offsetY / screenHeightPx)
-			}
-		}
-	}
+    // Save position when dialog closes
+    DisposableEffect(Unit) {
+        onDispose {
+            // Save position as ratio of screen size for orientation change support
+            prefs.edit {
+                putFloat(PREF_FLOATING_INPUT_X, offsetX / screenWidthPx)
+                putFloat(PREF_FLOATING_INPUT_Y, offsetY / screenHeightPx)
+            }
+        }
+    }
 
-	// Send text helper function
-	fun sendText() {
-		if (text.isNotEmpty()) {
-			bridge.injectString(text + "\n")
-			onDismiss()
-		}
-	}
+    // Send text helper function
+    fun sendText() {
+        if (text.isNotEmpty()) {
+            bridge.injectString(text + "\n")
+            onDismiss()
+        }
+    }
 
-	Dialog(
-		onDismissRequest = onDismiss,
-		properties = DialogProperties(
-			usePlatformDefaultWidth = false,
-			decorFitsSystemWindows = false
-		)
-	) {
-		Box(
-			modifier = Modifier
-				.fillMaxSize()
-				.pointerInput(Unit) {
-					// Dismiss when clicking outside
-					detectDragGestures { _, _ -> }
-				}
-		) {
-			Column(
-				modifier = Modifier
-					.offset { IntOffset(offsetX.roundToInt(), offsetY.roundToInt()) }
-					.width(windowWidthDp.dp)
-					.background(
-						MaterialTheme.colorScheme.surface,
-						RoundedCornerShape(12.dp)
-					)
-			) {
-				// Draggable header
-				Row(
-					modifier = Modifier
-						.fillMaxWidth()
-						.height(36.dp)
-						.background(
-							MaterialTheme.colorScheme.primary,
-							RoundedCornerShape(topStart = 12.dp, topEnd = 12.dp)
-						)
-						.pointerInput(Unit) {
-							detectDragGestures { change, dragAmount ->
-								change.consume()
-								offsetX = (offsetX + dragAmount.x).coerceIn(
-									0f,
-									screenWidthPx - windowWidthPx
-								)
-								offsetY = (offsetY + dragAmount.y).coerceIn(
-									0f,
-									screenHeightPx - with(density) { 200.dp.toPx() }
-								)
-							}
-						}
-						.padding(horizontal = 12.dp),
-					verticalAlignment = Alignment.CenterVertically,
-					horizontalArrangement = Arrangement.SpaceBetween
-				) {
-					Text(
-						text = stringResource(R.string.terminal_text_input_dialog_title),
-						style = MaterialTheme.typography.titleSmall,
-						color = MaterialTheme.colorScheme.onPrimary
-					)
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(
+            usePlatformDefaultWidth = false,
+            decorFitsSystemWindows = false
+        )
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .pointerInput(Unit) {
+                    // Dismiss when clicking outside
+                    detectDragGestures { _, _ -> }
+                }
+        ) {
+            Column(
+                modifier = Modifier
+                    .offset { IntOffset(offsetX.roundToInt(), offsetY.roundToInt()) }
+                    .width(windowWidthDp.dp)
+                    .background(
+                        MaterialTheme.colorScheme.surface,
+                        RoundedCornerShape(12.dp)
+                    )
+            ) {
+                // Draggable header
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(36.dp)
+                        .background(
+                            MaterialTheme.colorScheme.primary,
+                            RoundedCornerShape(topStart = 12.dp, topEnd = 12.dp)
+                        )
+                        .pointerInput(Unit) {
+                            detectDragGestures { change, dragAmount ->
+                                change.consume()
+                                offsetX = (offsetX + dragAmount.x).coerceIn(
+                                    0f,
+                                    screenWidthPx - windowWidthPx
+                                )
+                                offsetY = (offsetY + dragAmount.y).coerceIn(
+                                    0f,
+                                    screenHeightPx - with(density) { 200.dp.toPx() }
+                                )
+                            }
+                        }
+                        .padding(horizontal = 12.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Text(
+                        text = stringResource(R.string.terminal_text_input_dialog_title),
+                        style = MaterialTheme.typography.titleSmall,
+                        color = MaterialTheme.colorScheme.onPrimary
+                    )
 
-					IconButton(
-						onClick = onDismiss,
-						modifier = Modifier.size(24.dp)
-					) {
-						Icon(
-							Icons.Default.Close,
-							contentDescription = stringResource(R.string.button_close),
-							tint = MaterialTheme.colorScheme.onPrimary,
-							modifier = Modifier.size(18.dp)
-						)
-					}
-				}
+                    IconButton(
+                        onClick = onDismiss,
+                        modifier = Modifier.size(24.dp)
+                    ) {
+                        Icon(
+                            Icons.Default.Close,
+                            contentDescription = stringResource(R.string.button_close),
+                            tint = MaterialTheme.colorScheme.onPrimary,
+                            modifier = Modifier.size(18.dp)
+                        )
+                    }
+                }
 
-				// TextField container
-				Row(
-					modifier = Modifier
-						.fillMaxWidth()
-						.padding(12.dp),
-					verticalAlignment = Alignment.Bottom,
-					horizontalArrangement = Arrangement.spacedBy(8.dp)
-				) {
-					// Compose TextField for full IME support
-					TextField(
-						value = text,
-						onValueChange = { text = it },
-						placeholder = {
-							Text(stringResource(R.string.terminal_text_input_dialog_label))
-						},
-						keyboardOptions = KeyboardOptions(
-							imeAction = ImeAction.Send
-						),
-						keyboardActions = KeyboardActions(
-							onSend = { sendText() }
-						),
-						colors = TextFieldDefaults.colors(
-							focusedContainerColor = MaterialTheme.colorScheme.surfaceVariant,
-							unfocusedContainerColor = MaterialTheme.colorScheme.surfaceVariant,
-							focusedIndicatorColor = Color.Transparent,
-							unfocusedIndicatorColor = Color.Transparent
-						),
-						shape = RoundedCornerShape(8.dp),
-						modifier = Modifier
-							.weight(1f)
-							.height(90.dp)
-							.focusRequester(focusRequester)
-					)
+                // TextField container
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(12.dp),
+                    verticalAlignment = Alignment.Bottom,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    // Compose TextField for full IME support
+                    TextField(
+                        value = text,
+                        onValueChange = { text = it },
+                        placeholder = {
+                            Text(stringResource(R.string.terminal_text_input_dialog_label))
+                        },
+                        keyboardOptions = KeyboardOptions(
+                            imeAction = ImeAction.Send
+                        ),
+                        keyboardActions = KeyboardActions(
+                            onSend = { sendText() }
+                        ),
+                        colors = TextFieldDefaults.colors(
+                            focusedContainerColor = MaterialTheme.colorScheme.surfaceVariant,
+                            unfocusedContainerColor = MaterialTheme.colorScheme.surfaceVariant,
+                            focusedIndicatorColor = Color.Transparent,
+                            unfocusedIndicatorColor = Color.Transparent
+                        ),
+                        shape = RoundedCornerShape(8.dp),
+                        modifier = Modifier
+                            .weight(1f)
+                            .height(90.dp)
+                            .focusRequester(focusRequester)
+                    )
 
-					// Send button
-					FloatingActionButton(
-						onClick = { sendText() },
-						containerColor = MaterialTheme.colorScheme.primary,
-						contentColor = MaterialTheme.colorScheme.onPrimary,
-						modifier = Modifier.size(48.dp)
-					) {
-						Icon(
+                    // Send button
+                    FloatingActionButton(
+                        onClick = { sendText() },
+                        containerColor = MaterialTheme.colorScheme.primary,
+                        contentColor = MaterialTheme.colorScheme.onPrimary,
+                        modifier = Modifier.size(48.dp)
+                    ) {
+                        Icon(
                             Icons.AutoMirrored.Filled.Send,
-							contentDescription = stringResource(R.string.button_send)
-						)
-					}
-				}
-			}
-		}
-	}
+                            contentDescription = stringResource(R.string.button_send)
+                        )
+                    }
+                }
+            }
+        }
+    }
 }

--- a/app/src/main/java/org/connectbot/ui/components/InlinePrompt.kt
+++ b/app/src/main/java/org/connectbot/ui/components/InlinePrompt.kt
@@ -55,6 +55,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -86,14 +87,15 @@ fun InlinePrompt(
     onResponse: (PromptResponse) -> Unit,
     onCancel: () -> Unit,
     modifier: Modifier = Modifier,
-    onDismissed: () -> Unit = {},
+    onDismiss: () -> Unit = {}
 ) {
     var wasVisible by remember { mutableStateOf(false) }
+    val currentOnDismissed by rememberUpdatedState(onDismiss)
 
-    // Track when prompt becomes invisible to call onDismissed
+    // Track when prompt becomes invisible to call onDismiss
     LaunchedEffect(promptRequest) {
         if (wasVisible && promptRequest == null) {
-            onDismissed()
+            currentOnDismissed()
         }
         wasVisible = promptRequest != null
     }
@@ -141,7 +143,8 @@ fun InlinePrompt(
                 )
             }
 
-            null -> { /* No prompt */
+            null -> {
+                /* No prompt */
             }
         }
     }
@@ -233,7 +236,7 @@ private fun StringPromptContent(
             visualTransformation = if (isPassword) PasswordVisualTransformation() else VisualTransformation.None,
             keyboardOptions = KeyboardOptions(
                 imeAction = ImeAction.Done,
-                keyboardType = if (isPassword) KeyboardType.Password else KeyboardType.Unspecified,
+                keyboardType = if (isPassword) KeyboardType.Password else KeyboardType.Unspecified
             ),
             keyboardActions = KeyboardActions(
                 onDone = {
@@ -305,7 +308,7 @@ private fun HostKeyFingerprintPromptContent(
             text = stringResource(R.string.host_key_verification_title),
             style = MaterialTheme.typography.titleMedium,
             color = terminalColors.overlayText,
-            modifier = Modifier.padding(bottom = 8.dp),
+            modifier = Modifier.padding(bottom = 8.dp)
         )
 
         Text(
@@ -362,7 +365,7 @@ private fun HostKeyFingerprintPromptContent(
         // Fingerprint format selector
         ExposedDropdownMenuBox(
             expanded = dropdownExpanded,
-            onExpandedChange = { dropdownExpanded = it },
+            onExpandedChange = { dropdownExpanded = it }
         ) {
             TextField(
                 value = formats[selectedFormatIndex].first,
@@ -445,6 +448,6 @@ private fun HostKeyFingerprintPromptPreview() {
             md5 = "md5"
         ),
         onAccept = { },
-        onReject = { },
+        onReject = { }
     )
 }

--- a/app/src/main/java/org/connectbot/ui/components/PromptDialogs.kt
+++ b/app/src/main/java/org/connectbot/ui/components/PromptDialogs.kt
@@ -22,7 +22,9 @@ import android.content.ContextWrapper
 import androidx.biometric.BiometricPrompt
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.platform.LocalContext
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.FragmentActivity
@@ -42,11 +44,12 @@ fun BiometricPromptHandler(
 ) {
     val context = LocalContext.current
     val activity = remember(context) { context.findFragmentActivity() }
+    val currentOnResponse by rememberUpdatedState(onResponse)
 
     LaunchedEffect(prompt) {
         if (activity == null) {
             Timber.e("Cannot show BiometricPrompt: FragmentActivity not found")
-            onResponse(PromptResponse.BiometricResponse(false))
+            currentOnResponse(PromptResponse.BiometricResponse(false))
             return@LaunchedEffect
         }
 
@@ -55,12 +58,12 @@ fun BiometricPromptHandler(
         val callback = object : BiometricPrompt.AuthenticationCallback() {
             override fun onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult) {
                 Timber.d("Biometric authentication succeeded")
-                onResponse(PromptResponse.BiometricResponse(true))
+                currentOnResponse(PromptResponse.BiometricResponse(true))
             }
 
             override fun onAuthenticationError(errorCode: Int, errString: CharSequence) {
                 Timber.e("Biometric authentication error: $errorCode - $errString")
-                onResponse(PromptResponse.BiometricResponse(false))
+                currentOnResponse(PromptResponse.BiometricResponse(false))
             }
 
             override fun onAuthenticationFailed() {
@@ -94,4 +97,3 @@ private fun Context.findFragmentActivity(): FragmentActivity? {
     }
     return null
 }
-

--- a/app/src/main/java/org/connectbot/ui/components/ResizeDialog.kt
+++ b/app/src/main/java/org/connectbot/ui/components/ResizeDialog.kt
@@ -112,7 +112,7 @@ fun ResizeDialog(
                     }
                 },
                 enabled = !widthError && !heightError &&
-                        widthText.isNotEmpty() && heightText.isNotEmpty()
+                    widthText.isNotEmpty() && heightText.isNotEmpty()
             ) {
                 Text(stringResource(R.string.button_resize))
             }

--- a/app/src/main/java/org/connectbot/ui/components/RgbColorPickerDialog.kt
+++ b/app/src/main/java/org/connectbot/ui/components/RgbColorPickerDialog.kt
@@ -53,14 +53,14 @@ import org.connectbot.R
  *
  * @param title The title of the dialog
  * @param initialColor The initial ARGB color value
- * @param onColorSelected Callback when a color is selected, receives ARGB Int
+ * @param onSelectColor Callback when a color is selected, receives ARGB Int
  * @param onDismiss Callback when dialog is dismissed
  */
 @Composable
 fun RgbColorPickerDialog(
     title: String,
     initialColor: Int,
-    onColorSelected: (Int) -> Unit,
+    onSelectColor: (Int) -> Unit,
     onDismiss: () -> Unit
 ) {
     // Extract RGB components from ARGB Int
@@ -78,9 +78,9 @@ fun RgbColorPickerDialog(
 
     // Construct current color from RGB sliders
     val currentColor = (0xFF shl 24) or
-            (red.toInt() shl 16) or
-            (green.toInt() shl 8) or
-            blue.toInt()
+        (red.toInt() shl 16) or
+        (green.toInt() shl 8) or
+        blue.toInt()
 
     // Update hex input when sliders change
     LaunchedEffect(red, green, blue) {
@@ -170,7 +170,7 @@ fun RgbColorPickerDialog(
         },
         confirmButton = {
             TextButton(onClick = {
-                onColorSelected(currentColor)
+                onSelectColor(currentColor)
                 onDismiss()
             }) {
                 Text(stringResource(R.string.button_ok))
@@ -229,28 +229,26 @@ private fun ColorSliderRow(
  * - 6 digits: "aabbcc"
  * Returns null if invalid.
  */
-private fun parseHexColor(hex: String): Int? {
-    return when (hex.length) {
-        3 -> {
-            // Expand abc to aabbcc
-            val r = hex[0].toString().repeat(2)
-            val g = hex[1].toString().repeat(2)
-            val b = hex[2].toString().repeat(2)
-            try {
-                (r + g + b).toInt(16)
-            } catch (e: NumberFormatException) {
-                null
-            }
+private fun parseHexColor(hex: String): Int? = when (hex.length) {
+    3 -> {
+        // Expand abc to aabbcc
+        val r = hex[0].toString().repeat(2)
+        val g = hex[1].toString().repeat(2)
+        val b = hex[2].toString().repeat(2)
+        try {
+            (r + g + b).toInt(16)
+        } catch (e: NumberFormatException) {
+            null
         }
-
-        6 -> {
-            try {
-                hex.toInt(16)
-            } catch (e: NumberFormatException) {
-                null
-            }
-        }
-
-        else -> null
     }
+
+    6 -> {
+        try {
+            hex.toInt(16)
+        } catch (e: NumberFormatException) {
+            null
+        }
+    }
+
+    else -> null
 }

--- a/app/src/main/java/org/connectbot/ui/screens/colors/ColorsScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/colors/ColorsScreen.kt
@@ -77,7 +77,7 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import kotlinx.coroutines.launch
 import org.connectbot.R
 import org.connectbot.data.entity.ColorScheme
-import org.connectbot.ui.ScreenPreviews
+import org.connectbot.ui.PreviewScreen
 import org.connectbot.ui.common.getLocalizedColorSchemeDescription
 import org.connectbot.ui.theme.ConnectBotTheme
 
@@ -367,7 +367,7 @@ fun ColorsScreenContent(
     }
 }
 
-@ScreenPreviews
+@PreviewScreen
 @Composable
 private fun ColorsScreenEmptyPreview() {
     ConnectBotTheme {
@@ -392,7 +392,7 @@ private fun ColorsScreenEmptyPreview() {
     }
 }
 
-@ScreenPreviews
+@PreviewScreen
 @Composable
 private fun ColorsScreenLoadingPreview() {
     ConnectBotTheme {
@@ -417,7 +417,7 @@ private fun ColorsScreenLoadingPreview() {
     }
 }
 
-@ScreenPreviews
+@PreviewScreen
 @Composable
 private fun ColorsScreenPopulatedPreview() {
     ConnectBotTheme {

--- a/app/src/main/java/org/connectbot/ui/screens/colors/PaletteEditorScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/colors/PaletteEditorScreen.kt
@@ -73,7 +73,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import org.connectbot.R
-import org.connectbot.ui.ScreenPreviews
+import org.connectbot.ui.PreviewScreen
 import org.connectbot.ui.components.ColorPickerDialog
 import org.connectbot.ui.components.RgbColorPickerDialog
 
@@ -252,7 +252,7 @@ fun PaletteEditorScreenContent(
         RgbColorPickerDialog(
             title = stringResource(R.string.dialog_title_edit_color, colorIndex),
             initialColor = uiState.palette[colorIndex],
-            onColorSelected = { newColor ->
+            onSelectColor = { newColor ->
                 onUpdateColor(colorIndex, newColor)
             },
             onDismiss = { onCloseColorEditor() }
@@ -264,7 +264,7 @@ fun PaletteEditorScreenContent(
             title = stringResource(R.string.label_foreground_color),
             selectedColorIndex = uiState.foregroundColorIndex,
             palette = uiState.palette,
-            onColorSelected = { colorIndex ->
+            onSelectColor = { colorIndex ->
                 onUpdateForegroundColor(colorIndex)
                 showForegroundPicker = false
             },
@@ -277,7 +277,7 @@ fun PaletteEditorScreenContent(
             title = stringResource(R.string.label_background_color),
             selectedColorIndex = uiState.backgroundColorIndex,
             palette = uiState.palette,
-            onColorSelected = { colorIndex ->
+            onSelectColor = { colorIndex ->
                 onUpdateBackgroundColor(colorIndex)
                 showBackgroundPicker = false
             },
@@ -682,7 +682,7 @@ private fun DuplicateSchemeDialog(
     )
 }
 
-@ScreenPreviews
+@PreviewScreen
 @Composable
 private fun PaletteEditorScreenPreview() {
     PaletteEditorScreenContent(

--- a/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
@@ -538,7 +538,7 @@ fun ConsoleScreen(
                             onCancel = {
                                 bridge.promptManager.cancelPrompt()
                             },
-                            onDismissed = {
+                            onDismiss = {
                                 termFocusRequester.requestFocus()
                             },
                             modifier = Modifier

--- a/app/src/main/java/org/connectbot/ui/screens/contact/ContactScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/contact/ContactScreen.kt
@@ -38,7 +38,7 @@ import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import org.connectbot.R
-import org.connectbot.ui.ScreenPreviews
+import org.connectbot.ui.PreviewScreen
 import org.connectbot.ui.theme.ConnectBotTheme
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -147,7 +147,7 @@ private fun ContactLinkItem(
     HorizontalDivider()
 }
 
-@ScreenPreviews
+@PreviewScreen
 @Composable
 private fun ContactScreenPreview() {
     ConnectBotTheme {

--- a/app/src/main/java/org/connectbot/ui/screens/eula/EulaScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/eula/EulaScreen.kt
@@ -31,7 +31,7 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import org.connectbot.ui.ScreenPreviews
+import org.connectbot.ui.PreviewScreen
 import org.connectbot.ui.theme.ConnectBotTheme
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -93,7 +93,7 @@ fun EulaScreen(
     }
 }
 
-@ScreenPreviews
+@PreviewScreen
 @Composable
 private fun EulaScreenPreview() {
     ConnectBotTheme {

--- a/app/src/main/java/org/connectbot/ui/screens/generatepubkey/EntropyDialog.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/generatepubkey/EntropyDialog.kt
@@ -37,14 +37,14 @@ import org.connectbot.ui.components.EntropyGatherer
 
 @Composable
 fun EntropyGatherDialog(
-    onEntropyGathered: (ByteArray?) -> Unit,
+    onGatherEntropy: (ByteArray?) -> Unit,
     onDismiss: () -> Unit
 ) {
     var progress by remember { mutableIntStateOf(0) }
 
     AlertDialog(
         onDismissRequest = {
-            onEntropyGathered(null)
+            onGatherEntropy(null)
             onDismiss()
         },
         title = { Text(stringResource(R.string.pubkey_gather_entropy)) },
@@ -61,10 +61,10 @@ fun EntropyGatherDialog(
                 )
 
                 EntropyGatherer(
-                    onEntropyGathered = { entropy ->
-                        onEntropyGathered(entropy)
+                    onGatherEntropy = { entropy ->
+                        onGatherEntropy(entropy)
                     },
-                    onProgressUpdated = { newProgress ->
+                    onProgressUpdate = { newProgress ->
                         progress = newProgress
                     },
                     modifier = Modifier.padding(vertical = 8.dp)

--- a/app/src/main/java/org/connectbot/ui/screens/generatepubkey/GeneratePubkeyScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/generatepubkey/GeneratePubkeyScreen.kt
@@ -57,7 +57,7 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import org.connectbot.R
-import org.connectbot.ui.ScreenPreviews
+import org.connectbot.ui.PreviewScreen
 import org.connectbot.ui.theme.ConnectBotTheme
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -65,8 +65,8 @@ import org.connectbot.ui.theme.ConnectBotTheme
 fun GeneratePubkeyScreen(
     onNavigateBack: () -> Unit,
     modifier: Modifier = Modifier,
+    viewModel: GeneratePubkeyViewModel = hiltViewModel()
 ) {
-    val viewModel: GeneratePubkeyViewModel = hiltViewModel()
     val uiState by viewModel.uiState.collectAsState()
 
     GeneratePubkeyScreenContent(
@@ -81,7 +81,7 @@ fun GeneratePubkeyScreen(
         onConfirmUseChange = viewModel::updateConfirmUse,
         onUseBiometricChange = viewModel::updateUseBiometric,
         onGenerateKey = { viewModel.generateKey(onSuccess = onNavigateBack) },
-        onEntropyGathered = viewModel::onEntropyGathered,
+        onGatherEntropy = viewModel::onEntropyGathered,
         onCancelGeneration = {
             viewModel.cancelGeneration()
             onNavigateBack()
@@ -104,7 +104,7 @@ fun GeneratePubkeyScreenContent(
     onConfirmUseChange: (Boolean) -> Unit,
     onUseBiometricChange: (Boolean) -> Unit,
     onGenerateKey: () -> Unit,
-    onEntropyGathered: (ByteArray?) -> Unit,
+    onGatherEntropy: (ByteArray?) -> Unit,
     onCancelGeneration: () -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -139,7 +139,9 @@ fun GeneratePubkeyScreenContent(
                 isError = uiState.nicknameExists,
                 supportingText = if (uiState.nicknameExists) {
                     { Text(stringResource(R.string.pubkey_nickname_exists)) }
-                } else null
+                } else {
+                    null
+                }
             )
 
             Spacer(modifier = Modifier.height(16.dp))
@@ -345,7 +347,7 @@ fun GeneratePubkeyScreenContent(
     // Show entropy dialog when needed
     if (uiState.showEntropyDialog) {
         EntropyGatherDialog(
-            onEntropyGathered = onEntropyGathered,
+            onGatherEntropy = onGatherEntropy,
             onDismiss = onCancelGeneration
         )
     }
@@ -387,7 +389,7 @@ private fun KeyTypeOption(
     }
 }
 
-@ScreenPreviews
+@PreviewScreen
 @Composable
 private fun GeneratePubkeyScreenEmptyPreview() {
     ConnectBotTheme {
@@ -403,13 +405,13 @@ private fun GeneratePubkeyScreenEmptyPreview() {
             onConfirmUseChange = {},
             onUseBiometricChange = {},
             onGenerateKey = {},
-            onEntropyGathered = {},
+            onGatherEntropy = {},
             onCancelGeneration = {}
         )
     }
 }
 
-@ScreenPreviews
+@PreviewScreen
 @Composable
 private fun GeneratePubkeyScreenFilledPreview() {
     ConnectBotTheme {
@@ -433,13 +435,13 @@ private fun GeneratePubkeyScreenFilledPreview() {
             onConfirmUseChange = {},
             onUseBiometricChange = {},
             onGenerateKey = {},
-            onEntropyGathered = {},
+            onGatherEntropy = {},
             onCancelGeneration = {}
         )
     }
 }
 
-@ScreenPreviews
+@PreviewScreen
 @Composable
 private fun GeneratePubkeyScreenPasswordMismatchPreview() {
     ConnectBotTheme {
@@ -462,13 +464,13 @@ private fun GeneratePubkeyScreenPasswordMismatchPreview() {
             onConfirmUseChange = {},
             onUseBiometricChange = {},
             onGenerateKey = {},
-            onEntropyGathered = {},
+            onGatherEntropy = {},
             onCancelGeneration = {}
         )
     }
 }
 
-@ScreenPreviews
+@PreviewScreen
 @Composable
 private fun GeneratePubkeyScreenBiometricPreview() {
     ConnectBotTheme {
@@ -491,7 +493,7 @@ private fun GeneratePubkeyScreenBiometricPreview() {
             onConfirmUseChange = {},
             onUseBiometricChange = {},
             onGenerateKey = {},
-            onEntropyGathered = {},
+            onGatherEntropy = {},
             onCancelGeneration = {}
         )
     }

--- a/app/src/main/java/org/connectbot/ui/screens/generatepubkey/GeneratePubkeyViewModel.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/generatepubkey/GeneratePubkeyViewModel.kt
@@ -79,8 +79,8 @@ data class GeneratePubkeyUiState(
 
     val canGenerate: Boolean
         get() = nickname.isNotEmpty() &&
-                !nicknameExists &&
-                (useBiometric || !passwordMismatch)
+            !nicknameExists &&
+            (useBiometric || !passwordMismatch)
 
     /** Whether the current key type supports biometric protection */
     val keyTypeSupportsBiometric: Boolean
@@ -188,9 +188,7 @@ class GeneratePubkeyViewModel @Inject constructor(
         _uiState.update { it.copy(bits = finalBits) }
     }
 
-    private fun getClosestEcdsaSize(bits: Int): Int {
-        return ECDSA_SIZES.minByOrNull { kotlin.math.abs(it - bits) } ?: ECDSA_SIZES[0]
-    }
+    private fun getClosestEcdsaSize(bits: Int): Int = ECDSA_SIZES.minByOrNull { kotlin.math.abs(it - bits) } ?: ECDSA_SIZES[0]
 
     fun updatePassword1(password: String) {
         _uiState.update { it.copy(password1 = password) }

--- a/app/src/main/java/org/connectbot/ui/screens/help/HelpScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/help/HelpScreen.kt
@@ -61,7 +61,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import org.connectbot.BuildConfig
 import org.connectbot.R
-import org.connectbot.ui.ScreenPreviews
+import org.connectbot.ui.PreviewScreen
 import org.connectbot.ui.theme.ConnectBotTheme
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -320,7 +320,7 @@ private fun copyLogsToClipboard(context: Context, logs: String) {
     Toast.makeText(context, R.string.logs_copied, Toast.LENGTH_SHORT).show()
 }
 
-@ScreenPreviews
+@PreviewScreen
 @Composable
 private fun HelpScreenPreview() {
     ConnectBotTheme {

--- a/app/src/main/java/org/connectbot/ui/screens/hints/HintsScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/hints/HintsScreen.kt
@@ -37,7 +37,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import org.connectbot.R
-import org.connectbot.ui.ScreenPreviews
+import org.connectbot.ui.PreviewScreen
 import org.connectbot.ui.theme.ConnectBotTheme
 
 data class Hint(
@@ -139,7 +139,7 @@ fun HintsScreen(
     }
 }
 
-@ScreenPreviews
+@PreviewScreen
 @Composable
 private fun HintsScreenPreview() {
     ConnectBotTheme {

--- a/app/src/main/java/org/connectbot/ui/screens/hosteditor/HostEditorScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/hosteditor/HostEditorScreen.kt
@@ -69,7 +69,7 @@ import org.connectbot.data.entity.ColorScheme
 import org.connectbot.data.entity.Host
 import org.connectbot.data.entity.Profile
 import org.connectbot.data.entity.Pubkey
-import org.connectbot.ui.ScreenPreviews
+import org.connectbot.ui.PreviewScreen
 import org.connectbot.ui.common.getIconColors
 import org.connectbot.ui.common.getLocalizedColorSchemeDescription
 import org.connectbot.ui.common.getLocalizedFontDisplayName
@@ -1220,7 +1220,7 @@ private fun SwitchPreference(
     }
 }
 
-@ScreenPreviews
+@PreviewScreen
 @Composable
 private fun HostEditorScreenPreview() {
     ConnectBotTheme {

--- a/app/src/main/java/org/connectbot/ui/screens/hostlist/HostListScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/hostlist/HostListScreen.kt
@@ -84,7 +84,7 @@ import kotlinx.coroutines.launch
 import org.connectbot.R
 import org.connectbot.data.entity.Host
 import org.connectbot.ui.LocalTerminalManager
-import org.connectbot.ui.ScreenPreviews
+import org.connectbot.ui.PreviewScreen
 import org.connectbot.ui.components.DisconnectAllDialog
 import org.connectbot.ui.components.ShortcutCustomizationDialog
 import org.connectbot.ui.theme.ConnectBotTheme
@@ -769,7 +769,7 @@ private fun parseColor(colorString: String?): Color {
     }
 }
 
-@ScreenPreviews
+@PreviewScreen
 @Composable
 private fun HostListScreenEmptyPreview() {
     ConnectBotTheme {
@@ -795,7 +795,7 @@ private fun HostListScreenEmptyPreview() {
     }
 }
 
-@ScreenPreviews
+@PreviewScreen
 @Composable
 private fun HostListScreenLoadingPreview() {
     ConnectBotTheme {
@@ -821,7 +821,7 @@ private fun HostListScreenLoadingPreview() {
     }
 }
 
-@ScreenPreviews
+@PreviewScreen
 @Composable
 private fun HostListScreenErrorPreview() {
     ConnectBotTheme {
@@ -848,7 +848,7 @@ private fun HostListScreenErrorPreview() {
     }
 }
 
-@ScreenPreviews
+@PreviewScreen
 @Composable
 private fun HostListScreenPopulatedPreview() {
     ConnectBotTheme {

--- a/app/src/main/java/org/connectbot/ui/screens/portforwardlist/PortForwardEditorDialog.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/portforwardlist/PortForwardEditorDialog.kt
@@ -160,7 +160,9 @@ fun PortForwardEditorDialog(
                     isError = sourcePort.isNotEmpty() && !isSourcePortValid,
                     supportingText = if (sourcePort.isNotEmpty() && !isSourcePortValid) {
                         { Text(stringResource(R.string.portforward_port_range_error)) }
-                    } else null
+                    } else {
+                        null
+                    }
                 )
 
                 Spacer(modifier = Modifier.height(8.dp))
@@ -176,7 +178,9 @@ fun PortForwardEditorDialog(
                     isError = needsDestination && destination.isNotEmpty() && !isDestinationValid,
                     supportingText = if (needsDestination && destination.isNotEmpty() && !isDestinationValid) {
                         { Text(stringResource(R.string.portforward_destination_format_error)) }
-                    } else null
+                    } else {
+                        null
+                    }
                 )
             }
         },

--- a/app/src/main/java/org/connectbot/ui/screens/portforwardlist/PortForwardListScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/portforwardlist/PortForwardListScreen.kt
@@ -64,17 +64,17 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import org.connectbot.R
 import org.connectbot.data.entity.PortForward
-import org.connectbot.ui.ScreenPreviews
+import org.connectbot.ui.PreviewScreen
 import org.connectbot.ui.theme.ConnectBotTheme
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun PortForwardListScreen(
     onNavigateBack: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    viewModel: PortForwardListViewModel = hiltViewModel()
 ) {
     val terminalManager = org.connectbot.ui.LocalTerminalManager.current
-    val viewModel: PortForwardListViewModel = hiltViewModel()
 
     LaunchedEffect(terminalManager) {
         terminalManager?.let { viewModel.setTerminalManager(it) }
@@ -136,7 +136,7 @@ fun PortForwardListScreenContent(
             FloatingActionButton(
                 onClick = { showAddDialog = true },
                 // This matches the FloatingActionButtonMenu padding
-                modifier = Modifier.padding(end = 16.dp, bottom = 16.dp),
+                modifier = Modifier.padding(end = 16.dp, bottom = 16.dp)
             ) {
                 Icon(
                     Icons.Default.Add,
@@ -174,7 +174,7 @@ fun PortForwardListScreenContent(
                             start = 16.dp,
                             end = 16.dp,
                             top = 16.dp,
-                            bottom = 104.dp, // Extra padding to avoid FAB menu overlap (88dp + 16dp for menu padding)
+                            bottom = 104.dp // Extra padding to avoid FAB menu overlap (88dp + 16dp for menu padding)
                         ),
                         verticalArrangement = Arrangement.spacedBy(8.dp)
                     ) {
@@ -230,7 +230,7 @@ fun PortForwardListScreenContent(
     }
 }
 
-@ScreenPreviews
+@PreviewScreen
 @Composable
 private fun PortForwardListScreenEmptyPreview() {
     ConnectBotTheme {
@@ -249,7 +249,7 @@ private fun PortForwardListScreenEmptyPreview() {
     }
 }
 
-@ScreenPreviews
+@PreviewScreen
 @Composable
 private fun PortForwardListScreenLoadingPreview() {
     ConnectBotTheme {
@@ -268,7 +268,7 @@ private fun PortForwardListScreenLoadingPreview() {
     }
 }
 
-@ScreenPreviews
+@PreviewScreen
 @Composable
 private fun PortForwardListScreenErrorPreview() {
     ConnectBotTheme {
@@ -288,7 +288,7 @@ private fun PortForwardListScreenErrorPreview() {
     }
 }
 
-@ScreenPreviews
+@PreviewScreen
 @Composable
 private fun PortForwardListScreenPopulatedPreview() {
     ConnectBotTheme {

--- a/app/src/main/java/org/connectbot/ui/screens/pubkeyeditor/PubkeyEditorScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/pubkeyeditor/PubkeyEditorScreen.kt
@@ -52,6 +52,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -60,22 +61,23 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import org.connectbot.R
-import org.connectbot.ui.ScreenPreviews
+import org.connectbot.ui.PreviewScreen
 import org.connectbot.ui.theme.ConnectBotTheme
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun PubkeyEditorScreen(
     onNavigateBack: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    viewModel: PubkeyEditorViewModel = hiltViewModel()
 ) {
-    val viewModel: PubkeyEditorViewModel = hiltViewModel()
     val uiState by viewModel.uiState.collectAsState()
+    val currentOnNavigateBack by rememberUpdatedState(onNavigateBack)
 
     // Navigate back on successful save
     LaunchedEffect(uiState.saveSuccess) {
         if (uiState.saveSuccess) {
-            onNavigateBack()
+            currentOnNavigateBack()
         }
     }
 
@@ -167,7 +169,9 @@ fun PubkeyEditorScreenContent(
                         isError = uiState.nicknameExists,
                         supportingText = if (uiState.nicknameExists) {
                             { Text(stringResource(R.string.pubkey_nickname_exists)) }
-                        } else null
+                        } else {
+                            null
+                        }
                     )
 
                     Spacer(modifier = Modifier.height(16.dp))
@@ -330,7 +334,7 @@ fun PubkeyEditorScreenContent(
     }
 }
 
-@ScreenPreviews
+@PreviewScreen
 @Composable
 private fun PubkeyEditorScreenLoadingPreview() {
     ConnectBotTheme {
@@ -350,7 +354,7 @@ private fun PubkeyEditorScreenLoadingPreview() {
     }
 }
 
-@ScreenPreviews
+@PreviewScreen
 @Composable
 private fun PubkeyEditorScreenErrorPreview() {
     ConnectBotTheme {
@@ -371,7 +375,7 @@ private fun PubkeyEditorScreenErrorPreview() {
     }
 }
 
-@ScreenPreviews
+@PreviewScreen
 @Composable
 private fun PubkeyEditorScreenUnencryptedPreview() {
     ConnectBotTheme {
@@ -396,7 +400,7 @@ private fun PubkeyEditorScreenUnencryptedPreview() {
     }
 }
 
-@ScreenPreviews
+@PreviewScreen
 @Composable
 private fun PubkeyEditorScreenEncryptedPreview() {
     ConnectBotTheme {
@@ -422,7 +426,7 @@ private fun PubkeyEditorScreenEncryptedPreview() {
     }
 }
 
-@ScreenPreviews
+@PreviewScreen
 @Composable
 private fun PubkeyEditorScreenPasswordMismatchPreview() {
     ConnectBotTheme {
@@ -450,7 +454,7 @@ private fun PubkeyEditorScreenPasswordMismatchPreview() {
     }
 }
 
-@ScreenPreviews
+@PreviewScreen
 @Composable
 private fun PubkeyEditorScreenWrongPasswordPreview() {
     ConnectBotTheme {

--- a/app/src/main/java/org/connectbot/ui/screens/pubkeyeditor/PubkeyEditorViewModel.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/pubkeyeditor/PubkeyEditorViewModel.kt
@@ -58,7 +58,7 @@ data class PubkeyEditorUiState(
 
     val canSave: Boolean
         get() = nickname.isNotEmpty() && !passwordMismatch && !wrongPassword &&
-                !(willBeEncrypted && unlockAtStartup) && !nicknameExists
+            !(willBeEncrypted && unlockAtStartup) && !nicknameExists
 }
 
 @HiltViewModel
@@ -176,7 +176,7 @@ class PubkeyEditorViewModel @Inject constructor(
                     // 1. Key is encrypted and user provided old password (removing or changing password)
                     // 2. Key is not encrypted but user provided new password (adding password)
                     val needsPasswordChange = (state.isEncrypted && state.oldPassword.isNotEmpty()) ||
-                                             (!state.isEncrypted && state.newPassword1.isNotEmpty())
+                        (!state.isEncrypted && state.newPassword1.isNotEmpty())
 
                     var newPrivateKey = pubkey.privateKey
                     var newEncrypted = pubkey.encrypted

--- a/app/src/main/java/org/connectbot/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/settings/SettingsScreen.kt
@@ -66,7 +66,7 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import org.connectbot.BuildConfig
 import org.connectbot.R
 import org.connectbot.ui.ObservePermissionOnResume
-import org.connectbot.ui.ScreenPreviews
+import org.connectbot.ui.PreviewScreen
 import org.connectbot.ui.common.getLocalizedFontDisplayName
 import org.connectbot.ui.components.FontDownloadProgressDialog
 import org.connectbot.ui.theme.ConnectBotTheme
@@ -1321,7 +1321,7 @@ private fun LocalFontPreference(
     }
 }
 
-@ScreenPreviews
+@PreviewScreen
 @Composable
 private fun SettingsScreenPreview() {
     ConnectBotTheme {

--- a/app/src/main/java/org/connectbot/ui/theme/Theme.kt
+++ b/app/src/main/java/org/connectbot/ui/theme/Theme.kt
@@ -58,7 +58,7 @@ private val lightScheme = lightColorScheme(
     outline = md_theme_light_outline,
     inverseOnSurface = md_theme_light_inverseOnSurface,
     inverseSurface = md_theme_light_inverseSurface,
-    inversePrimary = md_theme_light_inversePrimary,
+    inversePrimary = md_theme_light_inversePrimary
 )
 
 private val darkScheme = darkColorScheme(
@@ -85,7 +85,7 @@ private val darkScheme = darkColorScheme(
     outline = md_theme_dark_outline,
     inverseOnSurface = md_theme_dark_inverseOnSurface,
     inverseSurface = md_theme_dark_inverseSurface,
-    inversePrimary = md_theme_dark_inversePrimary,
+    inversePrimary = md_theme_dark_inversePrimary
 )
 
 @Composable
@@ -102,6 +102,7 @@ fun ConnectBotTheme(
         }
 
         darkTheme -> darkScheme
+
         else -> lightScheme
     }
 

--- a/app/src/main/java/org/connectbot/util/Encryptor.kt
+++ b/app/src/main/java/org/connectbot/util/Encryptor.kt
@@ -51,7 +51,6 @@ object Encryptor {
     /** cipher algorithm (must be compatible with KEY_ALGORITHM)  */
     private const val CIPHER_ALGORITHM = "AES/CBC/PKCS5Padding"
 
-
     /**
      * Encrypt the specified cleartext using the given password.
      * With the correct salt, number of iterations, and password, the decrypt() method reverses
@@ -122,7 +121,6 @@ object Encryptor {
 
         return cipher.doFinal(cleartext)
     }
-
 
     /**
      * Decrypt the specified ciphertext using the given password.

--- a/app/src/main/java/org/connectbot/util/LocalFontProvider.kt
+++ b/app/src/main/java/org/connectbot/util/LocalFontProvider.kt
@@ -47,32 +47,30 @@ class LocalFontProvider(private val context: Context) {
      * @param displayName The display name for the font
      * @return The internal path if successful, null otherwise
      */
-    fun importFont(uri: Uri, displayName: String): String? {
-        return try {
-            val fileName = sanitizeFileName(displayName)
-            val destFile = File(fontsDir, fileName)
+    fun importFont(uri: Uri, displayName: String): String? = try {
+        val fileName = sanitizeFileName(displayName)
+        val destFile = File(fontsDir, fileName)
 
-            context.contentResolver.openInputStream(uri)?.use { input ->
-                FileOutputStream(destFile).use { output ->
-                    input.copyTo(output)
-                }
+        context.contentResolver.openInputStream(uri)?.use { input ->
+            FileOutputStream(destFile).use { output ->
+                input.copyTo(output)
             }
+        }
 
-            // Validate the font can be loaded
-            val typeface = Typeface.createFromFile(destFile)
-            if (typeface != null) {
-                fontCache[fileName] = typeface
-                Log.d(TAG, "Imported font: $displayName -> $fileName")
-                fileName
-            } else {
-                destFile.delete()
-                Log.w(TAG, "Failed to create typeface from: $displayName")
-                null
-            }
-        } catch (e: Exception) {
-            Log.e(TAG, "Failed to import font: $displayName", e)
+        // Validate the font can be loaded
+        val typeface = Typeface.createFromFile(destFile)
+        if (typeface != null) {
+            fontCache[fileName] = typeface
+            Log.d(TAG, "Imported font: $displayName -> $fileName")
+            fileName
+        } else {
+            destFile.delete()
+            Log.w(TAG, "Failed to create typeface from: $displayName")
             null
         }
+    } catch (e: Exception) {
+        Log.e(TAG, "Failed to import font: $displayName", e)
+        null
     }
 
     /**
@@ -104,12 +102,10 @@ class LocalFontProvider(private val context: Context) {
      * Get all imported local fonts.
      * Returns a list of (displayName, fileName) pairs.
      */
-    fun getImportedFonts(): List<Pair<String, String>> {
-        return fontsDir.listFiles()
-            ?.filter { it.isFile && isFontFile(it.name) }
-            ?.map { getDisplayName(it.name) to it.name }
-            ?: emptyList()
-    }
+    fun getImportedFonts(): List<Pair<String, String>> = fontsDir.listFiles()
+        ?.filter { it.isFile && isFontFile(it.name) }
+        ?.map { getDisplayName(it.name) to it.name }
+        ?: emptyList()
 
     /**
      * Delete a local font.
@@ -127,16 +123,12 @@ class LocalFontProvider(private val context: Context) {
     /**
      * Check if a font file exists.
      */
-    fun fontExists(fileName: String): Boolean {
-        return File(fontsDir, fileName).exists()
-    }
+    fun fontExists(fileName: String): Boolean = File(fontsDir, fileName).exists()
 
     /**
      * Get typeface for a local font, with fallback.
      */
-    fun getTypeface(fileName: String, fallback: Typeface = Typeface.MONOSPACE): Typeface {
-        return loadFont(fileName) ?: fallback
-    }
+    fun getTypeface(fileName: String, fallback: Typeface = Typeface.MONOSPACE): Typeface = loadFont(fileName) ?: fallback
 
     private fun sanitizeFileName(name: String): String {
         // Remove path separators and other problematic characters
@@ -172,9 +164,7 @@ class LocalFontProvider(private val context: Context) {
         /**
          * Check if a stored value represents a local font.
          */
-        fun isLocalFont(storedValue: String?): Boolean {
-            return storedValue?.startsWith(LOCAL_PREFIX) == true
-        }
+        fun isLocalFont(storedValue: String?): Boolean = storedValue?.startsWith(LOCAL_PREFIX) == true
 
         /**
          * Get the filename from a local font stored value.
@@ -187,8 +177,6 @@ class LocalFontProvider(private val context: Context) {
         /**
          * Create a stored value for a local font.
          */
-        fun createLocalFontValue(fileName: String): String {
-            return "$LOCAL_PREFIX$fileName"
-        }
+        fun createLocalFontValue(fileName: String): String = "$LOCAL_PREFIX$fileName"
     }
 }

--- a/app/src/main/java/org/connectbot/util/PubkeyUtils.kt
+++ b/app/src/main/java/org/connectbot/util/PubkeyUtils.kt
@@ -16,10 +16,10 @@
  */
 package org.connectbot.util
 
-import timber.log.Timber
 import com.trilead.ssh2.crypto.PEMDecoder
 import com.trilead.ssh2.crypto.keys.Ed25519Provider
 import org.connectbot.data.entity.Pubkey
+import timber.log.Timber
 import java.security.Key
 import java.security.KeyFactory
 import java.security.KeyPair
@@ -52,7 +52,7 @@ object PubkeyUtils {
         val fmt = key.format
         val encoded = key.encoded
         return "Key[algorithm=" + algo + ", format=" + fmt +
-                ", bytes=" + encoded.size + "]"
+            ", bytes=" + encoded.size + "]"
     }
 
     @Throws(Exception::class)
@@ -101,12 +101,13 @@ object PubkeyUtils {
     }
 
     @Throws(Exception::class)
-    fun decodePrivate(encoded: ByteArray, keyType: String?, secret: String?): PrivateKey? {
-        return if (secret != null && secret.isNotEmpty()) decodePrivate(
+    fun decodePrivate(encoded: ByteArray, keyType: String?, secret: String?): PrivateKey? = if (secret != null && secret.isNotEmpty()) {
+        decodePrivate(
             decrypt(encoded, secret),
             keyType
         )
-        else decodePrivate(encoded, keyType)
+    } else {
+        decodePrivate(encoded, keyType)
     }
 
     @Throws(NoSuchAlgorithmException::class, InvalidKeySpecException::class)

--- a/app/src/main/java/org/connectbot/util/TerminalFont.kt
+++ b/app/src/main/java/org/connectbot/util/TerminalFont.kt
@@ -54,16 +54,14 @@ enum class TerminalFont(
             if (name.startsWith(CUSTOM_PREFIX)) return null
             return entries.find {
                 it.name.equals(name, ignoreCase = true) ||
-                it.displayName.equals(name, ignoreCase = true)
+                    it.displayName.equals(name, ignoreCase = true)
             } ?: SYSTEM_DEFAULT
         }
 
         /**
          * Check if a font name represents a custom font.
          */
-        fun isCustomFont(name: String?): Boolean {
-            return name?.startsWith(CUSTOM_PREFIX) == true
-        }
+        fun isCustomFont(name: String?): Boolean = name?.startsWith(CUSTOM_PREFIX) == true
 
         /**
          * Extract the Google Fonts name from a custom font string.
@@ -77,9 +75,7 @@ enum class TerminalFont(
         /**
          * Create a custom font storage string from a Google Fonts name.
          */
-        fun createCustomFontValue(googleFontName: String): String {
-            return "$CUSTOM_PREFIX$googleFontName"
-        }
+        fun createCustomFontValue(googleFontName: String): String = "$CUSTOM_PREFIX$googleFontName"
 
         /**
          * Get the Google Fonts name for a given stored value.
@@ -119,15 +115,13 @@ enum class TerminalFont(
             if (storedValue.startsWith(LocalFontProvider.LOCAL_PREFIX)) return false
             return entries.any {
                 it.name.equals(storedValue, ignoreCase = true) ||
-                it.displayName.equals(storedValue, ignoreCase = true)
+                    it.displayName.equals(storedValue, ignoreCase = true)
             }
         }
 
         /**
          * Check if a stored value is a local font.
          */
-        fun isLocalFont(storedValue: String?): Boolean {
-            return LocalFontProvider.isLocalFont(storedValue)
-        }
+        fun isLocalFont(storedValue: String?): Boolean = LocalFontProvider.isLocalFont(storedValue)
     }
 }

--- a/app/src/oss/java/org/connectbot/util/ProviderLoader.kt
+++ b/app/src/oss/java/org/connectbot/util/ProviderLoader.kt
@@ -16,23 +16,22 @@
  */
 package org.connectbot.util
 
-import java.security.Security
-import org.conscrypt.OpenSSLProvider
-
 import android.content.Context
+import org.conscrypt.OpenSSLProvider
+import java.security.Security
 
 /**
  * Loads the Conscrypt provider for the oss (Open Source Software) version of ConnectBot that
  * uses OpenSSL. This provider doesn't rely on Google Play Services.
  */
 object ProviderLoader {
-	@JvmStatic
-	fun load(context: Context, listener: ProviderLoaderListener) {
-		try {
-			Security.insertProviderAt(OpenSSLProvider(), 1)
-			listener.onProviderLoaderSuccess()
-		} catch (e: Exception) {
-			listener.onProviderLoaderError()
-		}
-	}
+    @JvmStatic
+    fun load(context: Context, listener: ProviderLoaderListener) {
+        try {
+            Security.insertProviderAt(OpenSSLProvider(), 1)
+            listener.onProviderLoaderSuccess()
+        } catch (e: Exception) {
+            listener.onProviderLoaderError()
+        }
+    }
 }

--- a/app/src/test/java/org/connectbot/data/ColorSchemePresetsTest.kt
+++ b/app/src/test/java/org/connectbot/data/ColorSchemePresetsTest.kt
@@ -17,7 +17,9 @@
 
 package org.connectbot.data
 
-import org.junit.Assert.*
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
@@ -32,7 +34,7 @@ class ColorSchemePresetsTest {
         assertEquals("Solarized Dark", scheme.name)
         assertEquals("Precision colors for machines and people", scheme.description)
         assertEquals(12, scheme.defaultFg) // base0
-        assertEquals(8, scheme.defaultBg)  // base03
+        assertEquals(8, scheme.defaultBg) // base03
     }
 
     @Test
@@ -50,9 +52,9 @@ class ColorSchemePresetsTest {
         val scheme = ColorSchemePresets.solarizedDark
 
         // Check a few key colors
-        assertEquals(0xff073642.toInt(), scheme.colors[0])  // black: base02
-        assertEquals(0xffdc322f.toInt(), scheme.colors[1])  // red
-        assertEquals(0xff002b36.toInt(), scheme.colors[8])  // bright black: base03
+        assertEquals(0xff073642.toInt(), scheme.colors[0]) // black: base02
+        assertEquals(0xffdc322f.toInt(), scheme.colors[1]) // red
+        assertEquals(0xff002b36.toInt(), scheme.colors[8]) // bright black: base03
         assertEquals(0xff839496.toInt(), scheme.colors[12]) // bright blue: base0
     }
 

--- a/app/src/test/java/org/connectbot/data/dao/HostDaoTest.kt
+++ b/app/src/test/java/org/connectbot/data/dao/HostDaoTest.kt
@@ -298,27 +298,25 @@ class HostDaoTest {
         useCtrlAltAsMetaKey: Boolean = false,
         jumpHostId: Long? = null,
         profileId: Long? = 1L
-    ): Host {
-        return Host(
-            nickname = nickname,
-            protocol = protocol,
-            username = username,
-            hostname = hostname,
-            port = port,
-            hostKeyAlgo = hostKeyAlgo,
-            lastConnect = lastConnect,
-            color = color,
-            useKeys = useKeys,
-            useAuthAgent = useAuthAgent,
-            stayConnected = stayConnected,
-            postLogin = postLogin,
-            pubkeyId = pubkeyId,
-            wantSession = wantSession,
-            compression = compression,
-            scrollbackLines = scrollbackLines,
-            useCtrlAltAsMetaKey = useCtrlAltAsMetaKey,
-            jumpHostId = jumpHostId,
-            profileId = profileId
-        )
-    }
+    ): Host = Host(
+        nickname = nickname,
+        protocol = protocol,
+        username = username,
+        hostname = hostname,
+        port = port,
+        hostKeyAlgo = hostKeyAlgo,
+        lastConnect = lastConnect,
+        color = color,
+        useKeys = useKeys,
+        useAuthAgent = useAuthAgent,
+        stayConnected = stayConnected,
+        postLogin = postLogin,
+        pubkeyId = pubkeyId,
+        wantSession = wantSession,
+        compression = compression,
+        scrollbackLines = scrollbackLines,
+        useCtrlAltAsMetaKey = useCtrlAltAsMetaKey,
+        jumpHostId = jumpHostId,
+        profileId = profileId
+    )
 }

--- a/app/src/test/java/org/connectbot/data/dao/PortForwardDaoTest.kt
+++ b/app/src/test/java/org/connectbot/data/dao/PortForwardDaoTest.kt
@@ -254,14 +254,12 @@ class PortForwardDaoTest {
         sourcePort: Int = 8080,
         destAddr: String = "localhost",
         destPort: Int = 80
-    ): PortForward {
-        return PortForward(
-            hostId = hostId,
-            nickname = nickname,
-            type = type,
-            sourcePort = sourcePort,
-            destAddr = destAddr,
-            destPort = destPort
-        )
-    }
+    ): PortForward = PortForward(
+        hostId = hostId,
+        nickname = nickname,
+        type = type,
+        sourcePort = sourcePort,
+        destAddr = destAddr,
+        destPort = destPort
+    )
 }

--- a/app/src/test/java/org/connectbot/data/dao/ProfileDaoTest.kt
+++ b/app/src/test/java/org/connectbot/data/dao/ProfileDaoTest.kt
@@ -353,30 +353,26 @@ class ProfileDaoTest {
         delKey: String = "del",
         encoding: String = "UTF-8",
         emulation: String = "xterm-256color"
-    ): Profile {
-        return Profile(
-            name = name,
-            iconColor = iconColor,
-            colorSchemeId = colorSchemeId,
-            fontFamily = fontFamily,
-            fontSize = fontSize,
-            delKey = delKey,
-            encoding = encoding,
-            emulation = emulation
-        )
-    }
+    ): Profile = Profile(
+        name = name,
+        iconColor = iconColor,
+        colorSchemeId = colorSchemeId,
+        fontFamily = fontFamily,
+        fontSize = fontSize,
+        delKey = delKey,
+        encoding = encoding,
+        emulation = emulation
+    )
 
     private fun createTestHost(
         nickname: String,
         profileId: Long?
-    ): Host {
-        return Host(
-            nickname = nickname,
-            protocol = "ssh",
-            username = "user",
-            hostname = "example.com",
-            port = 22,
-            profileId = profileId
-        )
-    }
+    ): Host = Host(
+        nickname = nickname,
+        protocol = "ssh",
+        username = "user",
+        hostname = "example.com",
+        port = 22,
+        profileId = profileId
+    )
 }

--- a/app/src/test/java/org/connectbot/data/dao/PubkeyDaoTest.kt
+++ b/app/src/test/java/org/connectbot/data/dao/PubkeyDaoTest.kt
@@ -282,19 +282,17 @@ class PubkeyDaoTest {
         storageType: KeyStorageType = KeyStorageType.EXPORTABLE,
         allowBackup: Boolean = true,
         keystoreAlias: String? = null
-    ): Pubkey {
-        return Pubkey(
-            nickname = nickname,
-            type = type,
-            privateKey = privateKey,
-            publicKey = publicKey,
-            encrypted = encrypted,
-            startup = startup,
-            confirmation = confirmation,
-            createdDate = createdDate,
-            storageType = storageType,
-            allowBackup = allowBackup,
-            keystoreAlias = keystoreAlias
-        )
-    }
+    ): Pubkey = Pubkey(
+        nickname = nickname,
+        type = type,
+        privateKey = privateKey,
+        publicKey = publicKey,
+        encrypted = encrypted,
+        startup = startup,
+        confirmation = confirmation,
+        createdDate = createdDate,
+        storageType = storageType,
+        allowBackup = allowBackup,
+        keystoreAlias = keystoreAlias
+    )
 }

--- a/app/src/test/java/org/connectbot/data/migration/DatabaseMigrationRollbackTest.kt
+++ b/app/src/test/java/org/connectbot/data/migration/DatabaseMigrationRollbackTest.kt
@@ -321,46 +321,42 @@ class DatabaseMigrationRollbackTest {
         username: String = "user",
         hostname: String = "example.com",
         port: Int = 22
-    ): Host {
-        return Host(
-            nickname = nickname,
-            protocol = protocol,
-            username = username,
-            hostname = hostname,
-            port = port,
-            hostKeyAlgo = null,
-            lastConnect = 0,
-            color = "gray",
-            useKeys = false,
-            useAuthAgent = null,
-            stayConnected = false,
-            postLogin = null,
-            pubkeyId = 0,
-            wantSession = true,
-            compression = false,
-            scrollbackLines = 140,
-            useCtrlAltAsMetaKey = false,
-            jumpHostId = null,
-            profileId = 1L
-        )
-    }
+    ): Host = Host(
+        nickname = nickname,
+        protocol = protocol,
+        username = username,
+        hostname = hostname,
+        port = port,
+        hostKeyAlgo = null,
+        lastConnect = 0,
+        color = "gray",
+        useKeys = false,
+        useAuthAgent = null,
+        stayConnected = false,
+        postLogin = null,
+        pubkeyId = 0,
+        wantSession = true,
+        compression = false,
+        scrollbackLines = 140,
+        useCtrlAltAsMetaKey = false,
+        jumpHostId = null,
+        profileId = 1L
+    )
 
     private fun createTestPubkey(
         nickname: String,
         type: String = "ssh-rsa"
-    ): Pubkey {
-        return Pubkey(
-            nickname = nickname,
-            type = type,
-            privateKey = byteArrayOf(1, 2, 3),
-            publicKey = byteArrayOf(4, 5, 6),
-            encrypted = false,
-            startup = false,
-            confirmation = false,
-            createdDate = System.currentTimeMillis(),
-            storageType = KeyStorageType.EXPORTABLE,
-            allowBackup = true,
-            keystoreAlias = null
-        )
-    }
+    ): Pubkey = Pubkey(
+        nickname = nickname,
+        type = type,
+        privateKey = byteArrayOf(1, 2, 3),
+        publicKey = byteArrayOf(4, 5, 6),
+        encrypted = false,
+        startup = false,
+        confirmation = false,
+        createdDate = System.currentTimeMillis(),
+        storageType = KeyStorageType.EXPORTABLE,
+        allowBackup = true,
+        keystoreAlias = null
+    )
 }

--- a/app/src/test/java/org/connectbot/data/migration/DatabaseMigratorTest.kt
+++ b/app/src/test/java/org/connectbot/data/migration/DatabaseMigratorTest.kt
@@ -85,7 +85,6 @@ class DatabaseMigratorTest {
         assertThat(needed).isFalse()
     }
 
-
     @Test
     fun resetMigrationStateWorks() = runTest {
         migrator.resetMigrationState()

--- a/app/src/test/java/org/connectbot/data/migration/LegacyDatabasePreservationTest.kt
+++ b/app/src/test/java/org/connectbot/data/migration/LegacyDatabasePreservationTest.kt
@@ -98,7 +98,6 @@ class LegacyDatabasePreservationTest {
         assertThat(pubkeysMigratedFile.exists()).isFalse()
     }
 
-
     @Test
     fun `legacy databases can be read again after failed migration`() = runTest {
         // Create a legacy database with some data
@@ -118,9 +117,6 @@ class LegacyDatabasePreservationTest {
         assertThat(hosts).isNotEmpty()
         assertThat(hostsDbFile.exists()).isTrue()
     }
-
-
-
 
     @Test
     fun `partial write failure leaves legacy files intact`() = runTest {
@@ -159,7 +155,8 @@ class LegacyDatabasePreservationTest {
         val db = SQLiteDatabase.openOrCreateDatabase(file, null)
 
         // Create hosts table with basic structure
-        db.execSQL("""
+        db.execSQL(
+            """
             CREATE TABLE hosts (
                 _id INTEGER PRIMARY KEY,
                 nickname TEXT UNIQUE,
@@ -185,10 +182,12 @@ class LegacyDatabasePreservationTest {
                 usectrlaltasmeta TEXT,
                 quickdisconnect TEXT
             )
-        """)
+        """
+        )
 
         // Insert test data
-        db.execSQL("""
+        db.execSQL(
+            """
             INSERT INTO hosts (nickname, protocol, username, hostname, port,
                              hostkeyalgo, lastconnect, color, usekeys, useauthagent,
                              postlogin, pubkeyid, wantsession, compression, encoding,
@@ -198,7 +197,8 @@ class LegacyDatabasePreservationTest {
                     NULL, 0, 'gray', 'false', NULL,
                     NULL, 0, 'true', 'false', 'UTF-8',
                     'false', 10, 1, 'BACKSPACE', 140, 'false', 'false')
-        """)
+        """
+        )
 
         db.close()
     }
@@ -207,7 +207,8 @@ class LegacyDatabasePreservationTest {
         val db = SQLiteDatabase.openOrCreateDatabase(file, null)
 
         // Create hosts table
-        db.execSQL("""
+        db.execSQL(
+            """
             CREATE TABLE hosts (
                 _id INTEGER PRIMARY KEY,
                 nickname TEXT,
@@ -233,10 +234,12 @@ class LegacyDatabasePreservationTest {
                 usectrlaltasmeta TEXT,
                 quickdisconnect TEXT
             )
-        """)
+        """
+        )
 
         // Insert duplicate nicknames (no unique constraint in legacy DB)
-        db.execSQL("""
+        db.execSQL(
+            """
             INSERT INTO hosts (nickname, protocol, username, hostname, port,
                              hostkeyalgo, lastconnect, color, usekeys, useauthagent,
                              postlogin, pubkeyid, wantsession, compression, encoding,
@@ -246,9 +249,11 @@ class LegacyDatabasePreservationTest {
                     NULL, 0, 'gray', 'false', NULL,
                     NULL, 0, 'true', 'false', 'UTF-8',
                     'false', 10, 1, 'BACKSPACE', 140, 'false', 'false')
-        """)
+        """
+        )
 
-        db.execSQL("""
+        db.execSQL(
+            """
             INSERT INTO hosts (nickname, protocol, username, hostname, port,
                              hostkeyalgo, lastconnect, color, usekeys, useauthagent,
                              postlogin, pubkeyid, wantsession, compression, encoding,
@@ -258,7 +263,8 @@ class LegacyDatabasePreservationTest {
                     NULL, 0, 'gray', 'false', NULL,
                     NULL, 0, 'true', 'false', 'UTF-8',
                     'false', 10, 1, 'BACKSPACE', 140, 'false', 'false')
-        """)
+        """
+        )
 
         db.close()
     }
@@ -267,7 +273,8 @@ class LegacyDatabasePreservationTest {
         val db = SQLiteDatabase.openOrCreateDatabase(file, null)
 
         // Create pubkeys table
-        db.execSQL("""
+        db.execSQL(
+            """
             CREATE TABLE pubkeys (
                 _id INTEGER PRIMARY KEY,
                 nickname TEXT UNIQUE,
@@ -279,13 +286,16 @@ class LegacyDatabasePreservationTest {
                 confirmuse INTEGER,
                 lifetime INTEGER
             )
-        """)
+        """
+        )
 
         // Insert test pubkey
-        db.execSQL("""
+        db.execSQL(
+            """
             INSERT INTO pubkeys (nickname, type, private, public, encrypted, startup, confirmuse, lifetime)
             VALUES ('test-key', 'ssh-rsa', X'010203', X'040506', 0, 0, 0, 0)
-        """)
+        """
+        )
 
         db.close()
     }

--- a/app/src/test/java/org/connectbot/data/migration/LegacyMigrationRaceConditionTest.kt
+++ b/app/src/test/java/org/connectbot/data/migration/LegacyMigrationRaceConditionTest.kt
@@ -26,9 +26,9 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
-import org.connectbot.di.CoroutineDispatchers
 import org.assertj.core.api.Assertions.assertThat
 import org.connectbot.data.ConnectBotDatabase
+import org.connectbot.di.CoroutineDispatchers
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -127,10 +127,12 @@ class LegacyMigrationRaceConditionTest {
                     // This is the exact same code from DatabaseModule.kt
                     // It creates a default profile when the database is first created
                     Timber.d("Room onCreate callback - inserting default profile")
-                    db.execSQL("""
+                    db.execSQL(
+                        """
                         INSERT INTO profiles (name, color_scheme_id, font_size, del_key, encoding, emulation)
                         VALUES ('Default', -1, 10, 'del', 'UTF-8', 'xterm-256color')
-                    """.trimIndent())
+                        """.trimIndent()
+                    )
                 }
             })
             .allowMainThreadQueries()
@@ -153,12 +155,11 @@ class LegacyMigrationRaceConditionTest {
             assertThat(isMigrationNeeded)
                 .describedAs(
                     "isMigrationNeeded() should return true when legacy databases exist " +
-                    "and Room database was just created. The bug causes it to return false " +
-                    "because Room's onCreate callback inserts a default profile before " +
-                    "the migration check completes."
+                        "and Room database was just created. The bug causes it to return false " +
+                        "because Room's onCreate callback inserts a default profile before " +
+                        "the migration check completes."
                 )
                 .isTrue()
-
         } finally {
             database.close()
         }
@@ -190,10 +191,12 @@ class LegacyMigrationRaceConditionTest {
             .addCallback(object : RoomDatabase.Callback() {
                 override fun onCreate(db: SupportSQLiteDatabase) {
                     super.onCreate(db)
-                    db.execSQL("""
+                    db.execSQL(
+                        """
                         INSERT INTO profiles (name, color_scheme_id, font_size, del_key, encoding, emulation)
                         VALUES ('Default', -1, 10, 'del', 'UTF-8', 'xterm-256color')
-                    """.trimIndent())
+                        """.trimIndent()
+                    )
                 }
             })
             .allowMainThreadQueries()
@@ -222,7 +225,6 @@ class LegacyMigrationRaceConditionTest {
             // - isMigrationNeeded() checks: hosts.isEmpty && pubkeys.isEmpty && profiles.isEmpty
             // - profiles.isEmpty is FALSE (because of the default profile)
             // - So isMigrationNeeded() returns false, skipping migration
-
         } finally {
             database.close()
         }
@@ -239,7 +241,8 @@ class LegacyMigrationRaceConditionTest {
         val db = android.database.sqlite.SQLiteDatabase.openOrCreateDatabase(dbFile, null)
         try {
             // Create the hosts table with the legacy schema (version 27)
-            db.execSQL("""
+            db.execSQL(
+                """
                 CREATE TABLE IF NOT EXISTS hosts (
                     _id INTEGER PRIMARY KEY AUTOINCREMENT,
                     nickname TEXT NOT NULL,
@@ -265,16 +268,20 @@ class LegacyMigrationRaceConditionTest {
                     scrollback INTEGER DEFAULT 140,
                     ctrl_alt_meta INTEGER DEFAULT 0
                 )
-            """.trimIndent())
+                """.trimIndent()
+            )
 
             // Insert a sample host
-            db.execSQL("""
+            db.execSQL(
+                """
                 INSERT INTO hosts (nickname, protocol, username, hostname, port, usekeys)
                 VALUES ('test-server', 'ssh', 'testuser', 'test.example.com', 22, 1)
-            """.trimIndent())
+                """.trimIndent()
+            )
 
             // Create other tables that might be expected
-            db.execSQL("""
+            db.execSQL(
+                """
                 CREATE TABLE IF NOT EXISTS portforwards (
                     _id INTEGER PRIMARY KEY AUTOINCREMENT,
                     hostid INTEGER NOT NULL,
@@ -284,9 +291,11 @@ class LegacyMigrationRaceConditionTest {
                     destaddr TEXT NOT NULL,
                     destport INTEGER NOT NULL
                 )
-            """.trimIndent())
+                """.trimIndent()
+            )
 
-            db.execSQL("""
+            db.execSQL(
+                """
                 CREATE TABLE IF NOT EXISTS knownhosts (
                     _id INTEGER PRIMARY KEY AUTOINCREMENT,
                     hostid INTEGER,
@@ -295,24 +304,28 @@ class LegacyMigrationRaceConditionTest {
                     hostkeyalgo TEXT NOT NULL,
                     hostkey BLOB NOT NULL
                 )
-            """.trimIndent())
+                """.trimIndent()
+            )
 
-            db.execSQL("""
+            db.execSQL(
+                """
                 CREATE TABLE IF NOT EXISTS color_schemes (
                     _id INTEGER PRIMARY KEY AUTOINCREMENT,
                     name TEXT NOT NULL
                 )
-            """.trimIndent())
+                """.trimIndent()
+            )
 
-            db.execSQL("""
+            db.execSQL(
+                """
                 CREATE TABLE IF NOT EXISTS color_palette (
                     _id INTEGER PRIMARY KEY AUTOINCREMENT,
                     scheme_id INTEGER NOT NULL,
                     color_index INTEGER NOT NULL,
                     color INTEGER NOT NULL
                 )
-            """.trimIndent())
-
+                """.trimIndent()
+            )
         } finally {
             db.close()
         }
@@ -329,7 +342,8 @@ class LegacyMigrationRaceConditionTest {
         val db = android.database.sqlite.SQLiteDatabase.openOrCreateDatabase(dbFile, null)
         try {
             // Create the pubkeys table with the legacy schema (version 2)
-            db.execSQL("""
+            db.execSQL(
+                """
                 CREATE TABLE IF NOT EXISTS pubkeys (
                     _id INTEGER PRIMARY KEY AUTOINCREMENT,
                     nickname TEXT NOT NULL,
@@ -341,14 +355,16 @@ class LegacyMigrationRaceConditionTest {
                     confirmuse INTEGER DEFAULT 0,
                     lifetime INTEGER DEFAULT 0
                 )
-            """.trimIndent())
+                """.trimIndent()
+            )
 
             // Insert a sample pubkey
-            db.execSQL("""
+            db.execSQL(
+                """
                 INSERT INTO pubkeys (nickname, type, private, public, encrypted, startup, confirmuse)
                 VALUES ('my-test-key', 'RSA', X'010203', X'040506', 0, 1, 0)
-            """.trimIndent())
-
+                """.trimIndent()
+            )
         } finally {
             db.close()
         }

--- a/app/src/test/java/org/connectbot/service/BackupFilterTest.kt
+++ b/app/src/test/java/org/connectbot/service/BackupFilterTest.kt
@@ -386,18 +386,16 @@ class BackupFilterTest {
         nickname: String,
         allowBackup: Boolean,
         storageType: KeyStorageType
-    ): Pubkey {
-        return Pubkey(
-            nickname = nickname,
-            type = "RSA",
-            privateKey = ByteArray(16),
-            publicKey = ByteArray(16),
-            encrypted = false,
-            startup = false,
-            confirmation = false,
-            createdDate = System.currentTimeMillis(),
-            storageType = storageType,
-            allowBackup = allowBackup
-        )
-    }
+    ): Pubkey = Pubkey(
+        nickname = nickname,
+        type = "RSA",
+        privateKey = ByteArray(16),
+        publicKey = ByteArray(16),
+        encrypted = false,
+        startup = false,
+        confirmation = false,
+        createdDate = System.currentTimeMillis(),
+        storageType = storageType,
+        allowBackup = allowBackup
+    )
 }

--- a/app/src/test/java/org/connectbot/ui/screens/pubkeylist/PubkeyListViewModelTest.kt
+++ b/app/src/test/java/org/connectbot/ui/screens/pubkeylist/PubkeyListViewModelTest.kt
@@ -104,9 +104,7 @@ class PubkeyListViewModelTest {
         Timber.uprootAll()
     }
 
-    private fun createViewModel(): PubkeyListViewModel {
-        return PubkeyListViewModel(context, repository, dispatchers)
-    }
+    private fun createViewModel(): PubkeyListViewModel = PubkeyListViewModel(context, repository, dispatchers)
 
     // ========== Tests for encrypted key import with re-encryption ==========
 
@@ -197,7 +195,7 @@ class PubkeyListViewModelTest {
         viewModel.completeImportWithPassword(
             decryptPassword = "testpass",
             encrypt = true,
-            encryptPassword = "testpass"  // Same as decrypt password
+            encryptPassword = "testpass" // Same as decrypt password
         )
         advanceUntilIdle()
 
@@ -256,7 +254,7 @@ class PubkeyListViewModelTest {
 
         // Import unencrypted key without re-encrypting
         viewModel.completeImportWithPassword(
-            decryptPassword = "",  // No password needed for unencrypted key
+            decryptPassword = "", // No password needed for unencrypted key
             encrypt = false,
             encryptPassword = null
         )


### PR DESCRIPTION
Retry #1913. 
Run spotless apply across the full codebase (bypassing the ratchetFrom origin/main filter) and fix all non-auto-correctable ktlint violations:

- Move inline data class parameter comments above their parameters
- Move import-section comment to class level (TerminalKeyListener)
- Wrap multiple top-level emitters in Column (CheckingMigrationContent)
- Use rememberUpdatedState for lambdas captured inside effects (PermissionLifecycleObserver, InlinePrompt, PromptDialogs, PubkeyEditorScreen)
- Rename MultiPreview annotation ScreenPreviews → PreviewScreen
- Reorder ColorPickerDialog parameters (defaults after non-defaults)
- Replace wildcard import with specific assertions in ColorSchemePresetsTest
- Rename past-tense lambda parameters to present tense throughout: onFailed→onFail, onColorSelected→onSelectColor, onEntropyGathered→onGatherEntropy, onProgressUpdated→onProgressUpdate, onPermissionChanged→onPermissionChange, onDismissed→onDismiss, onToggleKeyLoaded→onToggleKeyLoad, onCopyPrivateKeyEncrypted→onCopyPrivateKeyEncrypt, onExportPrivateKeyEncrypted→onExportPrivateKeyEncrypt, onPasswordProvided→onProvidePassword, onPassphraseProvided→onProvidePassphrase
- Fix local modifier variable name in PubkeyListItem to avoid modifier-reused-check

All unit tests pass. spotlessCheck passes with ratchetFrom restored.