### PR TITLE
ci: ignore tags for main build

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -10,6 +10,8 @@ on:
       - 'LICENSE'
       - '.java-version'
       - 'icons/**'
+    tags-ignore:
+      - "v*.*.*"
   pull_request:
     branches: [ main ]
     paths:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ on:
       - 'LICENSE'
       - '.java-version'
       - 'icons/**'
+    tags-ignore:
+      - "v*.*.*"
   pull_request:
     branches: [ main ]
     paths-ignore:


### PR DESCRIPTION
If we don't ignore tags on the 'main' branch, we will get two builds simultaneously for version tags. This messes up the CI and ends up with the wrong version number being calculated depending on which finishes first.