### PR TITLE
ci: consider each scan as a new version

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -125,6 +125,9 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: >
+            -Dsonar.projectVersion=${{ github.sha }}
 
       - name: Prepare release
         if: ${{ inputs.is_push }}


### PR DESCRIPTION
This will force SonarQube to compare each commit.