### PR TITLE
Fix #2058: serialize all transport writes and flushes

### DIFF
--- a/app/src/androidTest/java/org/connectbot/service/TerminalBridgeWriteSerializationTest.kt
+++ b/app/src/androidTest/java/org/connectbot/service/TerminalBridgeWriteSerializationTest.kt
@@ -1,0 +1,230 @@
+/*
+ * ConnectBot: simple, powerful, open-source SSH client for Android
+ * Copyright 2026 Kenny Root, Jeffrey Sharkey
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.connectbot.service
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.view.KeyEvent
+import android.view.View
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.connectbot.data.entity.Host
+import org.connectbot.di.CoroutineDispatchers
+import org.connectbot.transport.AbsTransport
+import org.connectbot.ui.MainActivity
+import org.connectbot.util.waitUntilServiceBound
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * On-device regression test for GitHub issue #2058 — "ConnectBot loses chars
+ * on long copy+paste".
+ *
+ * Root cause: [TerminalKeyListener.onKey] wrote keyboard bytes directly to
+ * `transport.write(...)` from the caller's thread (UI), while paste data
+ * enqueued through [TerminalBridge.injectString] was written from the IO
+ * coroutine draining `transportOperations`. Under load (long paste + any
+ * keystroke) the two paths raced on the same underlying `OutputStream` and
+ * bytes interleaved at the SSH channel level — dropping characters.
+ *
+ * This test drives both paths concurrently against a transport that models a
+ * non-thread-safe byte stream (the same pattern as the real SSH
+ * [java.io.OutputStream] when two threads call `write()` on an
+ * unsynchronized buffer — the last writer's `System.arraycopy` clobbers the
+ * earlier writer's appended region, losing bytes). It then asserts that the
+ * bytes actually delivered equal the bytes attempted. On the pre-fix code
+ * bytes go missing exactly as users report.
+ *
+ * Must run on-device (androidTest) because `TerminalBridge`'s constructor
+ * transitively loads the termlib JNI (`jni_cb_term`), which is only built
+ * for Android ABIs.
+ */
+@HiltAndroidTest
+@RunWith(AndroidJUnit4::class)
+class TerminalBridgeWriteSerializationTest {
+
+    @get:Rule(order = 0)
+    val hiltRule = HiltAndroidRule(this)
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    @Before
+    fun setUp() {
+        hiltRule.inject()
+    }
+
+    /**
+     * Transport backed by a non-thread-safe "grow-and-copy" byte buffer —
+     * exactly the pattern that corrupts SSH's underlying stdin stream when
+     * two threads call write() concurrently. Concurrent writes race on the
+     * grow-then-copy-then-publish sequence, so the last writer's published
+     * buffer overwrites the earlier writer's with neither writer's bytes
+     * preserved.
+     *
+     * A short sleep between the allocate and the arraycopy widens the race
+     * window so the bug manifests deterministically instead of
+     * intermittently.
+     */
+    private class LossyNonThreadSafeTransport : AbsTransport() {
+        val attemptedBytes = AtomicInteger(0)
+
+        // Intentionally NOT volatile / NOT synchronized — the whole point is
+        // to model an unsynchronized shared buffer.
+        private var data: ByteArray = ByteArray(0)
+
+        fun receivedBytes(): Int = data.size
+
+        override fun connect() = Unit
+        override fun read(buffer: ByteArray, offset: Int, length: Int) = 0
+
+        override fun write(buffer: ByteArray) {
+            attemptedBytes.addAndGet(buffer.size)
+            val current = data
+            val next = ByteArray(current.size + buffer.size)
+            System.arraycopy(current, 0, next, 0, current.size)
+            // Widen the race window: between reading `data` and publishing
+            // `data = next`, another writer can complete its own
+            // grow-and-copy, and our publish will overwrite theirs.
+            Thread.sleep(1)
+            System.arraycopy(buffer, 0, next, current.size, buffer.size)
+            data = next
+        }
+
+        override fun write(c: Int) {
+            write(byteArrayOf(c.toByte()))
+        }
+
+        override fun flush() = Unit
+        override fun close() = Unit
+        override fun setDimensions(columns: Int, rows: Int, width: Int, height: Int) = Unit
+        override fun isConnected() = true
+        override fun isSessionOpen() = true
+        override fun getDefaultPort() = 22
+        override fun getDefaultNickname(username: String?, hostname: String?, port: Int) = "test"
+        override fun getSelectionArgs(uri: Uri, selection: MutableMap<String, String>) = Unit
+        override fun createHost(uri: Uri) = Host()
+        override fun usesNetwork() = true
+    }
+
+    @Test
+    fun concurrentPasteAndKeystrokeLoseCharactersAtTransport() {
+        // MainActivity is launched only to get the Hilt-wired TerminalManager
+        // via its bound service. We don't interact with the UI.
+        val intent = Intent(context, MainActivity::class.java)
+        ActivityScenario.launch<MainActivity>(intent).use { scenario ->
+            scenario.onActivity { activity ->
+                val state = runBlocking { activity.waitUntilServiceBound() }
+                val manager = state.terminalManager
+
+                // id <= 0 makes TerminalBridge take the short-circuit profile-
+                // observation path (no host observer needed).
+                val host = Host(
+                    id = 0L,
+                    nickname = "bridge-serialization-test",
+                    protocol = "local",
+                    username = "",
+                    hostname = "",
+                    port = 0,
+                    profileId = 1L
+                )
+                val dispatchers = CoroutineDispatchers(
+                    default = Dispatchers.Default,
+                    io = Dispatchers.IO,
+                    main = Dispatchers.Main
+                )
+
+                val bridge = TerminalBridge(manager, host, dispatchers)
+                try {
+                    val transport = LossyNonThreadSafeTransport()
+                    bridge.transport = transport
+
+                    val keyListener = TerminalBridge::class.java
+                        .getDeclaredField("keyListener")
+                        .apply { isAccessible = true }
+                        .get(bridge) as TerminalKeyListener
+
+                    val view = View(context)
+                    val iterations = 40
+
+                    runBlocking {
+                        val jobs = mutableListOf<Job>()
+                        repeat(iterations) { i ->
+                            // Paste path: injectString -> transportOperations
+                            // channel -> IO coroutine -> transport.write.
+                            jobs += launch(Dispatchers.Default) {
+                                bridge.injectString(
+                                    "paste-$i-" + "x".repeat(128)
+                                )
+                            }
+                            // Keystroke path: pre-fix this called
+                            // transport.write(0x09) directly from whichever
+                            // thread invoked onKey.
+                            jobs += launch(Dispatchers.IO) {
+                                val down = KeyEvent(
+                                    KeyEvent.ACTION_DOWN,
+                                    KeyEvent.KEYCODE_TAB
+                                )
+                                keyListener.onKey(
+                                    view,
+                                    KeyEvent.KEYCODE_TAB,
+                                    down
+                                )
+                            }
+                        }
+                        jobs.forEach { it.join() }
+
+                        // Let the serialized queue drain any remaining
+                        // enqueued writes.
+                        val expectedBytes =
+                            // Each paste: "paste-N-" (or "paste-NN-") + 128 'x's.
+                            (0 until iterations).sumOf { i ->
+                                "paste-$i-".length + 128
+                            } + iterations // one byte per Tab keystroke
+                        withTimeout(10_000) {
+                            while (transport.attemptedBytes.get() < expectedBytes) {
+                                delay(10)
+                            }
+                            delay(250)
+                        }
+                    }
+
+                    assertEquals(
+                        "Characters were lost at the transport layer: " +
+                            "attempted ${transport.attemptedBytes.get()} " +
+                            "bytes, but only ${transport.receivedBytes()} " +
+                            "survived. This is exactly the symptom reported " +
+                            "in issue #2058 — dropped characters on long " +
+                            "pastes due to unserialized writes racing at " +
+                            "the underlying OutputStream.",
+                        transport.attemptedBytes.get(),
+                        transport.receivedBytes()
+                    )
+                } finally {
+                    bridge.cleanup()
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/connectbot/service/TerminalBridge.kt
+++ b/app/src/main/java/org/connectbot/service/TerminalBridge.kt
@@ -74,6 +74,7 @@ class TerminalBridge {
     private sealed class TransportOperation {
         data class WriteData(val data: ByteArray) : TransportOperation()
         data class SetDimensions(val columns: Int, val rows: Int, val width: Int, val height: Int) : TransportOperation()
+        data object Flush : TransportOperation()
     }
 
     private val transportOperations = Channel<TransportOperation>(Channel.UNLIMITED)
@@ -302,6 +303,10 @@ class TerminalBridge {
                                 operation.height
                             )
                         }
+
+                        is TransportOperation.Flush -> {
+                            transport?.flush()
+                        }
                     }
                 } catch (e: IOException) {
                     Timber.e(e, "Error processing transport operation")
@@ -516,6 +521,33 @@ class TerminalBridge {
         transportOperations.trySend(
             TransportOperation.WriteData(string.toByteArray(charset(encoding)))
         )
+    }
+
+    /**
+     * Enqueue a single byte for transport write. Goes through the same serialized
+     * channel as [injectString] so keyboard input cannot interleave with paste data.
+     */
+    fun sendByte(c: Int) {
+        transportOperations.trySend(
+            TransportOperation.WriteData(byteArrayOf(c.toByte()))
+        )
+    }
+
+    /**
+     * Enqueue a byte array for transport write. Serialized with all other
+     * transport operations (paste, keyboard, resize, flush).
+     */
+    fun sendBytes(data: ByteArray) {
+        if (data.isEmpty()) return
+        transportOperations.trySend(TransportOperation.WriteData(data))
+    }
+
+    /**
+     * Enqueue a flush after any pending writes. Serialized with writes so the
+     * flush happens only after preceding bytes have been sent to the transport.
+     */
+    fun requestFlush() {
+        transportOperations.trySend(TransportOperation.Flush)
     }
 
     /**

--- a/app/src/main/java/org/connectbot/service/TerminalKeyListener.kt
+++ b/app/src/main/java/org/connectbot/service/TerminalKeyListener.kt
@@ -103,14 +103,14 @@ class TerminalKeyListener(
                     ) {
                         ourMetaState = ourMetaState and OUR_TRANSIENT.inv()
                         _modifierState.value = getModifierState()
-                        transport.write('/'.code)
+                        bridge.sendByte('/'.code)
                         return true
                     } else if (keyCode == KeyEvent.KEYCODE_SHIFT_RIGHT &&
                         (ourMetaState and OUR_TAB) != 0
                     ) {
                         ourMetaState = ourMetaState and OUR_TRANSIENT.inv()
                         _modifierState.value = getModifierState()
-                        transport.write(0x09)
+                        bridge.sendByte(0x09)
                         return true
                     }
                 } else if (leftModifiersAreSlashAndTab) {
@@ -119,14 +119,14 @@ class TerminalKeyListener(
                     ) {
                         ourMetaState = ourMetaState and OUR_TRANSIENT.inv()
                         _modifierState.value = getModifierState()
-                        transport.write('/'.code)
+                        bridge.sendByte('/'.code)
                         return true
                     } else if (keyCode == KeyEvent.KEYCODE_SHIFT_LEFT &&
                         (ourMetaState and OUR_TAB) != 0
                     ) {
                         ourMetaState = ourMetaState and OUR_TRANSIENT.inv()
                         _modifierState.value = getModifierState()
-                        transport.write(0x09)
+                        bridge.sendByte(0x09)
                         return true
                     }
                 }
@@ -155,7 +155,7 @@ class TerminalKeyListener(
                 event.action == KeyEvent.ACTION_MULTIPLE
             ) {
                 val input = encoding?.let { event.characters.toByteArray(charset(it)) }
-                input?.let { transport.write(it) }
+                input?.let { bridge.sendBytes(it) }
                 return true
             }
 
@@ -346,10 +346,10 @@ class TerminalKeyListener(
                     sendEscape()
                 }
                 if (finalChar < 0x80) {
-                    transport.write(finalChar)
+                    bridge.sendByte(finalChar)
                 } else {
                     encoding?.let {
-                        transport.write(
+                        bridge.sendBytes(
                             String(Character.toChars(finalChar))
                                 .toByteArray(charset(it))
                         )
@@ -365,7 +365,7 @@ class TerminalKeyListener(
                 }
 
                 KeyEvent.KEYCODE_TAB -> {
-                    transport.write(0x09)
+                    bridge.sendByte(0x09)
                     return true
                 }
 
@@ -376,12 +376,11 @@ class TerminalKeyListener(
                     )
                     when (camera) {
                         PreferenceConstants.CAMERA_CTRLA_SPACE -> {
-                            transport.write(0x01)
-                            transport.write(' '.code)
+                            bridge.sendBytes(byteArrayOf(0x01, ' '.code.toByte()))
                         }
 
                         PreferenceConstants.CAMERA_CTRLA -> {
-                            transport.write(0x01)
+                            bridge.sendByte(0x01)
                         }
 
                         PreferenceConstants.CAMERA_ESC -> {
@@ -390,7 +389,7 @@ class TerminalKeyListener(
 
                         PreferenceConstants.CAMERA_ESC_A -> {
                             bridge.terminalEmulator.dispatchKey(0, VTermKey.ESCAPE)
-                            transport.write('a'.code)
+                            bridge.sendByte('a'.code)
                         }
 
                         "text_input" -> {
@@ -487,12 +486,7 @@ class TerminalKeyListener(
             }
         } catch (e: IOException) {
             Timber.e(e, "Problem while trying to handle an onKey() event")
-            try {
-                transport?.flush()
-            } catch (_: IOException) {
-                Timber.d("Our transport was closed, dispatching disconnect event")
-                bridge.dispatchDisconnect(false)
-            }
+            bridge.requestFlush()
         } catch (_: NullPointerException) {
             Timber.d("Input before connection established ignored.")
             return true


### PR DESCRIPTION
## Summary

Fixes #2058 — long pastes drop characters.

`TerminalBridge` already runs a single IO coroutine that drains a `transportOperations` channel and writes to the transport serially — the comment at line 277 says so explicitly. But `TerminalKeyListener.onKey()` bypassed that queue in 12 places with direct `transport.write(...)` calls from the UI thread, and `transport.flush()` was never on the queue either.

When a paste was in flight (enqueued via `injectString`) and the user typed, held a modifier, pressed the camera button, or any soft keyboard emitted `ACTION_MULTIPLE`, the UI-thread `transport.write` raced the IO-thread `transport.write` on the underlying `stdin` `OutputStream`. Bytes interleaved at the SSH channel level → dropped characters on long pastes, exactly matching the symptom in the report (e.g. `"Singleton" → "Singlet"` in the diff attached to the issue).

## What changed

- `TerminalBridge`: added `TransportOperation.Flush` plus `sendByte(Int)` / `sendBytes(ByteArray)` / `requestFlush()` helpers that enqueue onto the same `transportOperations` channel.
- `TerminalKeyListener`: every `transport.write(...)` and the `transport.flush()` in the `IOException` path now go through those helpers. The Ctrl-A + Space camera path becomes a single atomic 2-byte enqueue rather than two separate writes. The nested `try { transport.flush() } catch { disconnect }` collapses to `bridge.requestFlush()` — writes no longer throw synchronously, and `Relay`'s read loop already handles disconnect detection.

No behavior changes for users beyond the bug being fixed.

## Test plan

Added `app/src/androidTest/java/org/connectbot/service/TerminalBridgeWriteSerializationTest.kt` — an on-device regression test that drives paste and keystroke paths concurrently against a non-thread-safe grow-and-copy transport (same shape as the real SSH `stdin` `OutputStream` under concurrent writers). Asserts `attempted bytes == delivered bytes`.

- **Pre-fix run on emulator:** `expected:<5510> but was:<5470>` — 40 characters lost on a single paste+type burst, reproducing the issue's symptom deterministically.
- **Post-fix run:** passes, all bytes delivered.

Must be an `androidTest` (not a JVM unit test) because `TerminalBridge`'s constructor transitively loads the termlib `jni_cb_term` native library, which is only built for Android ABIs.

- [x] `./gradlew spotlessCheck`
- [x] `./gradlew testOssDebugUnitTest`
- [x] `./gradlew :app:connectedOssDebugAndroidTest --tests org.connectbot.service.TerminalBridgeWriteSerializationTest` — red on main, green with this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)