### PR TITLE
TerminalKeyListener: refactor for testing

### DIFF
--- a/app/src/main/java/org/connectbot/service/TerminalBridge.kt
+++ b/app/src/main/java/org/connectbot/service/TerminalBridge.kt
@@ -153,7 +153,7 @@ class TerminalBridge {
     // Network state tracking for grace period
     private data class NetworkState(
         val ipAddresses: Set<String>,
-        val networkId: String
+        val networkId: String,
     )
 
     private var lastKnownNetworkState: NetworkState? = null
@@ -256,7 +256,7 @@ class TerminalBridge {
             },
             onResize = {
                 transportOperations.trySend(
-                    TransportOperation.SetDimensions(it.columns, it.rows, 0, 0)
+                    TransportOperation.SetDimensions(it.columns, it.rows, 0, 0),
                 )
             },
             onClipboardCopy = { text ->
@@ -269,7 +269,7 @@ class TerminalBridge {
                 // OSC 9;4 progress reporting - update progress state
                 Timber.d("OSC 9;4 progress: state=$state, progress=$progress")
                 _progressState.value = ProgressInfo(state, progress)
-            }
+            },
         )
 
         // Apply color scheme to terminal emulator
@@ -310,7 +310,7 @@ class TerminalBridge {
                                 operation.columns,
                                 operation.rows,
                                 operation.width,
-                                operation.height
+                                operation.height,
                             )
                         }
 
@@ -453,8 +453,8 @@ class TerminalBridge {
                         manager.reportError(
                             ServiceError.PortForwardLoadFailed(
                                 hostNickname = host.nickname,
-                                reason = e.message ?: "Failed to load port forwards"
-                            )
+                                reason = e.message ?: "Failed to load port forwards",
+                            ),
                         )
                     }
                 }
@@ -466,8 +466,8 @@ class TerminalBridge {
                     ServiceError.ConnectionFailed(
                         hostNickname = host.nickname,
                         hostname = host.hostname,
-                        reason = e.message ?: "Connection failed"
-                    )
+                        reason = e.message ?: "Connection failed",
+                    ),
                 )
             }
         }
@@ -498,7 +498,7 @@ class TerminalBridge {
         if (transport?.isSessionOpen() == true) {
             Timber.e(
                 "Session established, cannot use outputLine!",
-                IOException("outputLine call traceback")
+                IOException("outputLine call traceback"),
             )
         }
 
@@ -528,7 +528,7 @@ class TerminalBridge {
         }
 
         transportOperations.trySend(
-            TransportOperation.WriteData(string.toByteArray(charset(encoding)))
+            TransportOperation.WriteData(string.toByteArray(charset(encoding))),
         )
     }
 
@@ -538,7 +538,7 @@ class TerminalBridge {
      */
     fun sendByte(c: Int) {
         transportOperations.trySend(
-            TransportOperation.WriteData(byteArrayOf(c.toByte()))
+            TransportOperation.WriteData(byteArrayOf(c.toByte())),
         )
     }
 
@@ -982,7 +982,7 @@ class TerminalBridge {
         if (networkInfo != null) {
             lastKnownNetworkState = NetworkState(
                 ipAddresses = networkInfo.ipAddresses,
-                networkId = networkInfo.networkId
+                networkId = networkInfo.networkId,
             )
             Timber.d("Captured network state: ${networkInfo.ipAddresses.size} IPs")
         }
@@ -1036,7 +1036,7 @@ class TerminalBridge {
             scope.launch { _networkStatusMessages.emit(manager.res.getString(R.string.network_restored_no_previous_state)) }
             lastKnownNetworkState = NetworkState(
                 ipAddresses = newNetworkInfo.ipAddresses,
-                networkId = newNetworkInfo.networkId
+                networkId = newNetworkInfo.networkId,
             )
             // Allow connection to continue
             return
@@ -1050,7 +1050,7 @@ class TerminalBridge {
             scope.launch { _networkStatusMessages.emit(manager.res.getString(R.string.network_restored_same_ip)) }
             lastKnownNetworkState = NetworkState(
                 ipAddresses = newNetworkInfo.ipAddresses,
-                networkId = newNetworkInfo.networkId
+                networkId = newNetworkInfo.networkId,
             )
             // No action needed - connection continues
         } else {

--- a/app/src/main/java/org/connectbot/service/TerminalBridge.kt
+++ b/app/src/main/java/org/connectbot/service/TerminalBridge.kt
@@ -52,6 +52,7 @@ import org.connectbot.transport.AbsTransport
 import org.connectbot.transport.SSH
 import org.connectbot.transport.TransportFactory
 import org.connectbot.util.HostConstants
+import org.connectbot.util.PreferenceConstants
 import timber.log.Timber
 import java.io.IOException
 import java.nio.charset.Charset
@@ -275,7 +276,14 @@ class TerminalBridge {
         val ansiColors = fullColorPalette.sliceArray(0 until 16)
         terminalEmulator.applyColorScheme(ansiColors, defaultFgColor, defaultBgColor)
 
-        keyListener = TerminalKeyListener(terminalEmulator)
+        val stickyModifierSetting = when (
+            manager.prefs.getString(PreferenceConstants.STICKY_MODIFIERS, PreferenceConstants.NO)
+        ) {
+            PreferenceConstants.ALT -> StickyModifierSetting.ALT
+            PreferenceConstants.YES -> StickyModifierSetting.ALL
+            else -> StickyModifierSetting.NONE
+        }
+        keyListener = TerminalKeyListener(TerminalEmulatorKeyDispatcher(terminalEmulator), stickyModifierSetting)
 
         // Start the transport operation processor to serialize all writes
         startTransportOperationProcessor()

--- a/app/src/main/java/org/connectbot/service/TerminalKeyListener.kt
+++ b/app/src/main/java/org/connectbot/service/TerminalKeyListener.kt
@@ -23,9 +23,26 @@ import org.connectbot.terminal.ModifierManager
 import org.connectbot.terminal.TerminalEmulator
 import org.connectbot.terminal.VTermKey
 
+fun interface KeyDispatcher {
+    fun dispatchKey(modifiers: Int, key: Int)
+}
+
+class TerminalEmulatorKeyDispatcher(private val emulator: TerminalEmulator) : KeyDispatcher {
+    override fun dispatchKey(modifiers: Int, key: Int) = emulator.dispatchKey(modifiers, key)
+}
+
+enum class StickyModifierSetting(internal val mask: Int) {
+    NONE(0),
+    ALT(0x04),
+    ALL(0x01 or 0x04 or 0x10),
+}
+
 class TerminalKeyListener(
-    private val terminalEmulator: TerminalEmulator
+    private val keyDispatcher: KeyDispatcher,
+    stickyModifierSetting: StickyModifierSetting = StickyModifierSetting.NONE,
 ) : ModifierManager {
+
+    private val stickyMetas: Int = stickyModifierSetting.mask
 
     private var ourMetaState: Int = 0
 
@@ -33,17 +50,17 @@ class TerminalKeyListener(
     val modifierState: StateFlow<ModifierState> = _modifierState.asStateFlow()
 
     fun sendEscape() {
-        terminalEmulator.dispatchKey(0, VTermKey.ESCAPE)
+        keyDispatcher.dispatchKey(0, VTermKey.ESCAPE)
         clearTransients()
     }
 
     fun sendTab() {
-        terminalEmulator.dispatchKey(0, VTermKey.TAB)
+        keyDispatcher.dispatchKey(0, VTermKey.TAB)
         clearTransients()
     }
 
     fun sendPressedKey(key: Int) {
-        terminalEmulator.dispatchKey(modifiersForTerminal, key)
+        keyDispatcher.dispatchKey(modifiersForTerminal, key)
         clearTransients()
     }
 
@@ -52,8 +69,12 @@ class TerminalKeyListener(
         if ((ourMetaState and (code shl 1)) != 0) {
             // LOCKED → OFF
             ourMetaState = ourMetaState and (code shl 1).inv()
-        } else if (forceSticky || (ourMetaState and code) != 0) {
-            // TRANSIENT → LOCKED, or OFF → LOCKED when forceSticky
+        } else if (forceSticky || (stickyMetas and code) != 0) {
+            // OFF → LOCKED (sticky or forced)
+            ourMetaState = ourMetaState and code.inv()
+            ourMetaState = ourMetaState or (code shl 1)
+        } else if ((ourMetaState and code) != 0) {
+            // TRANSIENT → LOCKED
             ourMetaState = ourMetaState and code.inv()
             ourMetaState = ourMetaState or (code shl 1)
         } else {

--- a/app/src/main/java/org/connectbot/service/TerminalKeyListener.kt
+++ b/app/src/main/java/org/connectbot/service/TerminalKeyListener.kt
@@ -128,7 +128,7 @@ class TerminalKeyListener(
             (ourMetaState and OUR_SHIFT_LOCK) != 0 -> ModifierLevel.LOCKED
             (ourMetaState and OUR_SHIFT_ON) != 0 -> ModifierLevel.TRANSIENT
             else -> ModifierLevel.OFF
-        }
+        },
     )
 
     companion object {
@@ -148,11 +148,11 @@ class TerminalKeyListener(
 data class ModifierState(
     val ctrlState: ModifierLevel,
     val altState: ModifierLevel,
-    val shiftState: ModifierLevel
+    val shiftState: ModifierLevel,
 )
 
 enum class ModifierLevel {
     OFF,
     TRANSIENT,
-    LOCKED
+    LOCKED,
 }

--- a/app/src/test/java/org/connectbot/service/TerminalKeyListenerTest.kt
+++ b/app/src/test/java/org/connectbot/service/TerminalKeyListenerTest.kt
@@ -1,0 +1,175 @@
+/*
+ * ConnectBot: simple, powerful, open-source SSH client for Android
+ * Copyright 2026 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.connectbot.service
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class TerminalKeyListenerTest {
+
+    private val noopDispatcher = KeyDispatcher { _, _ -> }
+
+    // NONE: OFF -> TRANSIENT -> LOCKED -> OFF
+
+    @Test
+    fun `NONE ctrl first press goes to TRANSIENT`() {
+        val listener = TerminalKeyListener(noopDispatcher, StickyModifierSetting.NONE)
+        listener.metaPress(TerminalKeyListener.OUR_CTRL_ON)
+        assertEquals(ModifierLevel.TRANSIENT, listener.getModifierState().ctrlState)
+    }
+
+    @Test
+    fun `NONE ctrl second press goes to LOCKED`() {
+        val listener = TerminalKeyListener(noopDispatcher, StickyModifierSetting.NONE)
+        listener.metaPress(TerminalKeyListener.OUR_CTRL_ON)
+        listener.metaPress(TerminalKeyListener.OUR_CTRL_ON)
+        assertEquals(ModifierLevel.LOCKED, listener.getModifierState().ctrlState)
+    }
+
+    @Test
+    fun `NONE ctrl third press goes to OFF`() {
+        val listener = TerminalKeyListener(noopDispatcher, StickyModifierSetting.NONE)
+        listener.metaPress(TerminalKeyListener.OUR_CTRL_ON)
+        listener.metaPress(TerminalKeyListener.OUR_CTRL_ON)
+        listener.metaPress(TerminalKeyListener.OUR_CTRL_ON)
+        assertEquals(ModifierLevel.OFF, listener.getModifierState().ctrlState)
+    }
+
+    @Test
+    fun `NONE ctrl clearTransients removes TRANSIENT but not LOCKED`() {
+        val listener = TerminalKeyListener(noopDispatcher, StickyModifierSetting.NONE)
+        listener.metaPress(TerminalKeyListener.OUR_CTRL_ON)
+        listener.clearTransients()
+        assertEquals(ModifierLevel.OFF, listener.getModifierState().ctrlState)
+
+        listener.metaPress(TerminalKeyListener.OUR_CTRL_ON)
+        listener.metaPress(TerminalKeyListener.OUR_CTRL_ON)
+        listener.clearTransients()
+        assertEquals(ModifierLevel.LOCKED, listener.getModifierState().ctrlState)
+    }
+
+    // ALT: alt goes OFF -> LOCKED -> OFF; ctrl/shift still use 3-state
+
+    @Test
+    fun `ALT alt first press goes to LOCKED`() {
+        val listener = TerminalKeyListener(noopDispatcher, StickyModifierSetting.ALT)
+        listener.metaPress(TerminalKeyListener.OUR_ALT_ON)
+        assertEquals(ModifierLevel.LOCKED, listener.getModifierState().altState)
+    }
+
+    @Test
+    fun `ALT alt second press goes to OFF`() {
+        val listener = TerminalKeyListener(noopDispatcher, StickyModifierSetting.ALT)
+        listener.metaPress(TerminalKeyListener.OUR_ALT_ON)
+        listener.metaPress(TerminalKeyListener.OUR_ALT_ON)
+        assertEquals(ModifierLevel.OFF, listener.getModifierState().altState)
+    }
+
+    @Test
+    fun `ALT ctrl still uses 3-state`() {
+        val listener = TerminalKeyListener(noopDispatcher, StickyModifierSetting.ALT)
+        listener.metaPress(TerminalKeyListener.OUR_CTRL_ON)
+        assertEquals(ModifierLevel.TRANSIENT, listener.getModifierState().ctrlState)
+    }
+
+    // ALL: ctrl/shift/alt all go OFF -> LOCKED -> OFF
+
+    @Test
+    fun `ALL ctrl first press goes to LOCKED`() {
+        val listener = TerminalKeyListener(noopDispatcher, StickyModifierSetting.ALL)
+        listener.metaPress(TerminalKeyListener.OUR_CTRL_ON)
+        assertEquals(ModifierLevel.LOCKED, listener.getModifierState().ctrlState)
+    }
+
+    @Test
+    fun `ALL ctrl second press goes to OFF`() {
+        val listener = TerminalKeyListener(noopDispatcher, StickyModifierSetting.ALL)
+        listener.metaPress(TerminalKeyListener.OUR_CTRL_ON)
+        listener.metaPress(TerminalKeyListener.OUR_CTRL_ON)
+        assertEquals(ModifierLevel.OFF, listener.getModifierState().ctrlState)
+    }
+
+    @Test
+    fun `ALL clearTransients does not clear LOCKED state`() {
+        val listener = TerminalKeyListener(noopDispatcher, StickyModifierSetting.ALL)
+        listener.metaPress(TerminalKeyListener.OUR_CTRL_ON)
+        listener.clearTransients()
+        assertEquals(ModifierLevel.LOCKED, listener.getModifierState().ctrlState)
+    }
+
+    // sendPressedKey/sendTab/sendEscape clear TRANSIENT but preserve LOCKED
+
+    @Test
+    fun `sendPressedKey clears TRANSIENT ctrl`() {
+        val listener = TerminalKeyListener(noopDispatcher, StickyModifierSetting.NONE)
+        listener.metaPress(TerminalKeyListener.OUR_CTRL_ON)
+        listener.sendPressedKey(0)
+        assertEquals(ModifierLevel.OFF, listener.getModifierState().ctrlState)
+    }
+
+    @Test
+    fun `sendPressedKey preserves LOCKED ctrl`() {
+        val listener = TerminalKeyListener(noopDispatcher, StickyModifierSetting.NONE)
+        listener.metaPress(TerminalKeyListener.OUR_CTRL_ON)
+        listener.metaPress(TerminalKeyListener.OUR_CTRL_ON)
+        listener.sendPressedKey(0)
+        assertEquals(ModifierLevel.LOCKED, listener.getModifierState().ctrlState)
+    }
+
+    @Test
+    fun `sendTab clears TRANSIENT ctrl`() {
+        val listener = TerminalKeyListener(noopDispatcher, StickyModifierSetting.NONE)
+        listener.metaPress(TerminalKeyListener.OUR_CTRL_ON)
+        listener.sendTab()
+        assertEquals(ModifierLevel.OFF, listener.getModifierState().ctrlState)
+    }
+
+    @Test
+    fun `sendTab preserves LOCKED ctrl`() {
+        val listener = TerminalKeyListener(noopDispatcher, StickyModifierSetting.NONE)
+        listener.metaPress(TerminalKeyListener.OUR_CTRL_ON)
+        listener.metaPress(TerminalKeyListener.OUR_CTRL_ON)
+        listener.sendTab()
+        assertEquals(ModifierLevel.LOCKED, listener.getModifierState().ctrlState)
+    }
+
+    @Test
+    fun `sendEscape clears TRANSIENT ctrl`() {
+        val listener = TerminalKeyListener(noopDispatcher, StickyModifierSetting.NONE)
+        listener.metaPress(TerminalKeyListener.OUR_CTRL_ON)
+        listener.sendEscape()
+        assertEquals(ModifierLevel.OFF, listener.getModifierState().ctrlState)
+    }
+
+    @Test
+    fun `sendEscape preserves LOCKED ctrl`() {
+        val listener = TerminalKeyListener(noopDispatcher, StickyModifierSetting.NONE)
+        listener.metaPress(TerminalKeyListener.OUR_CTRL_ON)
+        listener.metaPress(TerminalKeyListener.OUR_CTRL_ON)
+        listener.sendEscape()
+        assertEquals(ModifierLevel.LOCKED, listener.getModifierState().ctrlState)
+    }
+
+    // forceSticky jumps directly to LOCKED regardless of StickyModifierSetting
+
+    @Test
+    fun `forceSticky jumps to LOCKED from OFF when setting is NONE`() {
+        val listener = TerminalKeyListener(noopDispatcher, StickyModifierSetting.NONE)
+        listener.metaPress(TerminalKeyListener.OUR_CTRL_ON, forceSticky = true)
+        assertEquals(ModifierLevel.LOCKED, listener.getModifierState().ctrlState)
+    }
+}


### PR DESCRIPTION
Accidentally altered the behavior of TerminalKeyListener, so refactor it for testability. Also restore the previous behavior and plumb in the stickyKeys preference.