### PR TITLE
Add more encodings for host connections

### DIFF
--- a/app/src/main/java/org/connectbot/ui/screens/profiles/ProfileEditorScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/profiles/ProfileEditorScreen.kt
@@ -260,6 +260,8 @@ fun ProfileEditorScreen(
 
                 EncodingSelector(
                     encoding = uiState.encoding,
+                    commonEncodings = viewModel.commonEncodings,
+                    allEncodings = viewModel.allEncodings,
                     onSelectEncoding = { viewModel.updateEncoding(it) },
                     modifier = Modifier.fillMaxWidth()
                 )
@@ -521,11 +523,17 @@ private fun DelKeySelector(
 @Composable
 private fun EncodingSelector(
     encoding: String,
+    commonEncodings: List<String>,
+    allEncodings: List<String>,
     onSelectEncoding: (String) -> Unit,
     modifier: Modifier = Modifier
 ) {
     var expanded by remember { mutableStateOf(false) }
-    val encodings = listOf("UTF-8", "ISO-8859-1", "US-ASCII", "Windows-1252")
+    var filterText by remember { mutableStateOf("") }
+
+    val filteredCommon = commonEncodings.filter { it.contains(filterText, ignoreCase = true) }
+    val filteredAll = allEncodings.filter { it.contains(filterText, ignoreCase = true) }
+    val showDivider = filteredCommon.isNotEmpty() && filteredAll.isNotEmpty()
 
     Column(modifier = modifier) {
         Text(
@@ -536,31 +544,54 @@ private fun EncodingSelector(
 
         ExposedDropdownMenuBox(
             expanded = expanded,
-            onExpandedChange = { expanded = it }
+            onExpandedChange = {
+                if (!it) {
+                    filterText = ""
+                }
+                expanded = it
+            }
         ) {
             OutlinedTextField(
-                value = encoding,
-                onValueChange = {},
-                readOnly = true,
+                value = if (expanded) filterText else encoding,
+                onValueChange = { filterText = it },
+                readOnly = !expanded,
                 singleLine = true,
                 trailingIcon = {
                     ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded)
                 },
                 colors = ExposedDropdownMenuDefaults.outlinedTextFieldColors(),
                 modifier = Modifier
-                    .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable)
+                    .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryEditable)
                     .fillMaxWidth()
             )
 
             ExposedDropdownMenu(
                 expanded = expanded,
-                onDismissRequest = { expanded = false }
+                onDismissRequest = {
+                    filterText = ""
+                    expanded = false
+                }
             ) {
-                encodings.forEach { enc ->
+                filteredCommon.forEach { enc ->
                     DropdownMenuItem(
                         text = { Text(enc) },
                         onClick = {
                             onSelectEncoding(enc)
+                            filterText = ""
+                            expanded = false
+                        },
+                        contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding
+                    )
+                }
+                if (showDivider) {
+                    HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
+                }
+                filteredAll.forEach { enc ->
+                    DropdownMenuItem(
+                        text = { Text(enc) },
+                        onClick = {
+                            onSelectEncoding(enc)
+                            filterText = ""
                             expanded = false
                         },
                         contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding

--- a/app/src/main/java/org/connectbot/ui/screens/profiles/ProfileEditorViewModel.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/profiles/ProfileEditorViewModel.kt
@@ -37,6 +37,7 @@ import org.connectbot.di.CoroutineDispatchers
 import org.connectbot.util.LocalFontProvider
 import org.connectbot.util.TerminalFont
 import org.connectbot.util.TerminalFontProvider
+import java.nio.charset.Charset
 import javax.inject.Inject
 
 data class ProfileEditorUiState(
@@ -71,6 +72,20 @@ class ProfileEditorViewModel @Inject constructor(
     @ApplicationContext private val context: Context,
     private val dispatchers: CoroutineDispatchers
 ) : ViewModel() {
+
+    val commonEncodings: List<String> = listOf(
+        "UTF-8",
+        "ISO-8859-1",
+        "US-ASCII",
+        "windows-1252",
+        "CP437"
+    )
+
+    val allEncodings: List<String> = run {
+        val charsets = Charset.availableCharsets().keys.toMutableSet()
+        charsets.add("CP437")
+        charsets.sortedWith(String.CASE_INSENSITIVE_ORDER)
+    }
 
     private val profileId: Long = savedStateHandle.get<Long>("profileId") ?: -1L
     private val localFontProvider = LocalFontProvider(context)

--- a/app/src/test/java/org/connectbot/ui/screens/profiles/ProfileEditorViewModelTest.kt
+++ b/app/src/test/java/org/connectbot/ui/screens/profiles/ProfileEditorViewModelTest.kt
@@ -1,0 +1,115 @@
+/*
+ * ConnectBot: simple, powerful, open-source SSH client for Android
+ * Copyright 2026 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.connectbot.ui.screens.profiles
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.lifecycle.SavedStateHandle
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.connectbot.data.ColorSchemeRepository
+import org.connectbot.data.ProfileRepository
+import org.connectbot.di.CoroutineDispatchers
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+class ProfileEditorViewModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private val dispatchers = CoroutineDispatchers(
+        default = testDispatcher,
+        io = testDispatcher,
+        main = testDispatcher
+    )
+    private lateinit var context: Context
+    private lateinit var profileRepository: ProfileRepository
+    private lateinit var colorSchemeRepository: ColorSchemeRepository
+    private lateinit var sharedPreferences: SharedPreferences
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        context = ApplicationProvider.getApplicationContext()
+        profileRepository = mock()
+        colorSchemeRepository = mock()
+        sharedPreferences = mock()
+
+        whenever(colorSchemeRepository.observeAllSchemes()).thenReturn(MutableStateFlow(emptyList()))
+        whenever(sharedPreferences.getString("customFonts", "")).thenReturn("")
+        whenever(sharedPreferences.getString("customTerminalTypes", "")).thenReturn("")
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun createViewModel(): ProfileEditorViewModel = ProfileEditorViewModel(
+        savedStateHandle = SavedStateHandle(),
+        profileRepository = profileRepository,
+        colorSchemeRepository = colorSchemeRepository,
+        prefs = sharedPreferences,
+        context = context,
+        dispatchers = dispatchers
+    )
+
+    @Test
+    fun commonEncodings_hasExpectedFiveEntriesInOrder() {
+        val viewModel = createViewModel()
+        assertEquals(
+            listOf("UTF-8", "ISO-8859-1", "US-ASCII", "windows-1252", "CP437"),
+            viewModel.commonEncodings
+        )
+    }
+
+    @Test
+    fun allEncodings_containsCP437() {
+        val viewModel = createViewModel()
+        assertTrue("allEncodings must contain CP437", viewModel.allEncodings.contains("CP437"))
+    }
+
+    @Test
+    fun allEncodings_isSortedAlphabetically() {
+        val viewModel = createViewModel()
+        val sorted = viewModel.allEncodings.sortedWith(String.CASE_INSENSITIVE_ORDER)
+        assertEquals("allEncodings must be sorted alphabetically (case-insensitive)", sorted, viewModel.allEncodings)
+    }
+
+    @Test
+    fun allEncodings_containsAllCommonEncodings() {
+        val viewModel = createViewModel()
+        val common = listOf("UTF-8", "ISO-8859-1", "US-ASCII", "windows-1252", "CP437")
+        common.forEach { encoding ->
+            assertTrue("allEncodings must contain $encoding", viewModel.allEncodings.contains(encoding))
+        }
+    }
+}


### PR DESCRIPTION
I missed this when migrating the old code. We should try to support everything that Android claims to support. We'll keep the common encodings at the top for convenience.