### PR TITLE
Fix enckey migration

### DIFF
--- a/app/src/main/java/org/connectbot/service/StartupKeyLoader.kt
+++ b/app/src/main/java/org/connectbot/service/StartupKeyLoader.kt
@@ -1,0 +1,57 @@
+/*
+ * ConnectBot: simple, powerful, open-source SSH client for Android
+ * Copyright 2025 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.connectbot.service
+
+import org.connectbot.data.entity.Pubkey
+import java.security.KeyPair
+
+/**
+ * Outcome of attempting to load a key marked as "unlock at startup" without user interaction.
+ */
+sealed class StartupKeyLoadOutcome {
+    data class Loaded(val pubkey: Pubkey, val pair: KeyPair) : StartupKeyLoadOutcome()
+    data class NeedsPassphrase(val pubkey: Pubkey) : StartupKeyLoadOutcome()
+    data class Failed(val pubkey: Pubkey, val reason: String) : StartupKeyLoadOutcome()
+}
+
+/**
+ * Classify a startup key into whether it can be loaded silently, needs a passphrase prompt,
+ * or has failed to load for other reasons. Extracted from TerminalManager so it can be unit
+ * tested without the Android service lifecycle.
+ *
+ * Encrypted keys are never attempted with a null password; the caller is expected to surface
+ * a prompt via the returned [StartupKeyLoadOutcome.NeedsPassphrase] outcome.
+ */
+fun classifyStartupKey(
+    pubkey: Pubkey,
+    convert: (Pubkey, String?) -> KeyPair?
+): StartupKeyLoadOutcome {
+    if (pubkey.encrypted) {
+        return StartupKeyLoadOutcome.NeedsPassphrase(pubkey)
+    }
+    return try {
+        val pair = convert(pubkey, null)
+        if (pair == null) {
+            StartupKeyLoadOutcome.Failed(pubkey, "Failed to convert key to KeyPair")
+        } else {
+            StartupKeyLoadOutcome.Loaded(pubkey, pair)
+        }
+    } catch (e: Exception) {
+        StartupKeyLoadOutcome.Failed(pubkey, e.message ?: "Unknown error loading key")
+    }
+}

--- a/app/src/main/java/org/connectbot/service/TerminalManager.kt
+++ b/app/src/main/java/org/connectbot/service/TerminalManager.kt
@@ -118,6 +118,10 @@ class TerminalManager :
         MutableSharedFlow<Set<String>>(replay = 1, extraBufferCapacity = 1)
     val loadedKeysChangedFlow: SharedFlow<Set<String>> = _loadedKeysChanged.asSharedFlow()
 
+    // Encrypted keys marked "unlock at startup" that still need a passphrase from the user.
+    private val _pendingStartupKeyPrompts = MutableStateFlow<List<Pubkey>>(emptyList())
+    val pendingStartupKeyPrompts: StateFlow<List<Pubkey>> = _pendingStartupKeyPrompts.asStateFlow()
+
     internal val loadedKeypairs: MutableMap<String, KeyHolder> = ConcurrentHashMap()
 
     internal lateinit var res: Resources
@@ -190,34 +194,26 @@ class TerminalManager :
         scope.launch(dispatchers.io) {
             try {
                 val pubkeys = pubkeyRepository.getStartupKeys()
+                val encryptedPending = mutableListOf<Pubkey>()
                 for (pubkey in pubkeys) {
-                    try {
-                        val pair = PubkeyUtils.convertToKeyPair(pubkey, null)
-                        if (pair != null) {
-                            addKey(pubkey, pair)
-                        } else {
-                            Timber.w(
-                                String.format(
-                                    "Failed to convert key '%s' to KeyPair",
-                                    pubkey.nickname
-                                )
-                            )
+                    when (val outcome = classifyStartupKey(pubkey, PubkeyUtils::convertToKeyPair)) {
+                        is StartupKeyLoadOutcome.Loaded -> addKey(outcome.pubkey, outcome.pair)
+
+                        is StartupKeyLoadOutcome.NeedsPassphrase -> encryptedPending.add(outcome.pubkey)
+
+                        is StartupKeyLoadOutcome.Failed -> {
+                            Timber.w("Failed to convert key '%s' to KeyPair: %s", pubkey.nickname, outcome.reason)
                             _serviceErrors.emit(
                                 ServiceError.KeyLoadFailed(
                                     keyName = pubkey.nickname,
-                                    reason = "Failed to convert key to KeyPair"
+                                    reason = outcome.reason
                                 )
                             )
                         }
-                    } catch (e: Exception) {
-                        Timber.w(e, "Problem adding key '%s' to in-memory cache", pubkey.nickname)
-                        _serviceErrors.emit(
-                            ServiceError.KeyLoadFailed(
-                                keyName = pubkey.nickname,
-                                reason = e.message ?: "Unknown error loading key"
-                            )
-                        )
                     }
+                }
+                if (encryptedPending.isNotEmpty()) {
+                    _pendingStartupKeyPrompts.value = encryptedPending.toList()
                 }
             } catch (e: Exception) {
                 Timber.e(e, "Failed to load startup keys")
@@ -473,6 +469,40 @@ class TerminalManager :
             val keys = HashSet(loadedKeypairs.keys)
             _loadedKeysChanged.emit(keys)
         }
+    }
+
+    /**
+     * Attempt to unlock an encrypted startup key with the supplied passphrase. On success the
+     * key is added to the in-memory cache and removed from [pendingStartupKeyPrompts].
+     *
+     * @return true if the key was decrypted and loaded, false if the passphrase was wrong or
+     *   the key otherwise failed to decode (the key stays in the pending queue).
+     */
+    fun unlockPendingStartupKey(pubkey: Pubkey, password: String): Boolean {
+        val pair = try {
+            PubkeyUtils.convertToKeyPair(pubkey, password)
+        } catch (_: PubkeyUtils.BadPasswordException) {
+            return false
+        } catch (e: Exception) {
+            Timber.w(e, "Failed to unlock startup key '%s'", pubkey.nickname)
+            return false
+        } ?: return false
+
+        addKey(pubkey, pair, true)
+        removeFromPendingStartupKeys(pubkey)
+        return true
+    }
+
+    /**
+     * Drop an encrypted startup key from [pendingStartupKeyPrompts] without loading it. The
+     * key's persisted `startup=true` flag is unaffected; the prompt will re-appear next launch.
+     */
+    fun dismissPendingStartupKey(pubkey: Pubkey) {
+        removeFromPendingStartupKeys(pubkey)
+    }
+
+    private fun removeFromPendingStartupKeys(pubkey: Pubkey) {
+        _pendingStartupKeyPrompts.value = _pendingStartupKeyPrompts.value.filterNot { it.id == pubkey.id }
     }
 
     fun addKey(pubkey: Pubkey, pair: KeyPair) {

--- a/app/src/main/java/org/connectbot/ui/screens/generatepubkey/GeneratePubkeyViewModel.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/generatepubkey/GeneratePubkeyViewModel.kt
@@ -323,7 +323,7 @@ class GeneratePubkeyViewModel @Inject constructor(
                     privateKey = PubkeyUtils.getEncodedPrivate(keyPair.private, state.password1),
                     publicKey = keyPair.public.encoded,
                     encrypted = encrypted,
-                    startup = state.unlockAtStartup && !encrypted,
+                    startup = state.unlockAtStartup,
                     confirmation = state.confirmUse,
                     createdDate = System.currentTimeMillis()
                 )

--- a/app/src/main/java/org/connectbot/ui/screens/hostlist/HostListScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/hostlist/HostListScreen.kt
@@ -28,11 +28,13 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.CheckCircle
@@ -44,6 +46,7 @@ import androidx.compose.material.icons.filled.Error
 import androidx.compose.material.icons.filled.Key
 import androidx.compose.material.icons.filled.Link
 import androidx.compose.material.icons.filled.LinkOff
+import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
@@ -56,6 +59,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
@@ -77,12 +81,15 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.core.graphics.toColorInt
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import kotlinx.coroutines.launch
 import org.connectbot.R
 import org.connectbot.data.entity.Host
+import org.connectbot.data.entity.Pubkey
 import org.connectbot.ui.LocalTerminalManager
 import org.connectbot.ui.PreviewScreen
 import org.connectbot.ui.components.DisconnectAllDialog
@@ -218,6 +225,15 @@ fun HostListScreen(
                 onSelectShortcut(shortcutHost!!, color, iconStyle)
                 shortcutHost = null
             }
+        )
+    }
+
+    uiState.startupKeyPrompt?.let { pendingKey ->
+        StartupKeyPasswordDialog(
+            pubkey = pendingKey,
+            wrongPassword = uiState.startupKeyWrongPassword,
+            onDismiss = viewModel::dismissStartupKeyPrompt,
+            onProvidePassword = viewModel::submitStartupKeyPassword
         )
     }
 
@@ -905,4 +921,53 @@ private fun HostListScreenPopulatedPreview() {
             onDisconnectAll = {}
         )
     }
+}
+
+@Composable
+private fun StartupKeyPasswordDialog(
+    pubkey: Pubkey,
+    wrongPassword: Boolean,
+    onDismiss: () -> Unit,
+    onProvidePassword: (String) -> Unit
+) {
+    var password by remember(pubkey.id) { mutableStateOf("") }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        icon = { Icon(Icons.Default.Lock, contentDescription = null) },
+        title = { Text(stringResource(R.string.pubkey_unlock)) },
+        text = {
+            Column {
+                Text(
+                    text = stringResource(R.string.pubkey_unlock_message, pubkey.nickname),
+                    modifier = Modifier.padding(bottom = 16.dp)
+                )
+                OutlinedTextField(
+                    value = password,
+                    onValueChange = { password = it },
+                    label = { Text(stringResource(R.string.prompt_password)) },
+                    visualTransformation = PasswordVisualTransformation(),
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+                    isError = wrongPassword,
+                    supportingText = if (wrongPassword) {
+                        { Text(stringResource(R.string.alert_wrong_password_msg)) }
+                    } else {
+                        null
+                    },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = { onProvidePassword(password) }) {
+                Text(stringResource(R.string.pubkey_unlock))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(android.R.string.cancel))
+            }
+        }
+    )
 }

--- a/app/src/main/java/org/connectbot/ui/screens/hostlist/HostListViewModel.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/hostlist/HostListViewModel.kt
@@ -36,6 +36,7 @@ import kotlinx.coroutines.withContext
 import org.connectbot.R
 import org.connectbot.data.HostRepository
 import org.connectbot.data.entity.Host
+import org.connectbot.data.entity.Pubkey
 import org.connectbot.di.CoroutineDispatchers
 import org.connectbot.service.ServiceError
 import org.connectbot.service.TerminalManager
@@ -56,7 +57,9 @@ data class HostListUiState(
     val sortedByColor: Boolean = false,
     val exportedJson: String? = null,
     val exportResult: ExportResult? = null,
-    val importResult: ImportResult? = null
+    val importResult: ImportResult? = null,
+    val startupKeyPrompt: Pubkey? = null,
+    val startupKeyWrongPassword: Boolean = false
 )
 
 data class ImportResult(
@@ -99,6 +102,8 @@ class HostListViewModel @Inject constructor(
             observeHostStatusChanges()
             // Collect service errors from TerminalManager
             collectServiceErrors()
+            // Surface any encrypted keys that are waiting for a passphrase to be entered
+            observePendingStartupKeyPrompts()
             // Update initial connection states
             updateConnectionStates(_uiState.value.hosts)
         }
@@ -320,5 +325,44 @@ class HostListViewModel @Inject constructor(
 
     fun clearImportResult() {
         _uiState.update { it.copy(importResult = null) }
+    }
+
+    private fun observePendingStartupKeyPrompts() {
+        val manager = terminalManager ?: return
+        viewModelScope.launch {
+            manager.pendingStartupKeyPrompts.collect { queue ->
+                val head = queue.firstOrNull()
+                _uiState.update { state ->
+                    state.copy(
+                        startupKeyPrompt = head,
+                        // Reset wrong-password flag whenever the head of the queue changes
+                        startupKeyWrongPassword = if (head?.id != state.startupKeyPrompt?.id) {
+                            false
+                        } else {
+                            state.startupKeyWrongPassword
+                        }
+                    )
+                }
+            }
+        }
+    }
+
+    fun submitStartupKeyPassword(password: String) {
+        val manager = terminalManager ?: return
+        val pubkey = _uiState.value.startupKeyPrompt ?: return
+        viewModelScope.launch {
+            val unlocked = withContext(dispatchers.default) {
+                manager.unlockPendingStartupKey(pubkey, password)
+            }
+            if (!unlocked) {
+                _uiState.update { it.copy(startupKeyWrongPassword = true) }
+            }
+        }
+    }
+
+    fun dismissStartupKeyPrompt() {
+        val manager = terminalManager ?: return
+        val pubkey = _uiState.value.startupKeyPrompt ?: return
+        manager.dismissPendingStartupKey(pubkey)
     }
 }

--- a/app/src/main/java/org/connectbot/ui/screens/pubkeyeditor/PubkeyEditorViewModel.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/pubkeyeditor/PubkeyEditorViewModel.kt
@@ -224,7 +224,7 @@ class PubkeyEditorViewModel @Inject constructor(
                         nickname = state.nickname,
                         privateKey = newPrivateKey,
                         encrypted = newEncrypted,
-                        startup = state.unlockAtStartup && !newEncrypted,
+                        startup = state.unlockAtStartup,
                         confirmation = state.confirmUse
                     )
 

--- a/app/src/test/java/org/connectbot/service/StartupKeyLoaderTest.kt
+++ b/app/src/test/java/org/connectbot/service/StartupKeyLoaderTest.kt
@@ -1,0 +1,95 @@
+/*
+ * ConnectBot: simple, powerful, open-source SSH client for Android
+ * Copyright 2025 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.connectbot.service
+
+import org.connectbot.data.entity.Pubkey
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.security.KeyPair
+import java.security.KeyPairGenerator
+
+/**
+ * Regression tests for issue #2081: encrypted startup keys must not be silently dropped.
+ */
+class StartupKeyLoaderTest {
+
+    private val rsaPair: KeyPair by lazy {
+        val keyGen = KeyPairGenerator.getInstance("RSA")
+        keyGen.initialize(2048)
+        keyGen.generateKeyPair()
+    }
+
+    private fun pubkey(encrypted: Boolean) = Pubkey(
+        id = 1L,
+        nickname = "k",
+        type = "RSA",
+        privateKey = byteArrayOf(0),
+        publicKey = byteArrayOf(0),
+        encrypted = encrypted,
+        startup = true,
+        confirmation = false,
+        createdDate = 0L
+    )
+
+    @Test
+    fun encryptedKey_requestsPassphrasePrompt_withoutInvokingConverter() {
+        var converterInvocations = 0
+        val outcome = classifyStartupKey(pubkey(encrypted = true)) { _, _ ->
+            converterInvocations++
+            null
+        }
+        assertTrue(
+            "Encrypted startup keys must surface a passphrase prompt instead of being silently skipped",
+            outcome is StartupKeyLoadOutcome.NeedsPassphrase
+        )
+        assertEquals(
+            "Encrypted key must not be attempted with a null password",
+            0,
+            converterInvocations
+        )
+    }
+
+    @Test
+    fun unencryptedKey_loadsImmediately() {
+        val key = pubkey(encrypted = false)
+        val outcome = classifyStartupKey(key) { p, password ->
+            assertEquals(key, p)
+            assertNull("Unencrypted key must be loaded with null password", password)
+            rsaPair
+        }
+        assertTrue(outcome is StartupKeyLoadOutcome.Loaded)
+        assertEquals(rsaPair, (outcome as StartupKeyLoadOutcome.Loaded).pair)
+    }
+
+    @Test
+    fun unencryptedKey_conversionReturningNull_reportsFailure() {
+        val outcome = classifyStartupKey(pubkey(encrypted = false)) { _, _ -> null }
+        assertTrue(outcome is StartupKeyLoadOutcome.Failed)
+    }
+
+    @Test
+    fun unencryptedKey_conversionThrowing_reportsFailure() {
+        val outcome = classifyStartupKey(pubkey(encrypted = false)) { _, _ ->
+            throw IllegalStateException("boom")
+        }
+        assertTrue(outcome is StartupKeyLoadOutcome.Failed)
+        assertEquals("boom", (outcome as StartupKeyLoadOutcome.Failed).reason)
+    }
+}

--- a/app/src/test/java/org/connectbot/ui/screens/generatepubkey/GeneratePubkeyViewModelTest.kt
+++ b/app/src/test/java/org/connectbot/ui/screens/generatepubkey/GeneratePubkeyViewModelTest.kt
@@ -1,0 +1,142 @@
+/*
+ * ConnectBot: simple, powerful, open-source SSH client for Android
+ * Copyright 2025 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.connectbot.ui.screens.generatepubkey
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.connectbot.data.PubkeyRepository
+import org.connectbot.data.entity.Pubkey
+import org.connectbot.di.CoroutineDispatchers
+import org.connectbot.util.BiometricAvailability
+import org.connectbot.util.BiometricKeyManager
+import org.junit.After
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import timber.log.Timber
+
+/**
+ * Regression tests for issue #2081 extended to the key-generation path: toggling
+ * "unlock at startup" together with a passphrase at key generation must persist
+ * startup=true on the newly saved key.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class GeneratePubkeyViewModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private val dispatchers = CoroutineDispatchers(
+        default = testDispatcher,
+        io = testDispatcher,
+        main = testDispatcher
+    )
+    private lateinit var repository: PubkeyRepository
+    private lateinit var biometricKeyManager: BiometricKeyManager
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        Timber.plant(object : Timber.Tree() {
+            override fun log(priority: Int, tag: String?, message: String, t: Throwable?) {
+                // No-op for tests
+            }
+        })
+        repository = mock()
+        biometricKeyManager = mock()
+        whenever(biometricKeyManager.isBiometricAvailable())
+            .thenReturn(BiometricAvailability.NO_HARDWARE)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        Timber.uprootAll()
+    }
+
+    private fun createViewModel(): GeneratePubkeyViewModel = GeneratePubkeyViewModel(repository, biometricKeyManager, dispatchers)
+
+    @Test
+    fun generateEncryptedKey_preservesUnlockAtStartup() = runTest {
+        val viewModel = createViewModel()
+        viewModel.updateNickname("my-encrypted-key")
+        viewModel.updateKeyType(KeyType.RSA)
+        viewModel.updateBits(KeyType.RSA.minBits) // fastest RSA for tests (1024)
+        viewModel.updatePassword1("pw")
+        viewModel.updatePassword2("pw")
+        viewModel.updateUnlockAtStartup(true)
+        advanceUntilIdle()
+
+        var succeeded = false
+        viewModel.generateKey { succeeded = true }
+        viewModel.onEntropyGathered(ByteArray(32) { it.toByte() })
+        advanceUntilIdle()
+
+        assertTrue("generateKey onSuccess callback should fire", succeeded)
+
+        val captor = argumentCaptor<Pubkey>()
+        verify(repository).save(captor.capture())
+        val saved = captor.firstValue
+        assertTrue(
+            "Passphrase-protected generated key must remain encrypted=true",
+            saved.encrypted
+        )
+        assertTrue(
+            "Generated encrypted key must persist unlockAtStartup=true when user enables it",
+            saved.startup
+        )
+    }
+
+    @Test
+    fun generateUnencryptedKey_preservesUnlockAtStartup() = runTest {
+        val viewModel = createViewModel()
+        viewModel.updateNickname("my-plain-key")
+        viewModel.updateKeyType(KeyType.RSA)
+        viewModel.updateBits(KeyType.RSA.minBits)
+        viewModel.updateUnlockAtStartup(true)
+        advanceUntilIdle()
+
+        viewModel.generateKey { }
+        viewModel.onEntropyGathered(ByteArray(32) { it.toByte() })
+        advanceUntilIdle()
+
+        val captor = argumentCaptor<Pubkey>()
+        verify(repository).save(captor.capture())
+        assertTrue(captor.firstValue.startup)
+    }
+
+    @Test
+    fun biometricSwitch_resetsUnlockAtStartup() {
+        val viewModel = createViewModel()
+        viewModel.updateKeyType(KeyType.RSA)
+        viewModel.updateUnlockAtStartup(true)
+        viewModel.updateUseBiometric(true)
+
+        assertTrue(
+            "Switching to biometric must clear unlockAtStartup since Keystore keys cannot auto-load",
+            !viewModel.uiState.value.unlockAtStartup
+        )
+    }
+}

--- a/app/src/test/java/org/connectbot/ui/screens/pubkeyeditor/PubkeyEditorViewModelTest.kt
+++ b/app/src/test/java/org/connectbot/ui/screens/pubkeyeditor/PubkeyEditorViewModelTest.kt
@@ -1,0 +1,123 @@
+/*
+ * ConnectBot: simple, powerful, open-source SSH client for Android
+ * Copyright 2025 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.connectbot.ui.screens.pubkeyeditor
+
+import androidx.lifecycle.SavedStateHandle
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.connectbot.data.PubkeyRepository
+import org.connectbot.data.entity.Pubkey
+import org.connectbot.di.CoroutineDispatchers
+import org.junit.After
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import timber.log.Timber
+
+/**
+ * Regression tests for issue #2081: pubkey password prompt never appears for encrypted
+ * keys on startup because the editor silently strips the "unlock at startup" flag when
+ * the key is encrypted.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class PubkeyEditorViewModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private val dispatchers = CoroutineDispatchers(
+        default = testDispatcher,
+        io = testDispatcher,
+        main = testDispatcher
+    )
+    private lateinit var repository: PubkeyRepository
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        Timber.plant(object : Timber.Tree() {
+            override fun log(priority: Int, tag: String?, message: String, t: Throwable?) {
+                // No-op for tests
+            }
+        })
+        repository = mock()
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        Timber.uprootAll()
+    }
+
+    private fun createViewModel(pubkeyId: Long): PubkeyEditorViewModel {
+        val savedStateHandle = SavedStateHandle(mapOf("pubkeyId" to pubkeyId))
+        return PubkeyEditorViewModel(savedStateHandle, repository, dispatchers)
+    }
+
+    /**
+     * Issue #2081: for an existing encrypted key, toggling "unlock at startup" on
+     * and saving (without changing the password) must persist startup=true.
+     *
+     * Previously the save path contained `startup = unlockAtStartup && !encrypted`,
+     * which silently cleared the flag whenever the key was password-protected. As a
+     * result the key was never auto-loaded and no passphrase prompt was offered on
+     * service start, so hosts configured to use "any in-memory pubkey" immediately
+     * fell back to password authentication.
+     */
+    @Test
+    fun save_encryptedKey_preservesUnlockAtStartup() = runTest {
+        val existingKey = Pubkey(
+            id = 42L,
+            nickname = "encrypted-key",
+            type = "RSA",
+            privateKey = byteArrayOf(1, 2, 3),
+            publicKey = byteArrayOf(4, 5, 6),
+            encrypted = true,
+            startup = false,
+            confirmation = false,
+            createdDate = 1_000L
+        )
+        whenever(repository.getById(42L)).thenReturn(existingKey)
+
+        val viewModel = createViewModel(42L)
+        advanceUntilIdle()
+
+        viewModel.updateUnlockAtStartup(true)
+        viewModel.save()
+        advanceUntilIdle()
+
+        val captor = argumentCaptor<Pubkey>()
+        verify(repository).save(captor.capture())
+        val saved = captor.firstValue
+        assertTrue(
+            "Encrypted key must keep encrypted=true after save",
+            saved.encrypted
+        )
+        assertTrue(
+            "Encrypted key must persist unlockAtStartup=true when user enables it",
+            saved.startup
+        )
+    }
+}


### PR DESCRIPTION
Fixes [https://github.com/connectbot/connectbot/issues/2081#issuecomment-4247738018](https://github.com/connectbot/connectbot/issues/2081#issuecomment-4247738018), where users report that after upgrading to v1.10.x, public-key authentication stops working for passphrase-protected keys—every connection falls back to password auth.

Three independent regressions introduced during the Compose/Room rewrite combine to produce the reported behavior.

**Bug A — editor silently strips "unlock at startup" from encrypted keys.**
`PubkeyEditorViewModel.save()` ran `startup = state.unlockAtStartup && !newEncrypted`, so the flag was zeroed whenever the key was encrypted. Users editing an existing encrypted key to re-enable the option silently saw the checkbox reset on save.

**Bug B — encrypted startup keys are silently dropped on service start.**
`TerminalManager.onCreate` loaded every startup key with `convertToKeyPair(pubkey, null)`. For encrypted keys that returns null and emits a generic `KeyLoadFailed`; the v1.9 "enter passphrase for startup keys" prompt was never reintroduced. Combined with a host configured to use "any in-memory pubkey", auth immediately falls back to password since no keys are ever cached.

**Bug C — key generation repeats Bug A.**
`GeneratePubkeyViewModel.saveKeyPair` had the same `startup = state.unlockAtStartup && !encrypted` gate, so a newly generated passphrase-protected key with "unlock at startup" ticked was persisted with `startup=false`.

## Changes

* `PubkeyEditorViewModel` / `GeneratePubkeyViewModel` — drop the `!encrypted` gate on `startup`. The biometric path in `saveBiometricKey` keeps its own `startup=false` because Keystore-backed keys genuinely cannot auto-load.
* New `StartupKeyLoader` — pure classifier returning `Loaded` / `NeedsPassphrase` / `Failed`, extracted so the decision logic is unit-testable outside the Android service lifecycle.
* `TerminalManager` — route encrypted startup keys to a new `pendingStartupKeyPrompts: StateFlow<List<Pubkey>>` instead of silently failing. Adds `unlockPendingStartupKey(pubkey, password)` and `dismissPendingStartupKey(pubkey)`.
* `HostListViewModel` / `HostListScreen` — observe the flow and surface a passphrase dialog per pending key, reusing existing `pubkey_unlock*` strings and the same visual pattern as `PubkeyListScreen`'s password dialog. Wrong passphrase sets an `isError` + supportingText = "Wrong password!" without dismissing.