### PR TITLE
Route clipboard paste through TerminalEmulator.paste (bracketed paste)

### DIFF
--- a/app/src/main/java/org/connectbot/service/TerminalBridge.kt
+++ b/app/src/main/java/org/connectbot/service/TerminalBridge.kt
@@ -506,7 +506,7 @@ class TerminalBridge {
 
     /**
      * Inject a specific string into this terminal. Used for post-login strings
-     * and pasting clipboard.
+     * and manual text input where bracketed paste is undesired.
      */
     fun injectString(string: String?) {
         if (string == null || string.isEmpty()) {
@@ -516,6 +516,19 @@ class TerminalBridge {
         transportOperations.trySend(
             TransportOperation.WriteData(string.toByteArray(charset(encoding)))
         )
+    }
+
+    /**
+     * Paste clipboard text into this terminal. When the remote side has
+     * enabled DEC mode 2004 (bracketed paste), the text is wrapped with
+     * ESC[200~/ESC[201~ so shells can treat it as paste rather than typed
+     * input. When the mode is off, the text is sent as if typed.
+     */
+    fun pasteClipboard(text: String?) {
+        if (text.isNullOrEmpty()) {
+            return
+        }
+        terminalEmulator.paste(text)
     }
 
     /**

--- a/app/src/main/java/org/connectbot/service/TerminalKeyListener.kt
+++ b/app/src/main/java/org/connectbot/service/TerminalKeyListener.kt
@@ -294,7 +294,7 @@ class TerminalKeyListener(
                 (derivedMetaState and KeyEvent.META_SHIFT_ON) != 0 &&
                 clipboard?.hasText() == true
             ) {
-                bridge.injectString(clipboard?.text.toString())
+                bridge.pasteClipboard(clipboard?.text.toString())
                 return true
             }
 

--- a/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
@@ -420,7 +420,7 @@ fun ConsoleScreen(
                                         context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
                                     val clip =
                                         clipboard.primaryClip?.getItemAt(0)?.text?.toString() ?: ""
-                                    bridge.injectString(clip)
+                                    bridge.pasteClipboard(clip)
                                 }
                                 true
                             }
@@ -723,7 +723,7 @@ fun ConsoleScreen(
                                     context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
                                 val clip =
                                     clipboard.primaryClip?.getItemAt(0)?.text?.toString() ?: ""
-                                bridge.injectString(clip)
+                                bridge.pasteClipboard(clip)
                             }
                         },
                         enabled = currentBridge != null

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,5 @@
+@file:Suppress("ktlint:standard:property-naming")
+
 pluginManagement {
     repositories {
         google()
@@ -5,7 +7,15 @@ pluginManagement {
     }
 }
 
-@file:Suppress("ktlint:standard:property-naming")
+// Substitute the published org.connectbot:termlib artifact with the locally
+// checked-out termlib sibling at ../termlib while the bracket_paste feature
+// branch is in flight on both repos.
+includeBuild("../termlib") {
+    dependencySubstitution {
+        substitute(module("org.connectbot:termlib")).using(project(":lib"))
+    }
+}
+
 val TRANSLATIONS_ONLY: String? by settings
 
 if (TRANSLATIONS_ONLY.isNullOrBlank()) {


### PR DESCRIPTION
Add TerminalBridge.pasteClipboard(text) that delegates to the termlib's new paste(String) API, which wraps the text in ESC[200~/ESC[201~ when the remote side has enabled DEC mode 2004. Update the three clipboard paste sites (Ctrl+Shift+V, paste toolbar button, hardware middle-button) to call pasteClipboard instead of injectString. injectString is kept for post-login strings and manual FloatingTextInputDialog entry, which must not be bracketed.

Context: #2058, connectbot/termlib#171