### PR TITLE
Try to make openUrl safer

### DIFF
--- a/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
@@ -152,7 +152,7 @@ fun ConsoleScreen(
     onNavigateBack: () -> Unit,
     onNavigateToPortForwards: (Long) -> Unit,
     modifier: Modifier = Modifier,
-    viewModel: ConsoleViewModel = hiltViewModel()
+    viewModel: ConsoleViewModel = hiltViewModel(),
 ) {
     val context = LocalContext.current
     val terminalManager = LocalTerminalManager.current
@@ -329,7 +329,7 @@ fun ConsoleScreen(
         uiState.error?.let { error ->
             snackbarHostState.showSnackbar(
                 message = error,
-                withDismissAction = true
+                withDismissAction = true,
             )
         }
     }
@@ -370,13 +370,13 @@ fun ConsoleScreen(
         snackbarHost = { SnackbarHost(snackbarHostState) },
         modifier = modifier.fillMaxSize(),
         contentWindowInsets = ScaffoldDefaults.contentWindowInsets
-            .union(WindowInsets.imeAnimationTarget)
+            .union(WindowInsets.imeAnimationTarget),
     ) { innerPadding ->
         // Show tabs if multiple terminals
         if (uiState.bridges.size > 1) {
             PrimaryTabRow(
                 selectedTabIndex = uiState.currentBridgeIndex,
-                modifier = Modifier.fillMaxWidth()
+                modifier = Modifier.fillMaxWidth(),
             ) {
                 uiState.bridges.forEachIndexed { index, bridge ->
                     Tab(
@@ -386,9 +386,9 @@ fun ConsoleScreen(
                             Text(
                                 bridge.host.nickname,
                                 maxLines = 1,
-                                overflow = TextOverflow.Ellipsis
+                                overflow = TextOverflow.Ellipsis,
                             )
-                        }
+                        },
                     )
                 }
             }
@@ -405,7 +405,7 @@ fun ConsoleScreen(
                     start = innerPadding.calculateStartPadding(layoutDirection),
                     end = innerPadding.calculateEndPadding(layoutDirection),
                     top = if (!titleBarHide) 0.dp else innerPadding.calculateTopPadding(),
-                    bottom = innerPadding.calculateBottomPadding()
+                    bottom = innerPadding.calculateBottomPadding(),
                 )
                 .windowInsetsPadding(WindowInsets.imeAnimationTarget)
                 .onPreviewKeyEvent { keyEvent ->
@@ -457,7 +457,7 @@ fun ConsoleScreen(
                     } else {
                         false
                     }
-                }
+                },
         ) {
             when {
                 uiState.isLoading -> {
@@ -478,8 +478,8 @@ fun ConsoleScreen(
                         modifier = Modifier
                             .fillMaxSize()
                             .padding(
-                                top = if (!titleBarHide) titleBarHeight else 0.dp
-                            )
+                                top = if (!titleBarHide) titleBarHeight else 0.dp,
+                            ),
                     ) {
                         // Get font from profile (stored in bridge)
                         val fontResult = rememberTerminalTypefaceResultFromStoredValue(bridge.fontFamily)
@@ -492,7 +492,7 @@ fun ConsoleScreen(
                             if (fontResult.loadFailed && !fontResult.isLoading) {
                                 coroutineScope.launch {
                                     snackbarHostState.showSnackbar(
-                                        message = "Failed to load font '${fontResult.requestedFontName}'. Using system default."
+                                        message = "Failed to load font '${fontResult.requestedFontName}'. Using system default.",
                                     )
                                 }
                             }
@@ -503,7 +503,7 @@ fun ConsoleScreen(
                             modifier = Modifier
                                 .fillMaxSize()
                                 .padding(
-                                    bottom = if (keyboardAlwaysVisible) TERMINAL_KEYBOARD_HEIGHT_DP.dp else 0.dp
+                                    bottom = if (keyboardAlwaysVisible) TERMINAL_KEYBOARD_HEIGHT_DP.dp else 0.dp,
                                 ),
                             typeface = fontResult.typeface,
                             initialFontSize = fontSize.sp,
@@ -519,7 +519,7 @@ fun ConsoleScreen(
                             },
                             onHyperlinkClick = { url ->
                                 openUrl(url)
-                            }
+                            },
                         )
 
                         // Set up text input request callback from bridge (for camera button)
@@ -537,7 +537,7 @@ fun ConsoleScreen(
                             enter = fadeIn(animationSpec = tween(durationMillis = 100)),
                             exit = fadeOut(animationSpec = tween(durationMillis = 100)),
                             modifier = Modifier
-                                .align(Alignment.BottomCenter)
+                                .align(Alignment.BottomCenter),
                         ) {
                             TerminalKeyboard(
                                 bridge = bridge,
@@ -555,7 +555,7 @@ fun ConsoleScreen(
                                     keyboardScrollInProgress = inProgress
                                 },
                                 imeVisible = imeVisible,
-                                playAnimation = !hasPlayedKeyboardAnimation
+                                playAnimation = !hasPlayedKeyboardAnimation,
                             )
                         }
 
@@ -575,7 +575,7 @@ fun ConsoleScreen(
                                 termFocusRequester.requestFocus()
                             },
                             modifier = Modifier
-                                .align(Alignment.BottomCenter)
+                                .align(Alignment.BottomCenter),
                         )
 
                         // Show reconnect/close overlay when session is disconnected
@@ -583,34 +583,34 @@ fun ConsoleScreen(
                             visible = disconnected && !connecting && promptState == null,
                             enter = slideInVertically(initialOffsetY = { it }),
                             exit = slideOutVertically(targetOffsetY = { it }),
-                            modifier = Modifier.align(Alignment.BottomCenter)
+                            modifier = Modifier.align(Alignment.BottomCenter),
                         ) {
                             val terminalColors = MaterialTheme.colorScheme.terminal
                             Column(
                                 modifier = Modifier
                                     .fillMaxWidth()
                                     .background(terminalColors.overlayBackground)
-                                    .padding(16.dp)
+                                    .padding(16.dp),
                             ) {
                                 Text(
                                     text = stringResource(R.string.alert_disconnect_msg),
                                     style = MaterialTheme.typography.bodyLarge,
                                     color = terminalColors.overlayText,
-                                    modifier = Modifier.padding(bottom = 16.dp)
+                                    modifier = Modifier.padding(bottom = 16.dp),
                                 )
                                 Row(
                                     modifier = Modifier.fillMaxWidth(),
-                                    horizontalArrangement = Arrangement.End
+                                    horizontalArrangement = Arrangement.End,
                                 ) {
                                     TextButton(onClick = { bridge.dispatchDisconnect(DisconnectReason.USER_REQUESTED) }) {
                                         Text(
                                             stringResource(R.string.console_menu_close),
-                                            color = terminalColors.overlayText
+                                            color = terminalColors.overlayText,
                                         )
                                     }
                                     Button(
                                         onClick = { viewModel.reconnect(bridge) },
-                                        modifier = Modifier.padding(start = 8.dp)
+                                        modifier = Modifier.padding(start = 8.dp),
                                     ) {
                                         Text(stringResource(R.string.console_menu_reconnect))
                                     }
@@ -629,7 +629,7 @@ fun ConsoleScreen(
                 onDismiss = { showUrlScanDialog = false },
                 onUrlClick = { url ->
                     openUrl(url)
-                }
+                },
             )
         }
 
@@ -645,7 +645,7 @@ fun ConsoleScreen(
                 onDisableForceSize = {
                     // Disable force size for this session
                     forceSize = null
-                }
+                },
             )
         }
 
@@ -656,7 +656,7 @@ fun ConsoleScreen(
                 onConfirm = {
                     showDisconnectDialog = false
                     currentBridge.dispatchDisconnect(DisconnectReason.USER_REQUESTED)
-                }
+                },
             )
         }
 
@@ -670,7 +670,7 @@ fun ConsoleScreen(
                 onDismiss = {
                     showTextInputDialog = false
                     termFocusRequester.requestFocus()
-                }
+                },
             )
         }
 
@@ -684,7 +684,7 @@ fun ConsoleScreen(
                         currentBridge?.host?.nickname
                             ?: stringResource(R.string.console_default_title),
                         maxLines = 1,
-                        overflow = TextOverflow.Ellipsis
+                        overflow = TextOverflow.Ellipsis,
                     )
                 },
                 modifier = Modifier.onSizeChanged {
@@ -694,14 +694,14 @@ fun ConsoleScreen(
                     IconButton(onClick = onNavigateBack) {
                         Icon(
                             Icons.AutoMirrored.Filled.ArrowBack,
-                            stringResource(R.string.button_back)
+                            stringResource(R.string.button_back),
                         )
                     }
                 },
                 colors = if (titleBarHide) {
                     // Translucent overlay when auto-hide is enabled
                     TopAppBarDefaults.topAppBarColors(
-                        containerColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.5f)
+                        containerColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.5f),
                     )
                 } else {
                     // Solid color when permanently visible
@@ -711,11 +711,11 @@ fun ConsoleScreen(
                     // Text Input button
                     IconButton(
                         onClick = { showTextInputDialog = true },
-                        enabled = currentBridge != null
+                        enabled = currentBridge != null,
                     ) {
                         Icon(
                             Icons.Default.Edit,
-                            contentDescription = stringResource(R.string.console_menu_text_input)
+                            contentDescription = stringResource(R.string.console_menu_text_input),
                         )
                     }
 
@@ -730,11 +730,11 @@ fun ConsoleScreen(
                                 bridge.injectString(clip)
                             }
                         },
-                        enabled = currentBridge != null
+                        enabled = currentBridge != null,
                     ) {
                         Icon(
                             Icons.Default.ContentPaste,
-                            contentDescription = stringResource(R.string.console_menu_paste)
+                            contentDescription = stringResource(R.string.console_menu_paste),
                         )
                     }
 
@@ -747,7 +747,7 @@ fun ConsoleScreen(
                         }) {
                             Icon(
                                 Icons.Default.MoreVert,
-                                contentDescription = stringResource(R.string.button_more_options)
+                                contentDescription = stringResource(R.string.button_more_options),
                             )
                         }
                         DropdownMenu(
@@ -759,7 +759,7 @@ fun ConsoleScreen(
                                     showTitleBar = false
                                 }
                                 termFocusRequester.requestFocus()
-                            }
+                            },
                         ) {
                             // Reconnect (shown only when disconnected)
                             if (disconnected) {
@@ -771,7 +771,7 @@ fun ConsoleScreen(
                                     },
                                     leadingIcon = {
                                         Icon(Icons.Default.Refresh, contentDescription = null)
-                                    }
+                                    },
                                 )
                             }
 
@@ -783,7 +783,7 @@ fun ConsoleScreen(
                                             stringResource(R.string.console_menu_close)
                                         } else {
                                             stringResource(R.string.list_host_disconnect)
-                                        }
+                                        },
                                     )
                                 },
                                 onClick = {
@@ -793,7 +793,7 @@ fun ConsoleScreen(
                                 enabled = currentBridge != null,
                                 leadingIcon = {
                                     Icon(Icons.Default.LinkOff, null)
-                                }
+                                },
                             )
 
                             // URL Scan
@@ -809,7 +809,7 @@ fun ConsoleScreen(
                                 leadingIcon = {
                                     Icon(Icons.Default.Link, contentDescription = null)
                                 },
-                                enabled = currentBridge != null
+                                enabled = currentBridge != null,
                             )
 
                             // Resize
@@ -819,7 +819,7 @@ fun ConsoleScreen(
                                     showMenu = false
                                     showResizeDialog = true
                                 },
-                                enabled = sessionOpen
+                                enabled = sessionOpen,
                             )
 
                             // Port Forwards (if available)
@@ -830,11 +830,11 @@ fun ConsoleScreen(
                                         showMenu = false
                                         currentBridge.host.id.let {
                                             onNavigateToPortForwards(
-                                                it
+                                                it,
                                             )
                                         }
                                     },
-                                    enabled = sessionOpen
+                                    enabled = sessionOpen,
                                 )
                             }
 
@@ -848,9 +848,9 @@ fun ConsoleScreen(
                                 trailingIcon = {
                                     Checkbox(
                                         checked = fullscreen,
-                                        onCheckedChange = null
+                                        onCheckedChange = null,
                                     )
-                                }
+                                },
                             )
 
                             // Title bar auto-hide toggle
@@ -863,13 +863,13 @@ fun ConsoleScreen(
                                 trailingIcon = {
                                     Checkbox(
                                         checked = titleBarHide,
-                                        onCheckedChange = null
+                                        onCheckedChange = null,
                                     )
-                                }
+                                },
                             )
                         }
                     }
-                }
+                },
             )
 
             // Progress indicator for OSC 9;4 progress reporting
@@ -886,7 +886,7 @@ fun ConsoleScreen(
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(top = titleBarHeight),
-                        color = progressColor
+                        color = progressColor,
                     )
                 } else {
                     LinearProgressIndicator(
@@ -894,7 +894,7 @@ fun ConsoleScreen(
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(top = titleBarHeight),
-                        color = progressColor
+                        color = progressColor,
                     )
                 }
             }
@@ -906,7 +906,7 @@ fun ConsoleScreen(
 private fun HostDisconnectDialog(
     host: Host,
     onDismiss: () -> Unit,
-    onConfirm: () -> Unit
+    onConfirm: () -> Unit,
 ) {
     AlertDialog(
         onDismissRequest = onDismiss,
@@ -915,7 +915,7 @@ private fun HostDisconnectDialog(
         },
         confirmButton = {
             TextButton(
-                onClick = onConfirm
+                onClick = onConfirm,
             ) {
                 Text(stringResource(R.string.button_yes))
             }
@@ -924,6 +924,6 @@ private fun HostDisconnectDialog(
             TextButton(onClick = onDismiss) {
                 Text(stringResource(R.string.button_no))
             }
-        }
+        },
     )
 }

--- a/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
@@ -104,7 +104,6 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.content.edit
-import androidx.core.net.toUri
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -128,6 +127,7 @@ import org.connectbot.ui.components.TerminalKeyboard
 import org.connectbot.ui.components.UrlScanDialog
 import org.connectbot.ui.theme.terminal
 import org.connectbot.util.PreferenceConstants
+import org.connectbot.util.UrlUtils
 import org.connectbot.util.rememberTerminalTypefaceResultFromStoredValue
 import timber.log.Timber
 
@@ -336,14 +336,17 @@ fun ConsoleScreen(
 
     val noUrlHandlerMessage = stringResource(R.string.console_url_no_handler)
 
+    val urlNotSupportedMessage = stringResource(R.string.console_url_not_supported)
+
     fun openUrl(url: String) {
-        val intent = Intent(Intent.ACTION_VIEW, url.toUri())
-            .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-        try {
-            context.startActivity(intent)
-        } catch (e: ActivityNotFoundException) {
+        UrlUtils.openUrl(context, url).onFailure { e ->
             coroutineScope.launch {
-                snackbarHostState.showSnackbar(noUrlHandlerMessage)
+                val message = if (e is ActivityNotFoundException) {
+                    noUrlHandlerMessage
+                } else {
+                    urlNotSupportedMessage
+                }
+                snackbarHostState.showSnackbar(message)
             }
         }
     }

--- a/app/src/main/java/org/connectbot/util/UrlUtils.kt
+++ b/app/src/main/java/org/connectbot/util/UrlUtils.kt
@@ -1,0 +1,97 @@
+/*
+ * ConnectBot: simple, powerful, open-source SSH client for Android
+ * Copyright 2025 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.connectbot.util
+
+import android.content.Context
+import android.content.Intent
+import androidx.core.net.toUri
+
+object UrlUtils {
+    private val schemeRegex = Regex("^[a-zA-Z][a-zA-Z0-9+.-]*:")
+
+    /**
+     * Normalizes a URL string by trimming and adding a default scheme if missing.
+     *
+     * @param url The raw URL string from terminal.
+     * @return The normalized URL string, or an empty string if the input was empty.
+     */
+    fun normalizeUrl(url: String): String {
+        val trimmedUrl = url.trim()
+        if (trimmedUrl.isEmpty()) return ""
+
+        val schemeMatch = schemeRegex.find(trimmedUrl)
+        if (schemeMatch != null) {
+            val scheme = schemeMatch.value.removeSuffix(":")
+            val rest = trimmedUrl.substring(schemeMatch.value.length)
+
+            // If it has :// it's definitely a scheme.
+            // If it's mailto: or tel:, it's a known scheme that doesn't use //.
+            if (rest.startsWith("//") ||
+                scheme.equals("mailto", ignoreCase = true) ||
+                scheme.equals("tel", ignoreCase = true)
+            ) {
+                return trimmedUrl
+            }
+
+            // It's likely a host:port if the scheme part contains a dot (e.g., google.com:80)
+            // OR if the part after the colon starts with digits (e.g., localhost:8080).
+            val startsWithPort = rest.isNotEmpty() && rest[0].isDigit() &&
+                rest.takeWhile { it.isDigit() }.let { digits ->
+                    digits.length == rest.length || rest[digits.length] == '/'
+                }
+
+            if (scheme.contains('.') || startsWithPort) {
+                return "https://$trimmedUrl"
+            }
+
+            // Otherwise treat it as a scheme (e.g., "javascript:", "intent:").
+            return trimmedUrl
+        }
+
+        return "https://$trimmedUrl"
+    }
+
+    private val supportedSchemes = setOf("http", "https", "mailto", "tel")
+
+    /**
+     * Attempts to open a URL using an ACTION_VIEW intent.
+     * Only allows specific safe schemes: http, https, mailto, tel.
+     *
+     * @param context The context to use for starting the activity.
+     * @param url The URL string to open.
+     * @return A Result indicating success or failure (e.g., ActivityNotFoundException, IllegalArgumentException).
+     */
+    fun openUrl(context: Context, url: String): Result<Unit> {
+        val normalizedUrl = normalizeUrl(url)
+        if (normalizedUrl.isEmpty()) return Result.success(Unit)
+
+        return runCatching {
+            val uri = normalizedUrl.toUri()
+            val scheme = uri.scheme?.lowercase()
+
+            if (scheme !in supportedSchemes) {
+                throw IllegalArgumentException("Unsupported scheme: $scheme")
+            }
+
+            val intent = Intent(Intent.ACTION_VIEW, uri).apply {
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            }
+            context.startActivity(intent)
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -595,6 +595,8 @@
 	<string name="console_menu_urlscan">"URL scan"</string>
 	<!-- Error shown in a snackbar when the user taps a URL but no app on the device can handle it -->
 	<string name="console_url_no_handler">No app available to open this URL</string>
+	<!-- Error shown in a snackbar when the URL type is not supported -->
+	<string name="console_url_not_supported">This URL type is not supported</string>
 
 	<!-- Button label to answer "Yes" to a yes/no prompt -->
 	<string name="button_yes">"Yes"</string>

--- a/app/src/test/java/org/connectbot/util/UrlUtilsTest.kt
+++ b/app/src/test/java/org/connectbot/util/UrlUtilsTest.kt
@@ -1,0 +1,165 @@
+/*
+ * ConnectBot: simple, powerful, open-source SSH client for Android
+ * Copyright 2025 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.connectbot.util
+
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.Intent
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+
+@RunWith(RobolectricTestRunner::class)
+class UrlUtilsTest {
+
+    @Test
+    fun normalizeUrl_EmptyInput_ReturnsEmptyString() {
+        assertEquals("", UrlUtils.normalizeUrl(""))
+        assertEquals("", UrlUtils.normalizeUrl("   "))
+    }
+
+    @Test
+    fun normalizeUrl_WithHttpScheme_StaysSame() {
+        assertEquals("http://google.com", UrlUtils.normalizeUrl("http://google.com"))
+    }
+
+    @Test
+    fun normalizeUrl_WithHttpsScheme_StaysSame() {
+        assertEquals("https://google.com", UrlUtils.normalizeUrl("https://google.com"))
+    }
+
+    @Test
+    fun normalizeUrl_WithMailtoScheme_StaysSame() {
+        assertEquals("mailto:test@example.com", UrlUtils.normalizeUrl("mailto:test@example.com"))
+    }
+
+    @Test
+    fun normalizeUrl_WithTelScheme_StaysSame() {
+        assertEquals("tel:123456789", UrlUtils.normalizeUrl("tel:123456789"))
+    }
+
+    @Test
+    fun normalizeUrl_WithJavascript_StaysSame() {
+        assertEquals("javascript:alert(1)", UrlUtils.normalizeUrl("javascript:alert(1)"))
+    }
+
+    @Test
+    fun normalizeUrl_WithoutScheme_AddsHttps() {
+        assertEquals("https://www.google.com", UrlUtils.normalizeUrl("www.google.com"))
+        assertEquals("https://google.com/search?q=test", UrlUtils.normalizeUrl("google.com/search?q=test"))
+        assertEquals("https://google.com:8080", UrlUtils.normalizeUrl("google.com:8080"))
+        assertEquals("https://example.com/path://foo", UrlUtils.normalizeUrl("example.com/path://foo"))
+        assertEquals("https://localhost:3000", UrlUtils.normalizeUrl("localhost:3000"))
+        assertEquals("https://myhost:8080/api/v1", UrlUtils.normalizeUrl("myhost:8080/api/v1"))
+    }
+
+    @Test
+    fun openUrl_StartsActivityWithCorrectIntent() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val url = "www.google.com"
+
+        val result = UrlUtils.openUrl(context, url)
+
+        assertTrue(result.isSuccess)
+
+        val shadowContext = shadowOf(context as android.app.Application)
+        val nextStartedActivity = shadowContext.nextStartedActivity
+
+        assertEquals(Intent.ACTION_VIEW, nextStartedActivity.action)
+        assertEquals("https://www.google.com", nextStartedActivity.dataString)
+        assertTrue(nextStartedActivity.flags and Intent.FLAG_ACTIVITY_NEW_TASK != 0)
+    }
+
+    @Test
+    fun openUrl_WithFullUrl_StartsActivityWithCorrectIntent() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val url = "http://example.com"
+
+        UrlUtils.openUrl(context, url)
+
+        val shadowContext = shadowOf(context as android.app.Application)
+        val nextStartedActivity = shadowContext.nextStartedActivity
+
+        assertEquals(Intent.ACTION_VIEW, nextStartedActivity.action)
+        assertEquals("http://example.com", nextStartedActivity.dataString)
+    }
+
+    @Test
+    fun openUrl_ReturnsFailure_WhenActivityNotFound() {
+        val context = mock(Context::class.java)
+        val url = "http://example.com"
+
+        `when`(context.startActivity(any())).thenThrow(ActivityNotFoundException())
+
+        val result = UrlUtils.openUrl(context, url)
+
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is ActivityNotFoundException)
+    }
+
+    @Test
+    fun openUrl_ReturnsFailure_WhenGenericExceptionOccurs() {
+        val context = mock(Context::class.java)
+        val url = "http://example.com"
+
+        `when`(context.startActivity(any())).thenThrow(RuntimeException("Test exception"))
+
+        val result = UrlUtils.openUrl(context, url)
+
+        assertTrue(result.isFailure)
+        assertEquals("Test exception", result.exceptionOrNull()?.message)
+    }
+
+    @Test
+    fun openUrl_ReturnsSuccess_ForEmptyUrl() {
+        val context = mock(Context::class.java)
+        val result = UrlUtils.openUrl(context, "")
+        assertTrue(result.isSuccess)
+    }
+
+    @Test
+    fun openUrl_ReturnsFailure_ForUnsupportedSchemes() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+
+        // intent:// scheme
+        val intentResult = UrlUtils.openUrl(context, "intent://example.com#Intent;scheme=http;package=com.android.browser;end")
+        assertTrue("Expected failure for intent://", intentResult.isFailure)
+        val intentExc = intentResult.exceptionOrNull()
+        assertTrue("Expected IllegalArgumentException but got $intentExc", intentExc is IllegalArgumentException)
+        assertEquals("Unsupported scheme: intent", intentExc?.message)
+
+        // file:// scheme
+        val fileResult = UrlUtils.openUrl(context, "file:///etc/passwd")
+        assertTrue(fileResult.isFailure)
+        assertTrue(fileResult.exceptionOrNull() is IllegalArgumentException)
+        assertEquals("Unsupported scheme: file", fileResult.exceptionOrNull()?.message)
+
+        // javascript: scheme
+        val jsResult = UrlUtils.openUrl(context, "javascript:alert(1)")
+        assertTrue(jsResult.isFailure)
+        assertTrue(jsResult.exceptionOrNull() is IllegalArgumentException)
+        assertEquals("Unsupported scheme: javascript", jsResult.exceptionOrNull()?.message)
+    }
+}


### PR DESCRIPTION
Only allow known schemes to be opened. If the scheme doesn't exist, prepend "https://" Otherwise put up the "no handler" message.

Fixes #2121