### PR TITLE
Fix reconnect

### DIFF
--- a/app/src/main/java/org/connectbot/service/DisconnectReason.kt
+++ b/app/src/main/java/org/connectbot/service/DisconnectReason.kt
@@ -1,6 +1,6 @@
 /*
  * ConnectBot: simple, powerful, open-source SSH client for Android
- * Copyright 2025 Kenny Root
+ * Copyright 2026 Kenny Root
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/org/connectbot/service/DisconnectReason.kt
+++ b/app/src/main/java/org/connectbot/service/DisconnectReason.kt
@@ -1,0 +1,30 @@
+/*
+ * ConnectBot: simple, powerful, open-source SSH client for Android
+ * Copyright 2025 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.connectbot.service
+
+enum class DisconnectReason {
+    USER_REQUESTED,
+    REMOTE_EOF,
+    IO_ERROR,
+    NETWORK_LOST,
+    AUTH_FAIL,
+    UNKNOWN;
+
+    val isIntentional: Boolean
+        get() = this == USER_REQUESTED || this == REMOTE_EOF
+}

--- a/app/src/main/java/org/connectbot/service/TerminalBridge.kt
+++ b/app/src/main/java/org/connectbot/service/TerminalBridge.kt
@@ -143,6 +143,8 @@ class TerminalBridge {
         private set
     var connecting = false
         private set
+    var disconnectReason: DisconnectReason = DisconnectReason.UNKNOWN
+        private set
     private var awaitingClose = false
 
     private var forcedSize = false
@@ -623,7 +625,7 @@ class TerminalBridge {
     /**
      * Force disconnection of this terminal bridge.
      */
-    fun dispatchDisconnect(immediate: Boolean) {
+    fun dispatchDisconnect(immediate: Boolean, reason: DisconnectReason = DisconnectReason.UNKNOWN) {
         // We don't need to do this multiple times.
         synchronized(this) {
             if (disconnected && !immediate) {
@@ -632,6 +634,9 @@ class TerminalBridge {
 
             disconnected = true
             connecting = false
+            if (disconnectReason == DisconnectReason.UNKNOWN) {
+                disconnectReason = reason
+            }
         }
 
         // Cancel any pending prompts
@@ -647,7 +652,7 @@ class TerminalBridge {
             }
         }
 
-        if (immediate || (host.quickDisconnect && !host.stayConnected)) {
+        if (immediate || reason.isIntentional || (host.quickDisconnect && !host.stayConnected)) {
             awaitingClose = true
             triggerDisconnectListener()
         } else {
@@ -996,7 +1001,7 @@ class TerminalBridge {
             _networkStatusMessages.emit(manager.res.getString(R.string.network_grace_period_expired))
 
             // Trigger normal disconnect flow
-            dispatchDisconnect(immediate = false)
+            dispatchDisconnect(immediate = false, reason = DisconnectReason.NETWORK_LOST)
         }
     }
 
@@ -1039,7 +1044,7 @@ class TerminalBridge {
             // IP changed - TCP connection is broken, must reconnect
             scope.launch { _networkStatusMessages.emit(manager.res.getString(R.string.network_restored_ip_changed)) }
             lastKnownNetworkState = null
-            dispatchDisconnect(immediate = false)
+            dispatchDisconnect(immediate = false, reason = DisconnectReason.NETWORK_LOST)
         }
     }
 

--- a/app/src/main/java/org/connectbot/service/TerminalBridge.kt
+++ b/app/src/main/java/org/connectbot/service/TerminalBridge.kt
@@ -624,11 +624,16 @@ class TerminalBridge {
 
     /**
      * Force disconnection of this terminal bridge.
+     *
+     * Intentional reasons ([DisconnectReason.isIntentional]) always take the
+     * immediate-close path, even if the bridge already reached the
+     * disconnected state — this is how the "Close" button on the reconnect
+     * overlay tears down a session that an IO_ERROR already marked disconnected.
      */
-    fun dispatchDisconnect(immediate: Boolean, reason: DisconnectReason = DisconnectReason.UNKNOWN) {
+    fun dispatchDisconnect(reason: DisconnectReason) {
         // We don't need to do this multiple times.
         synchronized(this) {
-            if (disconnected && !immediate) {
+            if (disconnected && !reason.isIntentional) {
                 return
             }
 
@@ -652,7 +657,7 @@ class TerminalBridge {
             }
         }
 
-        if (immediate || reason.isIntentional || (host.quickDisconnect && !host.stayConnected)) {
+        if (reason.isIntentional || (host.quickDisconnect && !host.stayConnected)) {
             awaitingClose = true
             triggerDisconnectListener()
         } else {
@@ -1001,7 +1006,7 @@ class TerminalBridge {
             _networkStatusMessages.emit(manager.res.getString(R.string.network_grace_period_expired))
 
             // Trigger normal disconnect flow
-            dispatchDisconnect(immediate = false, reason = DisconnectReason.NETWORK_LOST)
+            dispatchDisconnect(DisconnectReason.NETWORK_LOST)
         }
     }
 
@@ -1044,7 +1049,7 @@ class TerminalBridge {
             // IP changed - TCP connection is broken, must reconnect
             scope.launch { _networkStatusMessages.emit(manager.res.getString(R.string.network_restored_ip_changed)) }
             lastKnownNetworkState = null
-            dispatchDisconnect(immediate = false, reason = DisconnectReason.NETWORK_LOST)
+            dispatchDisconnect(DisconnectReason.NETWORK_LOST)
         }
     }
 

--- a/app/src/main/java/org/connectbot/service/TerminalManager.kt
+++ b/app/src/main/java/org/connectbot/service/TerminalManager.kt
@@ -265,7 +265,7 @@ class TerminalManager :
 
         stopIdleTimer()
 
-        disconnectAll(immediate = true, excludeLocal = false)
+        disconnectAll(excludeLocal = false)
 
         connectionNotifier.hideRunningNotification(this)
 
@@ -285,7 +285,7 @@ class TerminalManager :
     /**
      * Disconnect all currently connected bridges.
      */
-    fun disconnectAll(immediate: Boolean, excludeLocal: Boolean) {
+    fun disconnectAll(excludeLocal: Boolean) {
         var tmpBridges: Array<TerminalBridge>? = null
 
         synchronized(_bridges) {
@@ -300,7 +300,7 @@ class TerminalManager :
                 if (excludeLocal && !tmpBridge.isUsingNetwork()) {
                     continue
                 }
-                tmpBridge.dispatchDisconnect(immediate, DisconnectReason.USER_REQUESTED)
+                tmpBridge.dispatchDisconnect(DisconnectReason.USER_REQUESTED)
             }
         }
     }

--- a/app/src/main/java/org/connectbot/service/TerminalManager.kt
+++ b/app/src/main/java/org/connectbot/service/TerminalManager.kt
@@ -300,7 +300,7 @@ class TerminalManager :
                 if (excludeLocal && !tmpBridge.isUsingNetwork()) {
                     continue
                 }
-                tmpBridge.dispatchDisconnect(immediate)
+                tmpBridge.dispatchDisconnect(immediate, DisconnectReason.USER_REQUESTED)
             }
         }
     }

--- a/app/src/main/java/org/connectbot/transport/Local.kt
+++ b/app/src/main/java/org/connectbot/transport/Local.kt
@@ -24,6 +24,7 @@ import androidx.core.net.toUri
 import com.google.ase.Exec
 import org.connectbot.R
 import org.connectbot.data.entity.Host
+import org.connectbot.service.DisconnectReason
 import timber.log.Timber
 import java.io.FileDescriptor
 import java.io.FileInputStream
@@ -69,7 +70,7 @@ class Local @VisibleForTesting constructor(private val killer: Killer) : AbsTran
         shellPid = pids[0]
         val exitWatcher = Runnable {
             Exec.waitFor(shellPid)
-            bridge?.dispatchDisconnect(false)
+            bridge?.dispatchDisconnect(false, DisconnectReason.REMOTE_EOF)
         }
 
         val exitWatcherThread = Thread(exitWatcher)
@@ -99,7 +100,7 @@ class Local @VisibleForTesting constructor(private val killer: Killer) : AbsTran
     @Throws(IOException::class)
     override fun read(buffer: ByteArray, offset: Int, length: Int): Int {
         val inputStream = `is` ?: run {
-            bridge?.dispatchDisconnect(false)
+            bridge?.dispatchDisconnect(false, DisconnectReason.IO_ERROR)
             throw IOException("session closed")
         }
         return inputStream.read(buffer, offset, length)

--- a/app/src/main/java/org/connectbot/transport/Local.kt
+++ b/app/src/main/java/org/connectbot/transport/Local.kt
@@ -70,7 +70,7 @@ class Local @VisibleForTesting constructor(private val killer: Killer) : AbsTran
         shellPid = pids[0]
         val exitWatcher = Runnable {
             Exec.waitFor(shellPid)
-            bridge?.dispatchDisconnect(false, DisconnectReason.REMOTE_EOF)
+            bridge?.dispatchDisconnect(DisconnectReason.REMOTE_EOF)
         }
 
         val exitWatcherThread = Thread(exitWatcher)
@@ -100,7 +100,7 @@ class Local @VisibleForTesting constructor(private val killer: Killer) : AbsTran
     @Throws(IOException::class)
     override fun read(buffer: ByteArray, offset: Int, length: Int): Int {
         val inputStream = `is` ?: run {
-            bridge?.dispatchDisconnect(false, DisconnectReason.IO_ERROR)
+            bridge?.dispatchDisconnect(DisconnectReason.IO_ERROR)
             throw IOException("session closed")
         }
         return inputStream.read(buffer, offset, length)

--- a/app/src/main/java/org/connectbot/transport/SSH.kt
+++ b/app/src/main/java/org/connectbot/transport/SSH.kt
@@ -960,7 +960,7 @@ class SSH :
     }
 
     private fun onDisconnect(reason: DisconnectReason = DisconnectReason.IO_ERROR) {
-        bridge?.dispatchDisconnect(false, reason)
+        bridge?.dispatchDisconnect(reason)
     }
 
     @Throws(IOException::class)

--- a/app/src/main/java/org/connectbot/transport/SSH.kt
+++ b/app/src/main/java/org/connectbot/transport/SSH.kt
@@ -47,6 +47,7 @@ import org.connectbot.data.entity.Host
 import org.connectbot.data.entity.KeyStorageType
 import org.connectbot.data.entity.PortForward
 import org.connectbot.data.entity.Pubkey
+import org.connectbot.service.DisconnectReason
 import org.connectbot.service.TerminalBridge
 import org.connectbot.service.TerminalManager
 import org.connectbot.service.requestBiometricAuth
@@ -958,8 +959,8 @@ class SSH :
         jumpConnections.clear()
     }
 
-    private fun onDisconnect() {
-        bridge?.dispatchDisconnect(false)
+    private fun onDisconnect(reason: DisconnectReason = DisconnectReason.IO_ERROR) {
+        bridge?.dispatchDisconnect(false, reason)
     }
 
     @Throws(IOException::class)
@@ -988,7 +989,7 @@ class SSH :
 
         if ((newConditions and ChannelCondition.EOF) != 0) {
             close()
-            onDisconnect()
+            onDisconnect(DisconnectReason.REMOTE_EOF)
             throw IOException("Remote end closed connection")
         }
 

--- a/app/src/main/java/org/connectbot/transport/SSH.kt
+++ b/app/src/main/java/org/connectbot/transport/SSH.kt
@@ -988,8 +988,11 @@ class SSH :
         }
 
         if ((newConditions and ChannelCondition.EOF) != 0) {
-            close()
+            // Dispatch REMOTE_EOF before close(): connection.close() fires
+            // connectionLost() synchronously, which would otherwise race in
+            // with IO_ERROR and trigger the reconnect overlay.
             onDisconnect(DisconnectReason.REMOTE_EOF)
+            close()
             throw IOException("Remote end closed connection")
         }
 

--- a/app/src/main/java/org/connectbot/transport/Telnet.kt
+++ b/app/src/main/java/org/connectbot/transport/Telnet.kt
@@ -24,6 +24,7 @@ import androidx.core.net.toUri
 import de.mud.telnet.TelnetProtocolHandler
 import org.connectbot.R
 import org.connectbot.data.entity.Host
+import org.connectbot.service.DisconnectReason
 import org.connectbot.service.TerminalBridge
 import org.connectbot.service.TerminalManager
 import org.connectbot.util.HostConstants
@@ -178,7 +179,7 @@ class Telnet : AbsTransport {
             } while (n == 0)
             n = `is`!!.read(buffer, offset, length)
             if (n < 0) {
-                bridge?.dispatchDisconnect(false)
+                bridge?.dispatchDisconnect(false, DisconnectReason.REMOTE_EOF)
                 throw IOException("Remote end closed connection.")
             }
 
@@ -193,7 +194,7 @@ class Telnet : AbsTransport {
         try {
             os?.write(buffer)
         } catch (_: SocketException) {
-            bridge?.dispatchDisconnect(false)
+            bridge?.dispatchDisconnect(false, DisconnectReason.IO_ERROR)
         }
     }
 
@@ -202,7 +203,7 @@ class Telnet : AbsTransport {
         try {
             os?.write(c)
         } catch (_: SocketException) {
-            bridge?.dispatchDisconnect(false)
+            bridge?.dispatchDisconnect(false, DisconnectReason.IO_ERROR)
         }
     }
 

--- a/app/src/main/java/org/connectbot/transport/Telnet.kt
+++ b/app/src/main/java/org/connectbot/transport/Telnet.kt
@@ -179,7 +179,7 @@ class Telnet : AbsTransport {
             } while (n == 0)
             n = `is`!!.read(buffer, offset, length)
             if (n < 0) {
-                bridge?.dispatchDisconnect(false, DisconnectReason.REMOTE_EOF)
+                bridge?.dispatchDisconnect(DisconnectReason.REMOTE_EOF)
                 throw IOException("Remote end closed connection.")
             }
 
@@ -194,7 +194,7 @@ class Telnet : AbsTransport {
         try {
             os?.write(buffer)
         } catch (_: SocketException) {
-            bridge?.dispatchDisconnect(false, DisconnectReason.IO_ERROR)
+            bridge?.dispatchDisconnect(DisconnectReason.IO_ERROR)
         }
     }
 
@@ -203,7 +203,7 @@ class Telnet : AbsTransport {
         try {
             os?.write(c)
         } catch (_: SocketException) {
-            bridge?.dispatchDisconnect(false, DisconnectReason.IO_ERROR)
+            bridge?.dispatchDisconnect(DisconnectReason.IO_ERROR)
         }
     }
 

--- a/app/src/main/java/org/connectbot/ui/AppViewModel.kt
+++ b/app/src/main/java/org/connectbot/ui/AppViewModel.kt
@@ -242,7 +242,7 @@ class AppViewModel @Inject constructor(
         val state = _uiState.value
         if (state is AppUiState.Ready && _pendingDisconnectAll.value) {
             Timber.d("Executing pending disconnectAll")
-            state.terminalManager.disconnectAll(immediate = true, excludeLocal = false)
+            state.terminalManager.disconnectAll(excludeLocal = false)
             _pendingDisconnectAll.value = false
             viewModelScope.launch {
                 _finishActivity.send(Unit)

--- a/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
@@ -599,7 +599,7 @@ fun ConsoleScreen(
                                     modifier = Modifier.fillMaxWidth(),
                                     horizontalArrangement = Arrangement.End
                                 ) {
-                                    TextButton(onClick = { bridge.dispatchDisconnect(true, DisconnectReason.USER_REQUESTED) }) {
+                                    TextButton(onClick = { bridge.dispatchDisconnect(DisconnectReason.USER_REQUESTED) }) {
                                         Text(
                                             stringResource(R.string.console_menu_close),
                                             color = terminalColors.overlayText
@@ -652,7 +652,7 @@ fun ConsoleScreen(
                 onDismiss = { showDisconnectDialog = false },
                 onConfirm = {
                     showDisconnectDialog = false
-                    currentBridge.dispatchDisconnect(true, DisconnectReason.USER_REQUESTED)
+                    currentBridge.dispatchDisconnect(DisconnectReason.USER_REQUESTED)
                 }
             )
         }

--- a/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
@@ -113,6 +113,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.connectbot.R
 import org.connectbot.data.entity.Host
+import org.connectbot.service.DisconnectReason
 import org.connectbot.service.PromptRequest
 import org.connectbot.terminal.ProgressState
 import org.connectbot.terminal.SelectionController
@@ -598,7 +599,7 @@ fun ConsoleScreen(
                                     modifier = Modifier.fillMaxWidth(),
                                     horizontalArrangement = Arrangement.End
                                 ) {
-                                    TextButton(onClick = { showDisconnectDialog = true }) {
+                                    TextButton(onClick = { bridge.dispatchDisconnect(true, DisconnectReason.USER_REQUESTED) }) {
                                         Text(
                                             stringResource(R.string.console_menu_close),
                                             color = terminalColors.overlayText
@@ -651,7 +652,7 @@ fun ConsoleScreen(
                 onDismiss = { showDisconnectDialog = false },
                 onConfirm = {
                     showDisconnectDialog = false
-                    currentBridge.dispatchDisconnect(true)
+                    currentBridge.dispatchDisconnect(true, DisconnectReason.USER_REQUESTED)
                 }
             )
         }

--- a/app/src/main/java/org/connectbot/ui/screens/hostlist/HostListViewModel.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/hostlist/HostListViewModel.kt
@@ -268,12 +268,12 @@ class HostListViewModel @Inject constructor(
     }
 
     fun disconnectAll() {
-        terminalManager?.disconnectAll(immediate = true, excludeLocal = false)
+        terminalManager?.disconnectAll(excludeLocal = false)
     }
 
     fun disconnectHost(host: Host) {
         val bridge = terminalManager?.bridgesFlow?.value?.find { it.host.id == host.id }
-        bridge?.dispatchDisconnect(true, DisconnectReason.USER_REQUESTED)
+        bridge?.dispatchDisconnect(DisconnectReason.USER_REQUESTED)
     }
 
     fun clearError() {

--- a/app/src/main/java/org/connectbot/ui/screens/hostlist/HostListViewModel.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/hostlist/HostListViewModel.kt
@@ -38,6 +38,7 @@ import org.connectbot.data.HostRepository
 import org.connectbot.data.entity.Host
 import org.connectbot.data.entity.Pubkey
 import org.connectbot.di.CoroutineDispatchers
+import org.connectbot.service.DisconnectReason
 import org.connectbot.service.ServiceError
 import org.connectbot.service.TerminalManager
 import org.connectbot.util.PreferenceConstants
@@ -272,7 +273,7 @@ class HostListViewModel @Inject constructor(
 
     fun disconnectHost(host: Host) {
         val bridge = terminalManager?.bridgesFlow?.value?.find { it.host.id == host.id }
-        bridge?.dispatchDisconnect(true)
+        bridge?.dispatchDisconnect(true, DisconnectReason.USER_REQUESTED)
     }
 
     fun clearError() {

--- a/app/src/test/java/org/connectbot/ui/AppViewModelPermissionTest.kt
+++ b/app/src/test/java/org/connectbot/ui/AppViewModelPermissionTest.kt
@@ -161,7 +161,7 @@ class AppViewModelPermissionTest {
         val result = viewModel.executePendingDisconnectAllIfReady()
 
         assertFalse("Should return false when not pending", result)
-        verify(terminalManager, never()).disconnectAll(any(), any())
+        verify(terminalManager, never()).disconnectAll(any())
     }
 
     @Test
@@ -184,7 +184,7 @@ class AppViewModelPermissionTest {
 
         assertTrue("Should return true when executed", result)
         assertFalse("Should clear pending flag", viewModel.pendingDisconnectAll.value)
-        verify(terminalManager).disconnectAll(immediate = true, excludeLocal = false)
+        verify(terminalManager).disconnectAll(excludeLocal = false)
         assertEquals("Should emit finish activity event", 1, finishEvents.size)
 
         job.cancel()
@@ -254,7 +254,7 @@ class AppViewModelPermissionTest {
         advanceUntilIdle()
 
         assertTrue("Should execute when ready", result)
-        verify(terminalManager).disconnectAll(immediate = true, excludeLocal = false)
+        verify(terminalManager).disconnectAll(excludeLocal = false)
         assertEquals("Should emit finish event", 1, finishEvents.size)
         assertFalse("Should clear pending flag", viewModel.pendingDisconnectAll.value)
 


### PR DESCRIPTION
Fixes #2085. The "Connection Lost" overlay was appearing after a clean `exit` from a remote shell, and tapping **Close** raised a spurious "Are you sure you want to disconnect?" dialog for a session that was already gone.

**Root cause:** `SSH.read()` called `close()` before `onDisconnect(REMOTE_EOF)`. Inside `close()`, `connection.close()` synchronously fires `connectionLost()` on the registered `ConnectionMonitor`, which dispatched `IO_ERROR` first. That marked the bridge disconnected with a non-intentional reason and showed the reconnect overlay; the subsequent `REMOTE_EOF` dispatch was dropped by the disconnected-guard in `dispatchDisconnect`.

## Changes

- **New `DisconnectReason` enum** (`USER_REQUESTED`, `REMOTE_EOF`, `IO_ERROR`, `NETWORK_LOST`, `AUTH_FAIL`, `UNKNOWN`) threaded through `TerminalBridge.dispatchDisconnect`.
- Transports classify their disconnects: clean remote-EOF (user typed `exit`) → `REMOTE_EOF`; `IOException`/`ConnectionMonitor` paths → `IO_ERROR`; grace-period expiry / IP change → `NETWORK_LOST`; UI-initiated → `USER_REQUESTED`.
- Intentional reasons (`REMOTE_EOF`, `USER_REQUESTED`) skip the reconnect/close overlay and trigger the disconnect listener immediately.
- `SSH.read()` now dispatches `REMOTE_EOF` **before** `close()` so the follow-up `connectionLost` → `IO_ERROR` early-returns via the disconnected-guard.
- "Close" on the Connection Lost overlay no longer re-prompts for confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)