### PR TITLE
Add configurable swipe gesture key mappings

### DIFF
--- a/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.WindowInsets
@@ -84,6 +85,7 @@ import androidx.compose.ui.input.key.isShiftPressed
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
@@ -116,6 +118,7 @@ import org.connectbot.ui.components.TERMINAL_KEYBOARD_HEIGHT_DP
 import org.connectbot.ui.components.TerminalKeyboard
 import org.connectbot.ui.components.UrlScanDialog
 import org.connectbot.util.PreferenceConstants
+import org.connectbot.util.SwipeKeySequenceParser
 import org.connectbot.util.rememberTerminalTypefaceResultFromStoredValue
 import timber.log.Timber
 
@@ -159,6 +162,12 @@ fun ConsoleScreen(
     var fullscreen by remember { mutableStateOf(prefs.getBoolean("fullscreen", false)) }
     var titleBarHide by remember { mutableStateOf(prefs.getBoolean("titlebarhide", false)) }
     val volumeKeysChangeFontSize = remember { prefs.getBoolean(PreferenceConstants.VOLUME_FONT, true) }
+    val swipeLeftParsed = remember {
+        SwipeKeySequenceParser.parse(prefs.getString(PreferenceConstants.SWIPE_LEFT_KEYS, "") ?: "")
+    }
+    val swipeRightParsed = remember {
+        SwipeKeySequenceParser.parse(prefs.getString(PreferenceConstants.SWIPE_RIGHT_KEYS, "") ?: "")
+    }
 
     // Keyboard state
     val hasHardwareKeyboard = rememberHasHardwareKeyboard()
@@ -441,6 +450,30 @@ fun ConsoleScreen(
                             .fillMaxSize()
                             .padding(
                                 top = if (!titleBarHide) titleBarHeight else 0.dp
+                            )
+                            .then(
+                                if (swipeLeftParsed.isNotEmpty() || swipeRightParsed.isNotEmpty()) {
+                                    Modifier.pointerInput(swipeLeftParsed, swipeRightParsed) {
+                                        val thresholdPx = 100.dp.toPx()
+                                        var totalDragX = 0f
+                                        detectHorizontalDragGestures(
+                                            onDragStart = { totalDragX = 0f },
+                                            onDragEnd = {
+                                                if (totalDragX < -thresholdPx && swipeLeftParsed.isNotEmpty()) {
+                                                    bridge.injectString(swipeLeftParsed)
+                                                } else if (totalDragX > thresholdPx && swipeRightParsed.isNotEmpty()) {
+                                                    bridge.injectString(swipeRightParsed)
+                                                }
+                                            },
+                                            onDragCancel = { totalDragX = 0f },
+                                            onHorizontalDrag = { _, dragAmount ->
+                                                totalDragX += dragAmount
+                                            }
+                                        )
+                                    }
+                                } else {
+                                    Modifier
+                                }
                             )
                     ) {
                         // Get font from profile (stored in bridge)

--- a/app/src/main/java/org/connectbot/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/settings/SettingsScreen.kt
@@ -184,6 +184,8 @@ fun SettingsScreen(
         onBellVolumeChange = viewModel::updateBellVolume,
         onBellVibrateChange = viewModel::updateBellVibrate,
         onBellNotificationChange = viewModel::updateBellNotification,
+        onSwipeLeftKeysChange = viewModel::updateSwipeLeftKeys,
+        onSwipeRightKeysChange = viewModel::updateSwipeRightKeys,
         modifier = modifier
     )
 }
@@ -227,6 +229,8 @@ fun SettingsScreenContent(
     onBellVolumeChange: (Float) -> Unit,
     onBellVibrateChange: (Boolean) -> Unit,
     onBellNotificationChange: (Boolean) -> Unit,
+    onSwipeLeftKeysChange: (String) -> Unit,
+    onSwipeRightKeysChange: (String) -> Unit,
     modifier: Modifier = Modifier
 ) {
     Scaffold(
@@ -460,6 +464,41 @@ fun SettingsScreenContent(
                     summary = stringResource(R.string.pref_pg_updn_gesture_summary),
                     checked = uiState.pgupdngesture,
                     onCheckedChange = onPgUpDnGestureChange
+                )
+            }
+
+            // Swipe gestures
+            item {
+                PreferenceCategory(title = stringResource(R.string.pref_swipe_gestures_category))
+            }
+
+            item {
+                val swipeKeyPresets = listOf(
+                    stringResource(R.string.swipe_keys_none) to "",
+                    "Ctrl+B P" to "Ctrl+B P",
+                    "Ctrl+B N" to "Ctrl+B N",
+                    "Ctrl+A P" to "Ctrl+A P",
+                    "Ctrl+A N" to "Ctrl+A N"
+                )
+                val swipeCustomLabel = stringResource(R.string.swipe_keys_custom)
+                val swipeNoneLabel = stringResource(R.string.swipe_keys_none)
+
+                ListPreferenceWithCustom(
+                    title = stringResource(R.string.pref_swipe_left_keys_title),
+                    summary = uiState.swipeLeftKeys.ifEmpty { swipeNoneLabel },
+                    value = uiState.swipeLeftKeys,
+                    entries = swipeKeyPresets,
+                    onValueChange = onSwipeLeftKeysChange,
+                    customLabel = swipeCustomLabel
+                )
+
+                ListPreferenceWithCustom(
+                    title = stringResource(R.string.pref_swipe_right_keys_title),
+                    summary = uiState.swipeRightKeys.ifEmpty { swipeNoneLabel },
+                    value = uiState.swipeRightKeys,
+                    entries = swipeKeyPresets,
+                    onValueChange = onSwipeRightKeysChange,
+                    customLabel = swipeCustomLabel
                 )
             }
 
@@ -1358,7 +1397,9 @@ private fun SettingsScreenPreview() {
                 fontValidationInProgress = false,
                 fontValidationError = null,
                 fontImportInProgress = false,
-                fontImportError = null
+                fontImportError = null,
+                swipeLeftKeys = "Ctrl+B P",
+                swipeRightKeys = "Ctrl+B N"
             ),
             onNavigateBack = {},
             onAuthOnLaunchChange = {},
@@ -1394,7 +1435,9 @@ private fun SettingsScreenPreview() {
             onBellChange = {},
             onBellVolumeChange = {},
             onBellVibrateChange = {},
-            onBellNotificationChange = {}
+            onBellNotificationChange = {},
+            onSwipeLeftKeysChange = {},
+            onSwipeRightKeysChange = {}
         )
     }
 }

--- a/app/src/main/java/org/connectbot/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/settings/SettingsViewModel.kt
@@ -76,6 +76,8 @@ data class SettingsUiState(
     val customFonts: List<String> = emptyList(),
     val customTerminalTypes: List<String> = emptyList(),
     val localFonts: List<Pair<String, String>> = emptyList(),
+    val swipeLeftKeys: String = "",
+    val swipeRightKeys: String = "",
     val fontValidationInProgress: Boolean = false,
     val fontValidationError: String? = null,
     val fontImportInProgress: Boolean = false,
@@ -169,6 +171,8 @@ class SettingsViewModel @Inject constructor(
             bellVolume = prefs.getFloat("bellVolume", 0.5f),
             bellVibrate = prefs.getBoolean("bellVibrate", true),
             bellNotification = prefs.getBoolean("bellNotification", false),
+            swipeLeftKeys = prefs.getString(PreferenceConstants.SWIPE_LEFT_KEYS, "") ?: "",
+            swipeRightKeys = prefs.getString(PreferenceConstants.SWIPE_RIGHT_KEYS, "") ?: "",
             fontFamily = prefs.getString("fontFamily", "SYSTEM_DEFAULT") ?: "SYSTEM_DEFAULT",
             customFonts = customFonts,
             customTerminalTypes = customTerminalTypes,
@@ -309,6 +313,14 @@ class SettingsViewModel @Inject constructor(
 
     fun updateRotation(value: String) {
         updateStringPref("rotation", value) { copy(rotation = value) }
+    }
+
+    fun updateSwipeLeftKeys(value: String) {
+        updateStringPref(PreferenceConstants.SWIPE_LEFT_KEYS, value) { copy(swipeLeftKeys = value) }
+    }
+
+    fun updateSwipeRightKeys(value: String) {
+        updateStringPref(PreferenceConstants.SWIPE_RIGHT_KEYS, value) { copy(swipeRightKeys = value) }
     }
 
     fun updateLanguage(languageTag: String) {

--- a/app/src/main/java/org/connectbot/util/PreferenceConstants.kt
+++ b/app/src/main/java/org/connectbot/util/PreferenceConstants.kt
@@ -82,6 +82,10 @@ object PreferenceConstants {
     /* Security */
     const val AUTH_ON_LAUNCH: String = "authOnLaunch"
 
+    /* Swipe gesture key mappings */
+    const val SWIPE_LEFT_KEYS: String = "swipeLeftKeys"
+    const val SWIPE_RIGHT_KEYS: String = "swipeRightKeys"
+
     /* Font settings */
     const val FONT_FAMILY: String = "fontFamily"
     const val FONT_FAMILY_DEFAULT: String = "SYSTEM_DEFAULT"

--- a/app/src/main/java/org/connectbot/util/SwipeKeySequenceParser.kt
+++ b/app/src/main/java/org/connectbot/util/SwipeKeySequenceParser.kt
@@ -1,0 +1,58 @@
+/*
+ * ConnectBot: simple, powerful, open-source SSH client for Android
+ * Copyright 2025 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.connectbot.util
+
+/**
+ * Parses a human-readable key sequence string (e.g., "Ctrl+B N") into raw bytes
+ * suitable for [org.connectbot.service.TerminalBridge.injectString].
+ *
+ * Supported tokens (space-separated):
+ * - `Ctrl+X` → control character (X & 0x1F)
+ * - `Esc` → escape character (\u001B)
+ * - `Space` → literal space
+ * - `Tab` → tab character (\t)
+ * - `Enter` → carriage return (\r)
+ * - Single character → literal character
+ */
+object SwipeKeySequenceParser {
+    private val WHITESPACE = "\\s+".toRegex()
+
+    fun parse(sequence: String): String {
+        if (sequence.isBlank()) return ""
+
+        return sequence.trim().split(WHITESPACE).joinToString("") { token ->
+            when {
+                token.equals("Esc", ignoreCase = true) -> "\u001B"
+
+                token.equals("Space", ignoreCase = true) -> " "
+
+                token.equals("Tab", ignoreCase = true) -> "\t"
+
+                token.equals("Enter", ignoreCase = true) -> "\r"
+
+                token.startsWith("Ctrl+", ignoreCase = true) && token.length == 6 -> {
+                    val ch = token[5].uppercaseChar()
+                    (ch.code and 0x1F).toChar().toString()
+                }
+
+                token.length == 1 -> token
+
+                else -> token
+            }
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -286,6 +286,15 @@
 	<!-- Summary for the full screen preference -->
 	<string name="pref_pg_updn_gesture_summary">"Swipe the left third of the screen to send pg up/dn to the terminal"</string>
 
+	<!-- Swipe gesture key mappings -->
+	<string name="pref_swipe_gestures_category">"Swipe gestures"</string>
+	<string name="pref_swipe_left_keys_title">"Swipe left"</string>
+	<string name="pref_swipe_left_keys_summary">"Key sequence to send on swipe left"</string>
+	<string name="pref_swipe_right_keys_title">"Swipe right"</string>
+	<string name="pref_swipe_right_keys_summary">"Key sequence to send on swipe right"</string>
+	<string name="swipe_keys_none">"None"</string>
+	<string name="swipe_keys_custom">"Custom\u2026"</string>
+
 	<!-- Name for the full screen preference -->
 	<string name="pref_fullscreen_title">"Full screen"</string>
 	<!-- Summary for the full screen preference -->

--- a/app/src/test/java/org/connectbot/util/SwipeKeySequenceParserTest.kt
+++ b/app/src/test/java/org/connectbot/util/SwipeKeySequenceParserTest.kt
@@ -1,0 +1,99 @@
+/*
+ * ConnectBot: simple, powerful, open-source SSH client for Android
+ * Copyright 2025 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.connectbot.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SwipeKeySequenceParserTest {
+
+    @Test
+    fun `empty input returns empty string`() {
+        assertEquals("", SwipeKeySequenceParser.parse(""))
+    }
+
+    @Test
+    fun `blank input returns empty string`() {
+        assertEquals("", SwipeKeySequenceParser.parse("   "))
+    }
+
+    @Test
+    fun `Ctrl+B N produces control-B followed by N`() {
+        // Ctrl+B = 0x02
+        assertEquals("\u0002N", SwipeKeySequenceParser.parse("Ctrl+B N"))
+    }
+
+    @Test
+    fun `Ctrl+B P produces control-B followed by P`() {
+        // Ctrl+B = 0x02
+        assertEquals("\u0002P", SwipeKeySequenceParser.parse("Ctrl+B P"))
+    }
+
+    @Test
+    fun `Ctrl+A N produces control-A followed by N`() {
+        // Ctrl+A = 0x01
+        assertEquals("\u0001N", SwipeKeySequenceParser.parse("Ctrl+A N"))
+    }
+
+    @Test
+    fun `Ctrl+A P produces control-A followed by P`() {
+        // Ctrl+A = 0x01
+        assertEquals("\u0001P", SwipeKeySequenceParser.parse("Ctrl+A P"))
+    }
+
+    @Test
+    fun `Ctrl+A Space produces control-A followed by space`() {
+        assertEquals("\u0001 ", SwipeKeySequenceParser.parse("Ctrl+A Space"))
+    }
+
+    @Test
+    fun `Esc produces escape character`() {
+        assertEquals("\u001B", SwipeKeySequenceParser.parse("Esc"))
+    }
+
+    @Test
+    fun `case insensitivity for keywords`() {
+        assertEquals("\u001B", SwipeKeySequenceParser.parse("esc"))
+        assertEquals("\u001B", SwipeKeySequenceParser.parse("ESC"))
+        assertEquals("\u0002N", SwipeKeySequenceParser.parse("ctrl+B N"))
+        assertEquals(" ", SwipeKeySequenceParser.parse("space"))
+        assertEquals("\t", SwipeKeySequenceParser.parse("tab"))
+        assertEquals("\r", SwipeKeySequenceParser.parse("enter"))
+    }
+
+    @Test
+    fun `single character is passed through literally`() {
+        assertEquals("a", SwipeKeySequenceParser.parse("a"))
+        assertEquals("Z", SwipeKeySequenceParser.parse("Z"))
+    }
+
+    @Test
+    fun `Tab produces tab character`() {
+        assertEquals("\t", SwipeKeySequenceParser.parse("Tab"))
+    }
+
+    @Test
+    fun `Enter produces carriage return`() {
+        assertEquals("\r", SwipeKeySequenceParser.parse("Enter"))
+    }
+
+    @Test
+    fun `complex sequence with Esc and characters`() {
+        // Esc followed by literal characters
+        assertEquals("\u001Bb", SwipeKeySequenceParser.parse("Esc b"))
+    }
+}


### PR DESCRIPTION
## Summary

- Add horizontal swipe gestures on the terminal that send user-configured key sequences, enabling workflows like switching tmux windows with swipe left/right
- Add a `SwipeKeySequenceParser` utility to convert human-readable key sequences (e.g., `Ctrl+B N`) into raw bytes for `bridge.injectString()`
- Add settings UI under a new "Swipe gestures" category with presets for tmux (`Ctrl+B P`/`Ctrl+B N`) and screen (`Ctrl+A P`/`Ctrl+A N`), plus custom entry

Closes #758

## Test plan

- [x] Unit tests for `SwipeKeySequenceParser` (empty input, Ctrl+key combos, Esc, Space, Tab, Enter, case insensitivity)
- [x] `./gradlew check test` passes
- [x] `./gradlew lint` passes
- [ ] On device/emulator: Settings → Swipe gestures → set Swipe left to "Ctrl+B P", Swipe right to "Ctrl+B N"
- [ ] Connect to a host running tmux, swipe left/right on the terminal — should switch tmux windows
- [ ] Verify taps still show/hide keyboard and title bar
- [ ] Verify swipes shorter than 100dp threshold do nothing
- [ ] Verify "None" disables the gesture for that direction
- [ ] Verify custom key sequence entry works