### PR TITLE
Fix dark system bars on API ~24

### DIFF
--- a/app/src/main/java/org/connectbot/ui/MainActivity.kt
+++ b/app/src/main/java/org/connectbot/ui/MainActivity.kt
@@ -26,6 +26,7 @@ import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.os.IBinder
+import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
@@ -118,7 +119,12 @@ class MainActivity : AppCompatActivity() {
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        enableEdgeToEdge()
+        enableEdgeToEdge(
+            statusBarStyle = SystemBarStyle.auto(
+                lightScrim = android.graphics.Color.TRANSPARENT,
+                darkScrim = android.graphics.Color.TRANSPARENT
+            )
+        )
         super.onCreate(savedInstanceState)
 
         appViewModel = ViewModelProvider(this)[AppViewModel::class.java]

--- a/app/src/main/java/org/connectbot/ui/theme/Theme.kt
+++ b/app/src/main/java/org/connectbot/ui/theme/Theme.kt
@@ -30,6 +30,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
@@ -116,6 +117,7 @@ fun ConnectBotTheme(
     if (!view.isInEditMode) {
         SideEffect {
             val window = (view.context as Activity).window
+            window.statusBarColor = colorScheme.background.toArgb()
             WindowCompat.setDecorFitsSystemWindows(window, true)
             WindowCompat.getInsetsController(window, view).apply {
                 isAppearanceLightStatusBars = !darkTheme

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -26,6 +26,8 @@
 
 		<item name="windowActionBar">false</item>
 		<item name="windowNoTitle">true</item>
+
+		<item name="android:statusBarColor">@color/dark_primary</item>
 	</style>
 
 	<style name="AlertDialogTheme" parent="Theme.AppCompat.Dialog.Alert">


### PR DESCRIPTION
These directives are needed to make the notification bar not appear dark on dark.

Fixes #2067