### PR TITLE
Key from clip

### DIFF
--- a/app/src/main/java/org/connectbot/ui/screens/pubkeylist/PubkeyListScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/pubkeylist/PubkeyListScreen.kt
@@ -471,139 +471,123 @@ private fun PubkeyListItem(
     var passwordCallback by remember { mutableStateOf<((String) -> Unit)?>(null) }
     var exportPassphraseCallback by remember { mutableStateOf<((String) -> Unit)?>(null) }
 
-    ListItem(
-        headlineContent = {
-            Text(
-                text = pubkey.nickname,
-                fontWeight = FontWeight.Bold,
-            )
-        },
-        supportingContent = {
-            Text(
-                stringResource(
-                    R.string.pubkey_type_label,
-                    pubkey.type,
-                ),
-            )
-        },
-        leadingContent = {
-            val icon = when {
-                pubkey.isBiometric -> Icons.Outlined.Fingerprint
-                pubkey.encrypted -> Icons.Outlined.Lock
-                else -> Icons.Outlined.LockOpen
-            }
-
-            val iconModifier = when {
-                isLoaded ->
-                    Modifier
-                        .padding(2.dp)
-                        .border(
-                            width = 2.dp, // Border thickness
-                            color = Color.Green, // Border color
-                            shape = CircleShape, // Makes the border a circle
-                        )
-                        .clip(CircleShape)
-                        .padding(4.dp)
-
-                else -> Modifier.padding(2.dp).clip(CircleShape).padding(4.dp)
-            }
-
-            Box(
-                modifier = iconModifier,
-            ) {
-                Icon(
-                    imageVector = icon,
-                    contentDescription = when {
-                        pubkey.isBiometric -> stringResource(R.string.pubkey_biometric_description_icon)
-                        pubkey.encrypted -> stringResource(R.string.pubkey_encrypted_description)
-                        else -> stringResource(R.string.pubkey_not_encrypted_description)
-                    },
+    Column(modifier = modifier) {
+        ListItem(
+            headlineContent = {
+                Text(
+                    text = pubkey.nickname,
+                    fontWeight = FontWeight.Bold,
                 )
-            }
-        },
-        trailingContent = {
-            Box {
-                IconButton(onClick = { showMenu = true }) {
-                    Icon(Icons.Default.MoreVert, stringResource(R.string.button_more_options))
+            },
+            supportingContent = {
+                Text(
+                    stringResource(
+                        R.string.pubkey_type_label,
+                        pubkey.type,
+                    ),
+                )
+            },
+            leadingContent = {
+                val icon = when {
+                    pubkey.isBiometric -> Icons.Outlined.Fingerprint
+                    pubkey.encrypted -> Icons.Outlined.Lock
+                    else -> Icons.Outlined.LockOpen
                 }
-                DropdownMenu(
-                    expanded = showMenu,
-                    onDismissRequest = { showMenu = false },
-                ) {
-                    // Edit key
-                    DropdownMenuItem(
-                        text = {
-                            Text(stringResource(R.string.list_pubkey_edit))
-                        },
-                        onClick = {
-                            showMenu = false
-                            onEdit()
-                        },
-                        leadingIcon = {
-                            Icon(Icons.Default.Edit, null)
-                        },
-                    )
 
-                    // Copy public key
-                    val isImported = pubkey.type == "IMPORTED"
-                    DropdownMenuItem(
-                        text = { Text(stringResource(R.string.pubkey_copy_public)) },
-                        onClick = {
-                            showMenu = false
-                            onCopyPublicKey()
-                        },
-                        leadingIcon = {
-                            Icon(Icons.Default.ContentCopy, null)
-                        },
-                        enabled = !isImported,
-                    )
-
-                    // Export public key to file
-                    DropdownMenuItem(
-                        text = { Text(stringResource(R.string.pubkey_export_public)) },
-                        onClick = {
-                            showMenu = false
-                            onExportPublicKey()
-                        },
-                        leadingIcon = {
-                            Icon(Icons.Default.FileDownload, null)
-                        },
-                        enabled = !isImported,
-                    )
-
-                    // Copy private key in OpenSSH format (not available for Keystore keys)
-                    DropdownMenuItem(
-                        text = {
-                            Text(
-                                stringResource(
-                                    if (isImported) {
-                                        R.string.pubkey_copy_private
-                                    } else {
-                                        R.string.pubkey_copy_private_openssh
-                                    },
-                                ),
+                val iconModifier = when {
+                    isLoaded ->
+                        Modifier
+                            .padding(2.dp)
+                            .border(
+                                width = 2.dp, // Border thickness
+                                color = Color.Green, // Border color
+                                shape = CircleShape, // Makes the border a circle
                             )
-                        },
-                        onClick = {
-                            showMenu = false
-                            onCopyPrivateKeyOpenSSH { _, callback ->
-                                passwordCallback = callback
-                                showPasswordDialog = true
-                            }
-                        },
-                        leadingIcon = {
-                            Icon(Icons.Default.ContentCopy, null)
-                        },
-                        enabled = !pubkey.isBiometric,
-                    )
+                            .clip(CircleShape)
+                            .padding(4.dp)
 
-                    // Copy private key in PEM format (for non-imported keys)
-                    if (!isImported) {
+                    else -> Modifier.padding(2.dp).clip(CircleShape).padding(4.dp)
+                }
+
+                Box(
+                    modifier = iconModifier,
+                ) {
+                    Icon(
+                        imageVector = icon,
+                        contentDescription = when {
+                            pubkey.isBiometric -> stringResource(R.string.pubkey_biometric_description_icon)
+                            pubkey.encrypted -> stringResource(R.string.pubkey_encrypted_description)
+                            else -> stringResource(R.string.pubkey_not_encrypted_description)
+                        },
+                    )
+                }
+            },
+            trailingContent = {
+                Box {
+                    IconButton(onClick = { showMenu = true }) {
+                        Icon(Icons.Default.MoreVert, stringResource(R.string.button_more_options))
+                    }
+                    DropdownMenu(
+                        expanded = showMenu,
+                        onDismissRequest = { showMenu = false },
+                    ) {
+                        // Edit key
                         DropdownMenuItem(
-                            text = { Text(stringResource(R.string.pubkey_copy_private_pem)) },
+                            text = {
+                                Text(stringResource(R.string.list_pubkey_edit))
+                            },
                             onClick = {
                                 showMenu = false
-                                onCopyPrivateKeyPem { _, callback ->
+                                onEdit()
+                            },
+                            leadingIcon = {
+                                Icon(Icons.Default.Edit, null)
+                            },
+                        )
+
+                        // Copy public key
+                        val isImported = pubkey.type == "IMPORTED"
+                        DropdownMenuItem(
+                            text = { Text(stringResource(R.string.pubkey_copy_public)) },
+                            onClick = {
+                                showMenu = false
+                                onCopyPublicKey()
+                            },
+                            leadingIcon = {
+                                Icon(Icons.Default.ContentCopy, null)
+                            },
+                            enabled = !isImported,
+                        )
+
+                        // Export public key to file
+                        DropdownMenuItem(
+                            text = { Text(stringResource(R.string.pubkey_export_public)) },
+                            onClick = {
+                                showMenu = false
+                                onExportPublicKey()
+                            },
+                            leadingIcon = {
+                                Icon(Icons.Default.FileDownload, null)
+                            },
+                            enabled = !isImported,
+                        )
+
+                        // Copy private key in OpenSSH format (not available for Keystore keys)
+                        DropdownMenuItem(
+                            text = {
+                                Text(
+                                    stringResource(
+                                        if (isImported) {
+                                            R.string.pubkey_copy_private
+                                        } else {
+                                            R.string.pubkey_copy_private_openssh
+                                        },
+                                    ),
+                                )
+                            },
+                            onClick = {
+                                showMenu = false
+                                onCopyPrivateKeyOpenSSH { _, callback ->
                                     passwordCallback = callback
                                     showPasswordDialog = true
                                 }
@@ -613,65 +597,65 @@ private fun PubkeyListItem(
                             },
                             enabled = !pubkey.isBiometric,
                         )
-                    }
 
-                    // Copy private key encrypted (for non-imported keys)
-                    if (!isImported) {
-                        DropdownMenuItem(
-                            text = { Text(stringResource(R.string.pubkey_copy_private_encrypted)) },
-                            onClick = {
-                                showMenu = false
-                                onCopyPrivateKeyEncrypt(
-                                    { _, callback ->
+                        // Copy private key in PEM format (for non-imported keys)
+                        if (!isImported) {
+                            DropdownMenuItem(
+                                text = { Text(stringResource(R.string.pubkey_copy_private_pem)) },
+                                onClick = {
+                                    showMenu = false
+                                    onCopyPrivateKeyPem { _, callback ->
                                         passwordCallback = callback
                                         showPasswordDialog = true
-                                    },
-                                    { _, callback ->
-                                        exportPassphraseCallback = callback
-                                        showExportPassphraseDialog = true
-                                    },
+                                    }
+                                },
+                                leadingIcon = {
+                                    Icon(Icons.Default.ContentCopy, null)
+                                },
+                                enabled = !pubkey.isBiometric,
+                            )
+                        }
+
+                        // Copy private key encrypted (for non-imported keys)
+                        if (!isImported) {
+                            DropdownMenuItem(
+                                text = { Text(stringResource(R.string.pubkey_copy_private_encrypted)) },
+                                onClick = {
+                                    showMenu = false
+                                    onCopyPrivateKeyEncrypt(
+                                        { _, callback ->
+                                            passwordCallback = callback
+                                            showPasswordDialog = true
+                                        },
+                                        { _, callback ->
+                                            exportPassphraseCallback = callback
+                                            showExportPassphraseDialog = true
+                                        },
+                                    )
+                                },
+                                leadingIcon = {
+                                    Icon(Icons.Default.Lock, null)
+                                },
+                                enabled = !pubkey.isBiometric,
+                            )
+                        }
+
+                        // Export private key to file in OpenSSH format
+                        DropdownMenuItem(
+                            text = {
+                                Text(
+                                    stringResource(
+                                        if (isImported) {
+                                            R.string.pubkey_export_private
+                                        } else {
+                                            R.string.pubkey_export_private_openssh
+                                        },
+                                    ),
                                 )
                             },
-                            leadingIcon = {
-                                Icon(Icons.Default.Lock, null)
-                            },
-                            enabled = !pubkey.isBiometric,
-                        )
-                    }
-
-                    // Export private key to file in OpenSSH format
-                    DropdownMenuItem(
-                        text = {
-                            Text(
-                                stringResource(
-                                    if (isImported) {
-                                        R.string.pubkey_export_private
-                                    } else {
-                                        R.string.pubkey_export_private_openssh
-                                    },
-                                ),
-                            )
-                        },
-                        onClick = {
-                            showMenu = false
-                            onExportPrivateKeyOpenSSH { _, callback ->
-                                passwordCallback = callback
-                                showPasswordDialog = true
-                            }
-                        },
-                        leadingIcon = {
-                            Icon(Icons.Default.FileDownload, null)
-                        },
-                        enabled = !pubkey.isBiometric,
-                    )
-
-                    // Export private key to file in PEM format (for non-imported keys)
-                    if (!isImported) {
-                        DropdownMenuItem(
-                            text = { Text(stringResource(R.string.pubkey_export_private_pem)) },
                             onClick = {
                                 showMenu = false
-                                onExportPrivateKeyPem { _, callback ->
+                                onExportPrivateKeyOpenSSH { _, callback ->
                                     passwordCallback = callback
                                     showPasswordDialog = true
                                 }
@@ -681,99 +665,117 @@ private fun PubkeyListItem(
                             },
                             enabled = !pubkey.isBiometric,
                         )
-                    }
 
-                    // Export private key to file with encryption (for non-imported keys)
-                    if (!isImported) {
-                        DropdownMenuItem(
-                            text = { Text(stringResource(R.string.pubkey_export_private_encrypted)) },
-                            onClick = {
-                                showMenu = false
-                                onExportPrivateKeyEncrypt(
-                                    { _, callback ->
+                        // Export private key to file in PEM format (for non-imported keys)
+                        if (!isImported) {
+                            DropdownMenuItem(
+                                text = { Text(stringResource(R.string.pubkey_export_private_pem)) },
+                                onClick = {
+                                    showMenu = false
+                                    onExportPrivateKeyPem { _, callback ->
                                         passwordCallback = callback
                                         showPasswordDialog = true
-                                    },
-                                    { _, callback ->
-                                        exportPassphraseCallback = callback
-                                        showExportPassphraseDialog = true
-                                    },
-                                )
+                                    }
+                                },
+                                leadingIcon = {
+                                    Icon(Icons.Default.FileDownload, null)
+                                },
+                                enabled = !pubkey.isBiometric,
+                            )
+                        }
+
+                        // Export private key to file with encryption (for non-imported keys)
+                        if (!isImported) {
+                            DropdownMenuItem(
+                                text = { Text(stringResource(R.string.pubkey_export_private_encrypted)) },
+                                onClick = {
+                                    showMenu = false
+                                    onExportPrivateKeyEncrypt(
+                                        { _, callback ->
+                                            passwordCallback = callback
+                                            showPasswordDialog = true
+                                        },
+                                        { _, callback ->
+                                            exportPassphraseCallback = callback
+                                            showExportPassphraseDialog = true
+                                        },
+                                    )
+                                },
+                                leadingIcon = {
+                                    Icon(Icons.Default.Lock, null)
+                                },
+                                enabled = !pubkey.isBiometric,
+                            )
+                        }
+
+                        // Delete
+                        DropdownMenuItem(
+                            text = { Text(stringResource(R.string.pubkey_delete)) },
+                            onClick = {
+                                showMenu = false
+                                showDeleteDialog = true
                             },
                             leadingIcon = {
-                                Icon(Icons.Default.Lock, null)
+                                Icon(Icons.Default.Delete, null)
                             },
-                            enabled = !pubkey.isBiometric,
                         )
                     }
-
-                    // Delete
-                    DropdownMenuItem(
-                        text = { Text(stringResource(R.string.pubkey_delete)) },
-                        onClick = {
-                            showMenu = false
-                            showDeleteDialog = true
-                        },
-                        leadingIcon = {
-                            Icon(Icons.Default.Delete, null)
-                        },
-                    )
                 }
-            }
-        },
-        modifier = modifier.clickable {
-            onClick { targetPubkey, callback ->
-                // Show password dialog if needed
-                passwordCallback = callback
-                showPasswordDialog = true
-            }
-        },
-    )
-    HorizontalDivider()
-
-    // Password dialog for unlocking key
-    if (showPasswordDialog && passwordCallback != null) {
-        PubkeyPasswordDialog(
-            pubkey = pubkey,
-            onDismiss = {
-                showPasswordDialog = false
-                passwordCallback = null
             },
-            onProvidePassword = { password ->
-                passwordCallback?.invoke(password)
-                showPasswordDialog = false
-                passwordCallback = null
+            modifier = Modifier.clickable {
+                onClick { _, callback ->
+                    // Show password dialog if needed
+                    passwordCallback = callback
+                    showPasswordDialog = true
+                }
             },
         )
-    }
+        HorizontalDivider()
 
-    // Delete confirmation dialog
-    if (showDeleteDialog) {
-        PubkeyDeleteDialog(
-            pubkey = pubkey,
-            onDismiss = {
-                showDeleteDialog = false
-            },
-            onConfirm = {
-                showDeleteDialog = false
-                onDelete()
-            },
-        )
-    }
+        // Password dialog for unlocking key
+        if (showPasswordDialog && passwordCallback != null) {
+            PubkeyPasswordDialog(
+                pubkey = pubkey,
+                onDismiss = {
+                    showPasswordDialog = false
+                    passwordCallback = null
+                },
+                onProvidePassword = { password ->
+                    passwordCallback?.invoke(password)
+                    showPasswordDialog = false
+                    passwordCallback = null
+                },
+            )
+        }
 
-    // Export passphrase dialog
-    if (showExportPassphraseDialog && exportPassphraseCallback != null) {
-        ExportPassphraseDialog(
-            onDismiss = {
-                showExportPassphraseDialog = false
-                exportPassphraseCallback = null
-            },
-            onProvidePassphrase = { passphrase ->
-                exportPassphraseCallback?.invoke(passphrase)
-                showExportPassphraseDialog = false
-                exportPassphraseCallback = null
-            },
-        )
+        // Delete confirmation dialog
+        if (showDeleteDialog) {
+            PubkeyDeleteDialog(
+                pubkey = pubkey,
+                onDismiss = {
+                    showDeleteDialog = false
+                },
+                onConfirm = {
+                    showDeleteDialog = false
+                    onDelete()
+                },
+            )
+        }
+
+        // Export passphrase dialog
+        if (showExportPassphraseDialog && exportPassphraseCallback != null) {
+            ExportPassphraseDialog(
+                onDismiss = {
+                    showExportPassphraseDialog = false
+                    exportPassphraseCallback = null
+                },
+                onProvidePassphrase = { passphrase ->
+                    exportPassphraseCallback?.invoke(passphrase)
+                    showExportPassphraseDialog = false
+                    exportPassphraseCallback = null
+                },
+            )
+        }
     }
 }
 
@@ -853,7 +855,7 @@ private fun PubkeyDeleteDialog(
 private fun NicknameConfirmationDialog(
     initialNickname: String,
     onDismiss: () -> Unit,
-    onConfirm: (String) -> Unit
+    onConfirm: (String) -> Unit,
 ) {
     var nickname by rememberSaveable { mutableStateOf(initialNickname) }
 
@@ -866,13 +868,13 @@ private fun NicknameConfirmationDialog(
                 onValueChange = { nickname = it },
                 label = { Text(stringResource(R.string.prompt_nickname)) },
                 modifier = Modifier.fillMaxWidth(),
-                singleLine = true
+                singleLine = true,
             )
         },
         confirmButton = {
             TextButton(
                 onClick = { onConfirm(nickname) },
-                enabled = nickname.isNotBlank()
+                enabled = nickname.isNotBlank(),
             ) {
                 Text(stringResource(R.string.portforward_save))
             }
@@ -881,7 +883,7 @@ private fun NicknameConfirmationDialog(
             TextButton(onClick = onDismiss) {
                 Text(stringResource(android.R.string.cancel))
             }
-        }
+        },
     )
 }
 

--- a/app/src/main/java/org/connectbot/ui/screens/pubkeylist/PubkeyListScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/pubkeylist/PubkeyListScreen.kt
@@ -29,11 +29,11 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
@@ -218,9 +218,9 @@ fun PubkeyListScreen(
     if (showClipboardImportDialog) {
         ImportFromClipboardDialog(
             onDismiss = { showClipboardImportDialog = false },
-            onImport = { keyText, nickname ->
+            onImport = { keyText ->
                 showClipboardImportDialog = false
-                viewModel.importKeyFromText(keyText, nickname)
+                viewModel.importKeyFromText(keyText, "clipboard-key")
             },
         )
     }
@@ -1015,10 +1015,9 @@ private fun ImportPasswordDialog(
 @Composable
 private fun ImportFromClipboardDialog(
     onDismiss: () -> Unit,
-    onImport: (keyText: String, nickname: String) -> Unit,
+    onImport: (String) -> Unit,
 ) {
     val context = LocalContext.current
-    var nickname by rememberSaveable { mutableStateOf("clipboard-key") }
     var keyText by rememberSaveable { mutableStateOf("") }
 
     AlertDialog(
@@ -1026,44 +1025,34 @@ private fun ImportFromClipboardDialog(
         icon = { Icon(Icons.Default.ContentPaste, contentDescription = null) },
         title = { Text(stringResource(R.string.pubkey_import_from_clipboard)) },
         text = {
-            Column {
-                OutlinedTextField(
-                    value = nickname,
-                    onValueChange = { nickname = it },
-                    label = { Text(stringResource(R.string.prompt_nickname)) },
-                    modifier = Modifier.fillMaxWidth(),
-                    singleLine = true,
-                )
-                Spacer(modifier = Modifier.height(8.dp))
-                OutlinedTextField(
-                    value = keyText,
-                    onValueChange = { keyText = it },
-                    label = { Text(stringResource(R.string.pubkey_import_clipboard_key_label)) },
-                    trailingIcon = {
-                        IconButton(
-                            onClick = {
-                                val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE)
-                                        as android.content.ClipboardManager
-                                keyText = clipboard.primaryClip?.getItemAt(0)?.text?.toString() ?: keyText
-                            },
-                        ) {
-                            Icon(
-                                Icons.Default.ContentPaste,
-                                contentDescription = stringResource(R.string.pubkey_paste_from_clipboard),
-                            )
-                        }
-                    },
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(200.dp),
-                    minLines = 5,
-                )
-            }
+            OutlinedTextField(
+                value = keyText,
+                onValueChange = { keyText = it },
+                label = { Text(stringResource(R.string.pubkey_import_clipboard_key_label)) },
+                trailingIcon = {
+                    IconButton(
+                        onClick = {
+                            val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE)
+                                as android.content.ClipboardManager
+                            keyText = clipboard.primaryClip?.getItemAt(0)?.text?.toString() ?: keyText
+                        },
+                    ) {
+                        Icon(
+                            Icons.Default.ContentPaste,
+                            contentDescription = stringResource(R.string.pubkey_paste_from_clipboard),
+                        )
+                    }
+                },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(200.dp),
+                minLines = 5,
+            )
         },
         confirmButton = {
             TextButton(
-                onClick = { onImport(keyText, nickname) },
-                enabled = keyText.isNotBlank() && nickname.isNotBlank(),
+                onClick = { onImport(keyText) },
+                enabled = keyText.isNotBlank(),
             ) {
                 Text(stringResource(R.string.pubkey_import_button))
             }

--- a/app/src/main/java/org/connectbot/ui/screens/pubkeylist/PubkeyListScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/pubkeylist/PubkeyListScreen.kt
@@ -17,6 +17,7 @@
 
 package org.connectbot.ui.screens.pubkeylist
 
+import android.content.Context
 import android.net.Uri
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
@@ -30,6 +31,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -40,6 +42,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material.icons.filled.ContentPaste
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.FileDownload
@@ -209,6 +212,18 @@ fun PubkeyListScreen(
         }
     }
 
+    // Dialog for importing keys from clipboard text
+    var showClipboardImportDialog by rememberSaveable { mutableStateOf(false) }
+    if (showClipboardImportDialog) {
+        ImportFromClipboardDialog(
+            onDismiss = { showClipboardImportDialog = false },
+            onImport = { keyText ->
+                showClipboardImportDialog = false
+                viewModel.importKeyFromText(keyText)
+            }
+        )
+    }
+
     // Password dialog for importing encrypted keys
     val pendingImport = uiState.pendingImport
     if (pendingImport != null) {
@@ -253,6 +268,7 @@ fun PubkeyListScreen(
         onImportKey = {
             filePickerLauncher.launch(arrayOf("*/*"))
         },
+        onImportKeyFromClipboard = { showClipboardImportDialog = true },
         modifier = modifier,
     )
 }
@@ -276,6 +292,7 @@ fun PubkeyListScreenContent(
     onExportPrivateKeyPem: (Pubkey, (Pubkey, (String) -> Unit) -> Unit) -> Unit,
     onExportPrivateKeyEncrypt: (Pubkey, (Pubkey, (String) -> Unit) -> Unit, (Pubkey, (String) -> Unit) -> Unit) -> Unit,
     onImportKey: () -> Unit,
+    onImportKeyFromClipboard: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     var fabMenuExpanded by rememberSaveable { mutableStateOf(false) }
@@ -330,6 +347,14 @@ fun PubkeyListScreenContent(
                     },
                     icon = { Icon(Icons.Default.FileOpen, contentDescription = null) },
                     text = { Text(stringResource(R.string.pubkey_import_existing)) },
+                )
+                FloatingActionButtonMenuItem(
+                    onClick = {
+                        fabMenuExpanded = false
+                        onImportKeyFromClipboard()
+                    },
+                    icon = { Icon(Icons.Default.ContentPaste, contentDescription = null) },
+                    text = { Text(stringResource(R.string.pubkey_import_from_clipboard)) },
                 )
             }
         },
@@ -932,6 +957,59 @@ private fun ImportPasswordDialog(
 }
 
 @Composable
+private fun ImportFromClipboardDialog(
+    onDismiss: () -> Unit,
+    onImport: (String) -> Unit,
+) {
+    val context = LocalContext.current
+    var keyText by rememberSaveable { mutableStateOf("") }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        icon = { Icon(Icons.Default.ContentPaste, contentDescription = null) },
+        title = { Text(stringResource(R.string.pubkey_import_from_clipboard)) },
+        text = {
+            OutlinedTextField(
+                value = keyText,
+                onValueChange = { keyText = it },
+                label = { Text(stringResource(R.string.pubkey_import_clipboard_key_label)) },
+                trailingIcon = {
+                    IconButton(
+                        onClick = {
+                            val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE)
+                                    as android.content.ClipboardManager
+                            keyText = clipboard.primaryClip?.getItemAt(0)?.text?.toString() ?: keyText
+                        },
+                    ) {
+                        Icon(
+                            Icons.Default.ContentPaste,
+                            contentDescription = stringResource(R.string.pubkey_paste_from_clipboard),
+                        )
+                    }
+                },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(200.dp),
+                minLines = 5,
+            )
+        },
+        confirmButton = {
+            TextButton(
+                onClick = { onImport(keyText) },
+                enabled = keyText.isNotBlank(),
+            ) {
+                Text(stringResource(R.string.pubkey_import_button))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(android.R.string.cancel))
+            }
+        },
+    )
+}
+
+@Composable
 private fun ExportPassphraseDialog(
     onDismiss: () -> Unit,
     onProvidePassphrase: (String) -> Unit,
@@ -1032,6 +1110,7 @@ private fun PubkeyListScreenEmptyPreview() {
             onExportPrivateKeyPem = { _, _ -> },
             onExportPrivateKeyEncrypt = { _, _, _ -> },
             onImportKey = {},
+            onImportKeyFromClipboard = {},
         )
     }
 }
@@ -1060,6 +1139,7 @@ private fun PubkeyListScreenLoadingPreview() {
             onExportPrivateKeyPem = { _, _ -> },
             onExportPrivateKeyEncrypt = { _, _, _ -> },
             onImportKey = {},
+            onImportKeyFromClipboard = {},
         )
     }
 }
@@ -1123,6 +1203,7 @@ private fun PubkeyListScreenPopulatedPreview() {
             onExportPrivateKeyPem = { _, _ -> },
             onExportPrivateKeyEncrypt = { _, _, _ -> },
             onImportKey = {},
+            onImportKeyFromClipboard = {},
         )
     }
 }

--- a/app/src/main/java/org/connectbot/ui/screens/pubkeylist/PubkeyListScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/pubkeylist/PubkeyListScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
@@ -217,10 +218,20 @@ fun PubkeyListScreen(
     if (showClipboardImportDialog) {
         ImportFromClipboardDialog(
             onDismiss = { showClipboardImportDialog = false },
-            onImport = { keyText ->
+            onImport = { keyText, nickname ->
                 showClipboardImportDialog = false
-                viewModel.importKeyFromText(keyText)
-            }
+                viewModel.importKeyFromText(keyText, nickname)
+            },
+        )
+    }
+
+    // Nickname confirmation dialog for unencrypted file imports
+    val pendingNicknameConfirmation = uiState.pendingNicknameConfirmation
+    if (pendingNicknameConfirmation != null) {
+        NicknameConfirmationDialog(
+            initialNickname = pendingNicknameConfirmation.nickname,
+            onDismiss = { viewModel.cancelImportNickname() },
+            onConfirm = { nickname -> viewModel.confirmImportNickname(nickname) },
         )
     }
 
@@ -229,10 +240,10 @@ fun PubkeyListScreen(
     if (pendingImport != null) {
         ImportPasswordDialog(
             keyType = pendingImport.keyType,
-            nickname = pendingImport.nickname,
+            initialNickname = pendingImport.nickname,
             onDismiss = { viewModel.cancelImport() },
-            onImport = { decryptPassword, encrypt, encryptPassword ->
-                viewModel.completeImportWithPassword(decryptPassword, encrypt, encryptPassword)
+            onImport = { nickname, decryptPassword, encrypt, encryptPassword ->
+                viewModel.completeImportWithPassword(nickname, decryptPassword, encrypt, encryptPassword)
             },
         )
     }
@@ -839,19 +850,56 @@ private fun PubkeyDeleteDialog(
 }
 
 @Composable
+private fun NicknameConfirmationDialog(
+    initialNickname: String,
+    onDismiss: () -> Unit,
+    onConfirm: (String) -> Unit
+) {
+    var nickname by rememberSaveable { mutableStateOf(initialNickname) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.pubkey_import_button)) },
+        text = {
+            OutlinedTextField(
+                value = nickname,
+                onValueChange = { nickname = it },
+                label = { Text(stringResource(R.string.prompt_nickname)) },
+                modifier = Modifier.fillMaxWidth(),
+                singleLine = true
+            )
+        },
+        confirmButton = {
+            TextButton(
+                onClick = { onConfirm(nickname) },
+                enabled = nickname.isNotBlank()
+            ) {
+                Text(stringResource(R.string.portforward_save))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(android.R.string.cancel))
+            }
+        }
+    )
+}
+
+@Composable
 private fun ImportPasswordDialog(
     keyType: String,
-    nickname: String,
+    initialNickname: String,
     onDismiss: () -> Unit,
-    onImport: (decryptPassword: String, encrypt: Boolean, encryptPassword: String?) -> Unit,
+    onImport: (nickname: String, decryptPassword: String, encrypt: Boolean, encryptPassword: String?) -> Unit,
 ) {
+    var nickname by rememberSaveable { mutableStateOf(initialNickname) }
     var password by remember { mutableStateOf("") }
     var encryptKey by remember { mutableStateOf(true) }
     var reusePassword by remember { mutableStateOf(true) }
     var newPassword by remember { mutableStateOf("") }
     var confirmPassword by remember { mutableStateOf("") }
 
-    val canImport = password.isNotEmpty() && (
+    val canImport = nickname.isNotBlank() && password.isNotEmpty() && (
         !encryptKey ||
             reusePassword ||
             (newPassword.isNotEmpty() && newPassword == confirmPassword)
@@ -864,9 +912,17 @@ private fun ImportPasswordDialog(
         text = {
             Column {
                 Text(
-                    text = stringResource(R.string.pubkey_import_encrypted_message, nickname, keyType),
+                    text = stringResource(R.string.pubkey_import_encrypted_message, initialNickname, keyType),
                     modifier = Modifier.padding(bottom = 16.dp),
                 )
+                OutlinedTextField(
+                    value = nickname,
+                    onValueChange = { nickname = it },
+                    label = { Text(stringResource(R.string.prompt_nickname)) },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true,
+                )
+                Spacer(modifier = Modifier.height(8.dp))
                 OutlinedTextField(
                     value = password,
                     onValueChange = { password = it },
@@ -941,7 +997,7 @@ private fun ImportPasswordDialog(
                         reusePassword -> password
                         else -> newPassword
                     }
-                    onImport(password, encryptKey, encryptPassword)
+                    onImport(nickname, password, encryptKey, encryptPassword)
                 },
                 enabled = canImport,
             ) {
@@ -959,9 +1015,10 @@ private fun ImportPasswordDialog(
 @Composable
 private fun ImportFromClipboardDialog(
     onDismiss: () -> Unit,
-    onImport: (String) -> Unit,
+    onImport: (keyText: String, nickname: String) -> Unit,
 ) {
     val context = LocalContext.current
+    var nickname by rememberSaveable { mutableStateOf("clipboard-key") }
     var keyText by rememberSaveable { mutableStateOf("") }
 
     AlertDialog(
@@ -969,34 +1026,44 @@ private fun ImportFromClipboardDialog(
         icon = { Icon(Icons.Default.ContentPaste, contentDescription = null) },
         title = { Text(stringResource(R.string.pubkey_import_from_clipboard)) },
         text = {
-            OutlinedTextField(
-                value = keyText,
-                onValueChange = { keyText = it },
-                label = { Text(stringResource(R.string.pubkey_import_clipboard_key_label)) },
-                trailingIcon = {
-                    IconButton(
-                        onClick = {
-                            val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE)
-                                    as android.content.ClipboardManager
-                            keyText = clipboard.primaryClip?.getItemAt(0)?.text?.toString() ?: keyText
-                        },
-                    ) {
-                        Icon(
-                            Icons.Default.ContentPaste,
-                            contentDescription = stringResource(R.string.pubkey_paste_from_clipboard),
-                        )
-                    }
-                },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(200.dp),
-                minLines = 5,
-            )
+            Column {
+                OutlinedTextField(
+                    value = nickname,
+                    onValueChange = { nickname = it },
+                    label = { Text(stringResource(R.string.prompt_nickname)) },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true,
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                OutlinedTextField(
+                    value = keyText,
+                    onValueChange = { keyText = it },
+                    label = { Text(stringResource(R.string.pubkey_import_clipboard_key_label)) },
+                    trailingIcon = {
+                        IconButton(
+                            onClick = {
+                                val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE)
+                                        as android.content.ClipboardManager
+                                keyText = clipboard.primaryClip?.getItemAt(0)?.text?.toString() ?: keyText
+                            },
+                        ) {
+                            Icon(
+                                Icons.Default.ContentPaste,
+                                contentDescription = stringResource(R.string.pubkey_paste_from_clipboard),
+                            )
+                        }
+                    },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(200.dp),
+                    minLines = 5,
+                )
+            }
         },
         confirmButton = {
             TextButton(
-                onClick = { onImport(keyText) },
-                enabled = keyText.isNotBlank(),
+                onClick = { onImport(keyText, nickname) },
+                enabled = keyText.isNotBlank() && nickname.isNotBlank(),
             ) {
                 Text(stringResource(R.string.pubkey_import_button))
             }

--- a/app/src/main/java/org/connectbot/ui/screens/pubkeylist/PubkeyListViewModel.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/pubkeylist/PubkeyListViewModel.kt
@@ -94,6 +94,8 @@ data class PubkeyListUiState(
     val pendingPublicKeyExport: PendingPublicKeyExport? = null,
     // Key pending import that needs password (triggers password dialog in UI)
     val pendingImport: PendingImport? = null,
+    // Successfully parsed key awaiting nickname confirmation before saving
+    val pendingNicknameConfirmation: Pubkey? = null,
 )
 
 @HiltViewModel
@@ -724,11 +726,11 @@ class PubkeyListViewModel @Inject constructor(
         }
     }
 
-    fun importKeyFromText(keyText: String) {
+    fun importKeyFromText(keyText: String, nickname: String) {
         viewModelScope.launch {
             try {
                 val result = withContext(dispatchers.default) {
-                    parseKeyBytes(keyText.toByteArray(Charsets.UTF_8), "clipboard-key")
+                    parseKeyBytes(keyText.toByteArray(Charsets.UTF_8), nickname)
                 }
                 handleImportResult(result, "Failed to parse key from clipboard")
             } catch (e: Exception) {
@@ -743,8 +745,8 @@ class PubkeyListViewModel @Inject constructor(
     private fun handleImportResult(result: ImportResult, failureMessage: String) {
         when (result) {
             is ImportResult.Success -> {
-                viewModelScope.launch {
-                    repository.save(result.pubkey)
+                _uiState.update {
+                    it.copy(pendingNicknameConfirmation = result.pubkey)
                 }
             }
 
@@ -768,19 +770,32 @@ class PubkeyListViewModel @Inject constructor(
         }
     }
 
+    fun confirmImportNickname(nickname: String) {
+        val pubkey = _uiState.value.pendingNicknameConfirmation ?: return
+        viewModelScope.launch {
+            repository.save(pubkey.copy(nickname = nickname))
+            _uiState.update { it.copy(pendingNicknameConfirmation = null) }
+        }
+    }
+
+    fun cancelImportNickname() {
+        _uiState.update { it.copy(pendingNicknameConfirmation = null) }
+    }
+
     /**
      * Complete the import of an encrypted key with the provided password.
+     * @param nickname Nickname to save the key under
      * @param decryptPassword Password to decrypt the imported key
      * @param encrypt Whether to encrypt the key for storage
      * @param encryptPassword Password to use for encryption (null if not encrypting)
      */
-    fun completeImportWithPassword(decryptPassword: String, encrypt: Boolean, encryptPassword: String?) {
+    fun completeImportWithPassword(nickname: String, decryptPassword: String, encrypt: Boolean, encryptPassword: String?) {
         val pending = _uiState.value.pendingImport ?: return
 
         viewModelScope.launch {
             try {
                 val pubkey = withContext(dispatchers.io) {
-                    decryptAndImportKey(pending.keyData, pending.nickname, decryptPassword, encrypt, encryptPassword)
+                    decryptAndImportKey(pending.keyData, nickname, decryptPassword, encrypt, encryptPassword)
                 }
 
                 if (pubkey != null) {

--- a/app/src/main/java/org/connectbot/ui/screens/pubkeylist/PubkeyListViewModel.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/pubkeylist/PubkeyListViewModel.kt
@@ -714,35 +714,55 @@ class PubkeyListViewModel @Inject constructor(
                 val result = withContext(dispatchers.io) {
                     readKeyFromUri(uri)
                 }
-
-                when (result) {
-                    is ImportResult.Success -> {
-                        repository.save(result.pubkey)
-                    }
-
-                    is ImportResult.NeedsPassword -> {
-                        // Set pending import - UI will show password dialog
-                        _uiState.update {
-                            it.copy(
-                                pendingImport = PendingImport(
-                                    keyData = result.keyData,
-                                    nickname = result.nickname,
-                                    keyType = result.keyType,
-                                ),
-                            )
-                        }
-                    }
-
-                    is ImportResult.Failed -> {
-                        _uiState.update {
-                            it.copy(error = "Failed to parse key file")
-                        }
-                    }
-                }
+                handleImportResult(result, "Failed to parse key file")
             } catch (e: Exception) {
                 Timber.e(e, "Failed to import key")
                 _uiState.update {
                     it.copy(error = "Failed to import key: ${e.message}")
+                }
+            }
+        }
+    }
+
+    fun importKeyFromText(keyText: String) {
+        viewModelScope.launch {
+            try {
+                val result = withContext(dispatchers.default) {
+                    parseKeyBytes(keyText.toByteArray(Charsets.UTF_8), "clipboard-key")
+                }
+                handleImportResult(result, "Failed to parse key from clipboard")
+            } catch (e: Exception) {
+                Timber.e(e, "Failed to import key from clipboard")
+                _uiState.update {
+                    it.copy(error = "Failed to import key from clipboard: ${e.message}")
+                }
+            }
+        }
+    }
+
+    private fun handleImportResult(result: ImportResult, failureMessage: String) {
+        when (result) {
+            is ImportResult.Success -> {
+                viewModelScope.launch {
+                    repository.save(result.pubkey)
+                }
+            }
+
+            is ImportResult.NeedsPassword -> {
+                _uiState.update {
+                    it.copy(
+                        pendingImport = PendingImport(
+                            keyData = result.keyData,
+                            nickname = result.nickname,
+                            keyType = result.keyType,
+                        ),
+                    )
+                }
+            }
+
+            is ImportResult.Failed -> {
+                _uiState.update {
+                    it.copy(error = failureMessage)
                 }
             }
         }
@@ -864,6 +884,10 @@ class PubkeyListViewModel @Inject constructor(
             return ImportResult.Failed
         }
 
+        return parseKeyBytes(keyData, nickname)
+    }
+
+    private fun parseKeyBytes(keyData: ByteArray, nickname: String): ImportResult {
         val keyString = String(keyData)
 
         // Try to parse using PEMDecoder first (handles OpenSSH, traditional PEM formats)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1124,6 +1124,12 @@
 	<string name="hostpref_setting_title">Host setting</string>
 	<!-- Text for button which, when clicked, brings up picker to import an existing pubkey. -->
 	<string name="pubkey_import_existing">Import existing pubkey</string>
+	<!-- Text for button which, when clicked, imports a pubkey from the clipboard. -->
+	<string name="pubkey_import_from_clipboard">Import from clipboard</string>
+	<!-- Label for the key content text field in the import-from-clipboard dialog. -->
+	<string name="pubkey_import_clipboard_key_label">Private key content</string>
+	<!-- Content description for the paste button in the import-from-clipboard dialog. -->
+	<string name="pubkey_paste_from_clipboard">Paste from clipboard</string>
 
 	<!-- Title for notification permission dialog shown when user first tries to connect to a host.
 	     Explains that notifications keep SSH connections alive. -->

--- a/app/src/test/java/org/connectbot/ui/screens/pubkeylist/PubkeyListViewModelTest.kt
+++ b/app/src/test/java/org/connectbot/ui/screens/pubkeylist/PubkeyListViewModelTest.kt
@@ -366,6 +366,139 @@ class PubkeyListViewModelTest {
         assertNull("Error should be cleared", viewModel.uiState.value.error)
     }
 
+    // ========== Tests for importKeyFromText ==========
+
+    /**
+     * Tests importing an unencrypted PEM key from text.
+     *
+     * Scenario: User pastes an unencrypted private key into the clipboard import dialog.
+     * Expected: Key is parsed successfully and pendingNicknameConfirmation is set.
+     */
+    @Test
+    fun importKeyFromText_WithUnencryptedPemKey_SetsPendingNicknameConfirmation() = runTest {
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.importKeyFromText(testUnencryptedPemKey, "my-key")
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertNotNull("Should have pending nickname confirmation", state.pendingNicknameConfirmation)
+        assertEquals("Nickname should match", "my-key", state.pendingNicknameConfirmation?.nickname)
+        assertEquals("Type should be RSA", "RSA", state.pendingNicknameConfirmation?.type)
+        assertFalse("Key should not be encrypted", state.pendingNicknameConfirmation?.encrypted ?: true)
+        assertNull("Should have no pending import", state.pendingImport)
+        assertNull("Should have no error", state.error)
+    }
+
+    /**
+     * Tests importing an encrypted PEM key from text.
+     *
+     * Scenario: User pastes an encrypted private key into the clipboard import dialog.
+     * Expected: Key is detected as encrypted and pendingImport is set for password entry.
+     */
+    @Test
+    fun importKeyFromText_WithEncryptedPemKey_SetsPendingImport() = runTest {
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.importKeyFromText(testEncryptedPemKey, "encrypted-key")
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertNotNull("Should have pending import", state.pendingImport)
+        assertEquals("Nickname should match", "encrypted-key", state.pendingImport?.nickname)
+        assertNull("Should have no pending nickname confirmation", state.pendingNicknameConfirmation)
+        assertNull("Should have no error", state.error)
+    }
+
+    /**
+     * Tests importing invalid text that is not a valid key.
+     *
+     * Scenario: User pastes random text that is not a valid private key.
+     * Expected: Import fails and error state is set.
+     */
+    @Test
+    fun importKeyFromText_WithInvalidText_SetsError() = runTest {
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.importKeyFromText("this is not a valid key", "bad-key")
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertNotNull("Should have an error", state.error)
+        assertNull("Should have no pending import", state.pendingImport)
+        assertNull("Should have no pending nickname confirmation", state.pendingNicknameConfirmation)
+        verify(repository, never()).save(any())
+    }
+
+    // ========== Tests for confirmImportNickname ==========
+
+    /**
+     * Tests confirming the nickname for a successfully parsed key.
+     *
+     * Scenario: User imports an unencrypted key and confirms its nickname in the dialog.
+     * Expected: Key is saved with the confirmed nickname and pendingNicknameConfirmation is cleared.
+     */
+    @Test
+    fun confirmImportNickname_SavesKeyWithConfirmedNickname() = runTest {
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.importKeyFromText(testUnencryptedPemKey, "my-key")
+        advanceUntilIdle()
+        assertNotNull("Should have pending confirmation", viewModel.uiState.value.pendingNicknameConfirmation)
+
+        viewModel.confirmImportNickname("confirmed-name")
+        advanceUntilIdle()
+
+        val captor = argumentCaptor<Pubkey>()
+        verify(repository).save(captor.capture())
+        assertEquals("Saved key should use confirmed nickname", "confirmed-name", captor.firstValue.nickname)
+        assertNull("pendingNicknameConfirmation should be cleared", viewModel.uiState.value.pendingNicknameConfirmation)
+    }
+
+    /**
+     * Tests that confirmImportNickname does nothing when there is no pending confirmation.
+     *
+     * Scenario: confirmImportNickname is called without a prior successful import.
+     * Expected: No action is taken and no key is saved.
+     */
+    @Test
+    fun confirmImportNickname_WithNoPendingConfirmation_DoesNothing() = runTest {
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.confirmImportNickname("some-key")
+        advanceUntilIdle()
+
+        verify(repository, never()).save(any())
+    }
+
+    // ========== Tests for cancelImportNickname ==========
+
+    /**
+     * Tests that cancelImportNickname clears the pending nickname confirmation.
+     *
+     * Scenario: User imports an unencrypted key but cancels the nickname confirmation dialog.
+     * Expected: pendingNicknameConfirmation is cleared and no key is saved.
+     */
+    @Test
+    fun cancelImportNickname_ClearsPendingNicknameConfirmation() = runTest {
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.importKeyFromText(testUnencryptedPemKey, "my-key")
+        advanceUntilIdle()
+        assertNotNull("Should have pending confirmation", viewModel.uiState.value.pendingNicknameConfirmation)
+
+        viewModel.cancelImportNickname()
+
+        assertNull("pendingNicknameConfirmation should be cleared after cancel", viewModel.uiState.value.pendingNicknameConfirmation)
+        verify(repository, never()).save(any())
+    }
+
     // ========== Helper methods ==========
 
     private fun setErrorState(viewModel: PubkeyListViewModel, error: String) {

--- a/app/src/test/java/org/connectbot/ui/screens/pubkeylist/PubkeyListViewModelTest.kt
+++ b/app/src/test/java/org/connectbot/ui/screens/pubkeylist/PubkeyListViewModelTest.kt
@@ -125,6 +125,7 @@ class PubkeyListViewModelTest {
 
         // Import with encrypt=false (don't re-encrypt for storage)
         viewModel.completeImportWithPassword(
+            nickname = "test-key",
             decryptPassword = "testpass",
             encrypt = false,
             encryptPassword = null,
@@ -160,6 +161,7 @@ class PubkeyListViewModelTest {
 
         // Import with encrypt=true and a new password
         viewModel.completeImportWithPassword(
+            nickname = "test-key",
             decryptPassword = "testpass",
             encrypt = true,
             encryptPassword = "newpassword",
@@ -193,6 +195,7 @@ class PubkeyListViewModelTest {
 
         // Import with encrypt=true, reusing the same password for encryption
         viewModel.completeImportWithPassword(
+            nickname = "test-key",
             decryptPassword = "testpass",
             encrypt = true,
             encryptPassword = "testpass", // Same as decrypt password
@@ -224,6 +227,7 @@ class PubkeyListViewModelTest {
 
         // Try to import with wrong decrypt password
         viewModel.completeImportWithPassword(
+            nickname = "test-key",
             decryptPassword = "wrongpassword",
             encrypt = false,
             encryptPassword = null,
@@ -254,6 +258,7 @@ class PubkeyListViewModelTest {
 
         // Import unencrypted key without re-encrypting
         viewModel.completeImportWithPassword(
+            nickname = "unencrypted-key",
             decryptPassword = "", // No password needed for unencrypted key
             encrypt = false,
             encryptPassword = null,
@@ -287,6 +292,7 @@ class PubkeyListViewModelTest {
 
         // Import unencrypted key but encrypt it for storage
         viewModel.completeImportWithPassword(
+            nickname = "encrypt-for-storage",
             decryptPassword = "",
             encrypt = true,
             encryptPassword = "storagepassword",
@@ -314,7 +320,7 @@ class PubkeyListViewModelTest {
         viewModel = createViewModel()
         advanceUntilIdle()
 
-        viewModel.completeImportWithPassword("password", false, null)
+        viewModel.completeImportWithPassword("any-key", "password", false, null)
         advanceUntilIdle()
 
         verify(repository, never()).save(any())


### PR DESCRIPTION
Fix #1934, #1596.
Show a dialog with a multi-line text field and a paste button so the user can review and edit key content before importing. Refactors shared key parsing into parseKeyBytes(), reused by both file and clipboard imports.