### PR TITLE
TerminalKeyListener: distinguish between HW and SW keys

### DIFF
--- a/app/src/main/java/org/connectbot/service/TerminalKeyListener.kt
+++ b/app/src/main/java/org/connectbot/service/TerminalKeyListener.kt
@@ -23,6 +23,23 @@ import org.connectbot.terminal.ModifierManager
 import org.connectbot.terminal.TerminalEmulator
 import org.connectbot.terminal.VTermKey
 
+// Internal modifier bitmasks
+private const val OUR_CTRL_ON = 0x01
+private const val OUR_CTRL_LOCK = 0x02
+private const val OUR_ALT_ON = 0x04
+private const val OUR_ALT_LOCK = 0x08
+private const val OUR_SHIFT_ON = 0x10
+private const val OUR_SHIFT_LOCK = 0x20
+
+private const val OUR_CTRL_MASK = OUR_CTRL_ON or OUR_CTRL_LOCK
+private const val OUR_ALT_MASK = OUR_ALT_ON or OUR_ALT_LOCK
+private const val OUR_SHIFT_MASK = OUR_SHIFT_ON or OUR_SHIFT_LOCK
+
+// Terminal modifier bitmasks (per VTerm spec)
+private const val VTERM_MOD_SHIFT = 1
+private const val VTERM_MOD_ALT = 2
+private const val VTERM_MOD_CTRL = 4
+
 fun interface KeyDispatcher {
     fun dispatchKey(modifiers: Int, key: Int)
 }
@@ -33,10 +50,21 @@ class TerminalEmulatorKeyDispatcher(private val emulator: TerminalEmulator) : Ke
 
 enum class StickyModifierSetting(internal val mask: Int) {
     NONE(0),
-    ALT(0x04),
-    ALL(0x01 or 0x04 or 0x10),
+    ALT(OUR_ALT_ON),
+    ALL(OUR_CTRL_ON or OUR_ALT_ON or OUR_SHIFT_ON),
 }
 
+/**
+ * Handles key state tracking for terminal modifiers (Ctrl, Alt, Shift).
+ *
+ * This class distinguishes between two types of interaction:
+ * 1. **Hardware Keyboards:** Modifiers typically only enter the "sticky" cycle
+ *    (TRANSIENT -> LOCKED) if the user has enabled the "Sticky Modifiers" preference.
+ * 2. **Software (On-screen) Keyboards:** Because on-screen buttons cannot be "held"
+ *    while pressing another key, they use the [metaPress] method with `forceSticky = true`
+ *    to ensure they at least enter the TRANSIENT state, allowing for one-handed
+ *    modifier use.
+ */
 class TerminalKeyListener(
     private val keyDispatcher: KeyDispatcher,
     stickyModifierSetting: StickyModifierSetting = StickyModifierSetting.NONE,
@@ -64,38 +92,44 @@ class TerminalKeyListener(
         clearTransients()
     }
 
+    /**
+     * Toggles the state of a modifier key.
+     *
+     * The state machine follows a 3-state toggle:
+     * OFF → TRANSIENT → LOCKED → OFF
+     *
+     * @param code The modifier code (e.g., [OUR_CTRL_ON]).
+     * @param forceSticky If true, forces the transition to at least TRANSIENT even if
+     *   the modifier isn't in the [stickyMetas] list. This is primarily used by
+     *   on-screen keyboards.
+     */
     @JvmOverloads
     fun metaPress(code: Int, forceSticky: Boolean = false) {
         if ((ourMetaState and (code shl 1)) != 0) {
             // LOCKED → OFF
             ourMetaState = ourMetaState and (code shl 1).inv()
-        } else if (forceSticky || (stickyMetas and code) != 0) {
-            // OFF → LOCKED (sticky or forced)
-            ourMetaState = ourMetaState and code.inv()
-            ourMetaState = ourMetaState or (code shl 1)
         } else if ((ourMetaState and code) != 0) {
             // TRANSIENT → LOCKED
             ourMetaState = ourMetaState and code.inv()
             ourMetaState = ourMetaState or (code shl 1)
-        } else {
+        } else if (forceSticky || (stickyMetas and code) != 0) {
             // OFF → TRANSIENT
             ourMetaState = ourMetaState or code
+        } else {
+            return
         }
         _modifierState.value = getModifierState()
     }
 
     /**
      * Build VTerm modifier mask from our meta state.
-     * Bit 0: Shift
-     * Bit 1: Alt
-     * Bit 2: Ctrl
      */
     private val modifiersForTerminal: Int
         get() {
             var mask = 0
-            if ((ourMetaState and OUR_SHIFT_MASK) != 0) mask = mask or 1
-            if ((ourMetaState and OUR_ALT_MASK) != 0) mask = mask or 2
-            if ((ourMetaState and OUR_CTRL_MASK) != 0) mask = mask or 4
+            if ((ourMetaState and OUR_SHIFT_MASK) != 0) mask = mask or VTERM_MOD_SHIFT
+            if ((ourMetaState and OUR_ALT_MASK) != 0) mask = mask or VTERM_MOD_ALT
+            if ((ourMetaState and OUR_CTRL_MASK) != 0) mask = mask or VTERM_MOD_CTRL
             return mask
         }
 
@@ -132,16 +166,9 @@ class TerminalKeyListener(
     )
 
     companion object {
-        const val OUR_CTRL_ON = 0x01
-        const val OUR_CTRL_LOCK = 0x02
-        const val OUR_ALT_ON = 0x04
-        const val OUR_ALT_LOCK = 0x08
-        const val OUR_SHIFT_ON = 0x10
-        const val OUR_SHIFT_LOCK = 0x20
-
-        private const val OUR_CTRL_MASK = OUR_CTRL_ON or OUR_CTRL_LOCK
-        private const val OUR_ALT_MASK = OUR_ALT_ON or OUR_ALT_LOCK
-        private const val OUR_SHIFT_MASK = OUR_SHIFT_ON or OUR_SHIFT_LOCK
+        const val CTRL_ON = OUR_CTRL_ON
+        const val ALT_ON = OUR_ALT_ON
+        const val SHIFT_ON = OUR_SHIFT_ON
     }
 }
 

--- a/app/src/main/java/org/connectbot/ui/components/TerminalKeyboard.kt
+++ b/app/src/main/java/org/connectbot/ui/components/TerminalKeyboard.kt
@@ -103,7 +103,7 @@ fun TerminalKeyboard(
     onOpenTextInput: () -> Unit = {},
     onScrollInProgressChange: (Boolean) -> Unit = {},
     imeVisible: Boolean = false,
-    playAnimation: Boolean = false
+    playAnimation: Boolean = false,
 ) {
     val keyHandler = bridge.keyHandler
     val modifierState by keyHandler.modifierState.collectAsState()
@@ -111,7 +111,7 @@ fun TerminalKeyboard(
     TerminalKeyboardContent(
         modifierState = modifierState,
         onCtrlPress = {
-            keyHandler.metaPress(TerminalKeyListener.OUR_CTRL_ON, true)
+            keyHandler.metaPress(TerminalKeyListener.CTRL_ON, true)
             onInteraction()
         },
         onEscPress = {
@@ -133,7 +133,7 @@ fun TerminalKeyboard(
         onScrollInProgressChange = onScrollInProgressChange,
         imeVisible = imeVisible,
         playAnimation = playAnimation,
-        modifier = modifier
+        modifier = modifier,
     )
 }
 
@@ -155,7 +155,7 @@ private fun TerminalKeyboardContent(
     onScrollInProgressChange: (Boolean) -> Unit,
     imeVisible: Boolean,
     playAnimation: Boolean,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     val scrollState = rememberScrollState()
     val currentOnScrollInProgressChange by rememberUpdatedState(onScrollInProgressChange)
@@ -174,14 +174,14 @@ private fun TerminalKeyboardContent(
             // Scroll all the way to the right to show all keys
             scrollState.animateScrollTo(
                 value = scrollState.maxValue,
-                animationSpec = tween(durationMillis = 500)
+                animationSpec = tween(durationMillis = 500),
             )
 
             // Then scroll back to the left
             delay(300)
             scrollState.animateScrollTo(
                 value = 0,
-                animationSpec = tween(durationMillis = 500)
+                animationSpec = tween(durationMillis = 500),
             )
         }
     }
@@ -194,169 +194,169 @@ private fun TerminalKeyboardContent(
                     onPress = {
                         onInteraction()
                         tryAwaitRelease()
-                    }
+                    },
                 )
             },
         color = MaterialTheme.colorScheme.surface.copy(alpha = UI_OPACITY),
-        tonalElevation = 8.dp
+        tonalElevation = 8.dp,
     ) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
                 .height(TERMINAL_KEYBOARD_HEIGHT_DP.dp),
-            verticalAlignment = Alignment.CenterVertically
+            verticalAlignment = Alignment.CenterVertically,
         ) {
             // Scrollable key buttons
             Row(
                 modifier = Modifier
                     .weight(1f)
                     .horizontalScroll(scrollState),
-                horizontalArrangement = Arrangement.Start // No spacing between keys
+                horizontalArrangement = Arrangement.Start, // No spacing between keys
             ) {
                 // Ctrl key (sticky modifier)
                 ModifierKeyButton(
                     text = stringResource(R.string.button_key_ctrl),
                     contentDescription = stringResource(R.string.image_description_toggle_control_character),
                     modifierLevel = modifierState.ctrlState,
-                    onClick = onCtrlPress
+                    onClick = onCtrlPress,
                 )
 
                 // Esc key
                 KeyButton(
                     text = stringResource(R.string.button_key_esc),
                     contentDescription = stringResource(R.string.image_description_send_escape_character),
-                    onClick = onEscPress
+                    onClick = onEscPress,
                 )
 
                 // Tab key
                 KeyButton(
                     text = "⇥", // Tab symbol
                     contentDescription = stringResource(R.string.image_description_send_tab_character),
-                    onClick = onTabPress
+                    onClick = onTabPress,
                 )
 
                 // Arrow keys (repeatable)
                 RepeatableKeyButton(
                     icon = Icons.Default.KeyboardArrowUp,
                     contentDescription = stringResource(R.string.image_description_up),
-                    onPress = { onKeyPress(VTermKey.UP) }
+                    onPress = { onKeyPress(VTermKey.UP) },
                 )
 
                 RepeatableKeyButton(
                     icon = Icons.Default.KeyboardArrowDown,
                     contentDescription = stringResource(R.string.image_description_down),
-                    onPress = { onKeyPress(VTermKey.DOWN) }
+                    onPress = { onKeyPress(VTermKey.DOWN) },
                 )
 
                 RepeatableKeyButton(
                     icon = Icons.Default.KeyboardArrowLeft,
                     contentDescription = stringResource(R.string.image_description_left),
-                    onPress = { onKeyPress(VTermKey.LEFT) }
+                    onPress = { onKeyPress(VTermKey.LEFT) },
                 )
 
                 RepeatableKeyButton(
                     icon = Icons.Default.KeyboardArrowRight,
                     contentDescription = stringResource(R.string.image_description_right),
-                    onPress = { onKeyPress(VTermKey.RIGHT) }
+                    onPress = { onKeyPress(VTermKey.RIGHT) },
                 )
 
                 // Home/End
                 KeyButton(
                     text = stringResource(R.string.button_key_home),
                     contentDescription = null,
-                    onClick = { onKeyPress(VTermKey.HOME) }
+                    onClick = { onKeyPress(VTermKey.HOME) },
                 )
 
                 KeyButton(
                     text = stringResource(R.string.button_key_end),
                     contentDescription = null,
-                    onClick = { onKeyPress(VTermKey.END) }
+                    onClick = { onKeyPress(VTermKey.END) },
                 )
 
                 // Page Up/Down
                 KeyButton(
                     text = stringResource(R.string.button_key_pgup),
                     contentDescription = null,
-                    onClick = { onKeyPress(VTermKey.PAGEUP) }
+                    onClick = { onKeyPress(VTermKey.PAGEUP) },
                 )
 
                 KeyButton(
                     text = stringResource(R.string.button_key_pgdn),
                     contentDescription = null,
-                    onClick = { onKeyPress(VTermKey.PAGEDOWN) }
+                    onClick = { onKeyPress(VTermKey.PAGEDOWN) },
                 )
 
                 // Function keys F1-F12
                 KeyButton(
                     text = stringResource(R.string.button_key_f1),
                     contentDescription = null,
-                    onClick = { onKeyPress(VTermKey.FUNCTION_1) }
+                    onClick = { onKeyPress(VTermKey.FUNCTION_1) },
                 )
 
                 KeyButton(
                     text = stringResource(R.string.button_key_f2),
                     contentDescription = null,
-                    onClick = { onKeyPress(VTermKey.FUNCTION_2) }
+                    onClick = { onKeyPress(VTermKey.FUNCTION_2) },
                 )
 
                 KeyButton(
                     text = stringResource(R.string.button_key_f3),
                     contentDescription = null,
-                    onClick = { onKeyPress(VTermKey.FUNCTION_3) }
+                    onClick = { onKeyPress(VTermKey.FUNCTION_3) },
                 )
 
                 KeyButton(
                     text = stringResource(R.string.button_key_f4),
                     contentDescription = null,
-                    onClick = { onKeyPress(VTermKey.FUNCTION_4) }
+                    onClick = { onKeyPress(VTermKey.FUNCTION_4) },
                 )
 
                 KeyButton(
                     text = stringResource(R.string.button_key_f5),
                     contentDescription = null,
-                    onClick = { onKeyPress(VTermKey.FUNCTION_5) }
+                    onClick = { onKeyPress(VTermKey.FUNCTION_5) },
                 )
 
                 KeyButton(
                     text = stringResource(R.string.button_key_f6),
                     contentDescription = null,
-                    onClick = { onKeyPress(VTermKey.FUNCTION_6) }
+                    onClick = { onKeyPress(VTermKey.FUNCTION_6) },
                 )
 
                 KeyButton(
                     text = stringResource(R.string.button_key_f7),
                     contentDescription = null,
-                    onClick = { onKeyPress(VTermKey.FUNCTION_7) }
+                    onClick = { onKeyPress(VTermKey.FUNCTION_7) },
                 )
 
                 KeyButton(
                     text = stringResource(R.string.button_key_f8),
                     contentDescription = null,
-                    onClick = { onKeyPress(VTermKey.FUNCTION_8) }
+                    onClick = { onKeyPress(VTermKey.FUNCTION_8) },
                 )
 
                 KeyButton(
                     text = stringResource(R.string.button_key_f9),
                     contentDescription = null,
-                    onClick = { onKeyPress(VTermKey.FUNCTION_9) }
+                    onClick = { onKeyPress(VTermKey.FUNCTION_9) },
                 )
 
                 KeyButton(
                     text = stringResource(R.string.button_key_f10),
                     contentDescription = null,
-                    onClick = { onKeyPress(VTermKey.FUNCTION_10) }
+                    onClick = { onKeyPress(VTermKey.FUNCTION_10) },
                 )
 
                 KeyButton(
                     text = stringResource(R.string.button_key_f11),
                     contentDescription = null,
-                    onClick = { onKeyPress(VTermKey.FUNCTION_11) }
+                    onClick = { onKeyPress(VTermKey.FUNCTION_11) },
                 )
 
                 KeyButton(
                     text = stringResource(R.string.button_key_f12),
                     contentDescription = null,
-                    onClick = { onKeyPress(VTermKey.FUNCTION_12) }
+                    onClick = { onKeyPress(VTermKey.FUNCTION_12) },
                 )
             }
 
@@ -368,20 +368,20 @@ private fun TerminalKeyboardContent(
                 },
                 modifier = Modifier.size(
                     width = TERMINAL_KEYBOARD_WIDTH_DP.dp,
-                    height = TERMINAL_KEYBOARD_HEIGHT_DP.dp
+                    height = TERMINAL_KEYBOARD_HEIGHT_DP.dp,
                 ),
                 shape = RectangleShape,
                 border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline),
-                color = MaterialTheme.colorScheme.surface.copy(alpha = UI_OPACITY)
+                color = MaterialTheme.colorScheme.surface.copy(alpha = UI_OPACITY),
             ) {
                 Box(
                     contentAlignment = Alignment.Center,
-                    modifier = Modifier.fillMaxSize()
+                    modifier = Modifier.fillMaxSize(),
                 ) {
                     Icon(
                         Icons.Default.Edit,
                         contentDescription = stringResource(R.string.terminal_keyboard_text_input_button),
-                        modifier = Modifier.height(TERMINAL_KEYBOARD_CONTENT_SIZE_DP.dp)
+                        modifier = Modifier.height(TERMINAL_KEYBOARD_CONTENT_SIZE_DP.dp),
                     )
                 }
             }
@@ -398,15 +398,15 @@ private fun TerminalKeyboardContent(
                 },
                 modifier = Modifier.size(
                     width = TERMINAL_KEYBOARD_WIDTH_DP.dp,
-                    height = TERMINAL_KEYBOARD_HEIGHT_DP.dp
+                    height = TERMINAL_KEYBOARD_HEIGHT_DP.dp,
                 ),
                 shape = RectangleShape,
                 border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline),
-                color = MaterialTheme.colorScheme.surface.copy(alpha = UI_OPACITY)
+                color = MaterialTheme.colorScheme.surface.copy(alpha = UI_OPACITY),
             ) {
                 Box(
                     contentAlignment = Alignment.Center,
-                    modifier = Modifier.fillMaxSize()
+                    modifier = Modifier.fillMaxSize(),
                 ) {
                     Icon(
                         if (imeVisible) Icons.Default.KeyboardHide else Icons.Default.Keyboard,
@@ -415,9 +415,9 @@ private fun TerminalKeyboardContent(
                                 R.string.image_description_hide_keyboard
                             } else {
                                 R.string.image_description_show_keyboard
-                            }
+                            },
                         ),
-                        modifier = Modifier.height(TERMINAL_KEYBOARD_CONTENT_SIZE_DP.dp)
+                        modifier = Modifier.height(TERMINAL_KEYBOARD_CONTENT_SIZE_DP.dp),
                     )
                 }
             }
@@ -437,7 +437,7 @@ private fun KeyButton(
     icon: ImageVector? = null,
     onClick: (() -> Unit)? = null,
     backgroundColor: Color = MaterialTheme.colorScheme.surface.copy(alpha = UI_OPACITY),
-    tint: Color = MaterialTheme.colorScheme.onSurface
+    tint: Color = MaterialTheme.colorScheme.onSurface,
 ) {
     val surfaceModifier = modifier
         .size(width = TERMINAL_KEYBOARD_WIDTH_DP.dp, height = TERMINAL_KEYBOARD_HEIGHT_DP.dp)
@@ -445,20 +445,20 @@ private fun KeyButton(
     val content: @Composable () -> Unit = {
         Box(
             contentAlignment = Alignment.Center,
-            modifier = Modifier.fillMaxSize()
+            modifier = Modifier.fillMaxSize(),
         ) {
             if (text != null) {
                 Text(
                     text = text,
                     style = MaterialTheme.typography.labelSmall,
-                    color = tint
+                    color = tint,
                 )
             } else if (icon != null) {
                 Icon(
                     imageVector = icon,
                     contentDescription = contentDescription,
                     tint = tint,
-                    modifier = Modifier.height(TERMINAL_KEYBOARD_CONTENT_SIZE_DP.dp)
+                    modifier = Modifier.height(TERMINAL_KEYBOARD_CONTENT_SIZE_DP.dp),
                 )
             }
         }
@@ -471,7 +471,7 @@ private fun KeyButton(
             shape = RectangleShape,
             border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline),
             color = backgroundColor,
-            content = content
+            content = content,
         )
     } else {
         Surface(
@@ -479,7 +479,7 @@ private fun KeyButton(
             shape = RectangleShape,
             border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline),
             color = backgroundColor,
-            content = content
+            content = content,
         )
     }
 }
@@ -494,7 +494,7 @@ private fun RepeatableKeyButton(
     icon: ImageVector,
     contentDescription: String?,
     onPress: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     val coroutineScope = rememberCoroutineScope()
     var isPressed by remember { mutableStateOf(false) }
@@ -552,10 +552,10 @@ private fun RepeatableKeyButton(
                     } else {
                         repeatJob?.cancel()
                     }
-                }
+                },
             )
         },
-        backgroundColor = backgroundColor
+        backgroundColor = backgroundColor,
     )
 }
 
@@ -565,7 +565,7 @@ private fun ModifierKeyButton(
     contentDescription: String?,
     modifierLevel: ModifierLevel,
     onClick: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     val backgroundColor = when (modifierLevel) {
         ModifierLevel.OFF -> MaterialTheme.colorScheme.surface.copy(alpha = UI_OPACITY)
@@ -585,7 +585,7 @@ private fun ModifierKeyButton(
         onClick = onClick,
         modifier = modifier,
         backgroundColor = backgroundColor,
-        tint = textColor
+        tint = textColor,
     )
 }
 
@@ -597,7 +597,7 @@ private fun TerminalKeyboardPreview() {
             modifierState = ModifierState(
                 ctrlState = ModifierLevel.OFF,
                 altState = ModifierLevel.OFF,
-                shiftState = ModifierLevel.OFF
+                shiftState = ModifierLevel.OFF,
             ),
             onCtrlPress = {},
             onEscPress = {},
@@ -609,7 +609,7 @@ private fun TerminalKeyboardPreview() {
             onOpenTextInput = {},
             onScrollInProgressChange = {},
             imeVisible = false,
-            playAnimation = false
+            playAnimation = false,
         )
     }
 }
@@ -622,7 +622,7 @@ private fun TerminalKeyboardCtrlPressedPreview() {
             modifierState = ModifierState(
                 ctrlState = ModifierLevel.TRANSIENT,
                 altState = ModifierLevel.OFF,
-                shiftState = ModifierLevel.OFF
+                shiftState = ModifierLevel.OFF,
             ),
             onCtrlPress = {},
             onEscPress = {},
@@ -634,7 +634,7 @@ private fun TerminalKeyboardCtrlPressedPreview() {
             onOpenTextInput = {},
             onScrollInProgressChange = {},
             imeVisible = false,
-            playAnimation = false
+            playAnimation = false,
         )
     }
 }
@@ -647,7 +647,7 @@ private fun TerminalKeyboardCtrlLockedPreview() {
             modifierState = ModifierState(
                 ctrlState = ModifierLevel.LOCKED,
                 altState = ModifierLevel.OFF,
-                shiftState = ModifierLevel.OFF
+                shiftState = ModifierLevel.OFF,
             ),
             onCtrlPress = {},
             onEscPress = {},
@@ -659,7 +659,7 @@ private fun TerminalKeyboardCtrlLockedPreview() {
             onOpenTextInput = {},
             onScrollInProgressChange = {},
             imeVisible = false,
-            playAnimation = false
+            playAnimation = false,
         )
     }
 }
@@ -672,7 +672,7 @@ private fun TerminalKeyboardImeVisiblePreview() {
             modifierState = ModifierState(
                 ctrlState = ModifierLevel.OFF,
                 altState = ModifierLevel.OFF,
-                shiftState = ModifierLevel.OFF
+                shiftState = ModifierLevel.OFF,
             ),
             onCtrlPress = {},
             onEscPress = {},
@@ -684,7 +684,7 @@ private fun TerminalKeyboardImeVisiblePreview() {
             onOpenTextInput = {},
             onScrollInProgressChange = {},
             imeVisible = true,
-            playAnimation = false
+            playAnimation = false,
         )
     }
 }

--- a/app/src/test/java/org/connectbot/service/TerminalKeyListenerTest.kt
+++ b/app/src/test/java/org/connectbot/service/TerminalKeyListenerTest.kt
@@ -23,153 +23,93 @@ class TerminalKeyListenerTest {
 
     private val noopDispatcher = KeyDispatcher { _, _ -> }
 
-    // NONE: OFF -> TRANSIENT -> LOCKED -> OFF
+    // NONE: sticky is OFF for all modifiers. metaPress only works if forceSticky=true.
 
     @Test
-    fun `NONE ctrl first press goes to TRANSIENT`() {
+    fun `NONE ctrl first press does nothing if not forced`() {
         val listener = TerminalKeyListener(noopDispatcher, StickyModifierSetting.NONE)
-        listener.metaPress(TerminalKeyListener.OUR_CTRL_ON)
+        listener.metaPress(TerminalKeyListener.CTRL_ON, forceSticky = false)
+        assertEquals(ModifierLevel.OFF, listener.getModifierState().ctrlState)
+    }
+
+    @Test
+    fun `NONE ctrl first press goes to TRANSIENT if forced`() {
+        val listener = TerminalKeyListener(noopDispatcher, StickyModifierSetting.NONE)
+        listener.metaPress(TerminalKeyListener.CTRL_ON, forceSticky = true)
         assertEquals(ModifierLevel.TRANSIENT, listener.getModifierState().ctrlState)
     }
 
     @Test
-    fun `NONE ctrl second press goes to LOCKED`() {
+    fun `NONE ctrl second press goes to LOCKED if forced`() {
         val listener = TerminalKeyListener(noopDispatcher, StickyModifierSetting.NONE)
-        listener.metaPress(TerminalKeyListener.OUR_CTRL_ON)
-        listener.metaPress(TerminalKeyListener.OUR_CTRL_ON)
+        listener.metaPress(TerminalKeyListener.CTRL_ON, forceSticky = true)
+        listener.metaPress(TerminalKeyListener.CTRL_ON, forceSticky = true)
         assertEquals(ModifierLevel.LOCKED, listener.getModifierState().ctrlState)
     }
 
     @Test
-    fun `NONE ctrl third press goes to OFF`() {
+    fun `NONE ctrl third press goes to OFF if forced`() {
         val listener = TerminalKeyListener(noopDispatcher, StickyModifierSetting.NONE)
-        listener.metaPress(TerminalKeyListener.OUR_CTRL_ON)
-        listener.metaPress(TerminalKeyListener.OUR_CTRL_ON)
-        listener.metaPress(TerminalKeyListener.OUR_CTRL_ON)
+        listener.metaPress(TerminalKeyListener.CTRL_ON, forceSticky = true)
+        listener.metaPress(TerminalKeyListener.CTRL_ON, forceSticky = true)
+        listener.metaPress(TerminalKeyListener.CTRL_ON, forceSticky = true)
         assertEquals(ModifierLevel.OFF, listener.getModifierState().ctrlState)
     }
 
     @Test
     fun `NONE ctrl clearTransients removes TRANSIENT but not LOCKED`() {
         val listener = TerminalKeyListener(noopDispatcher, StickyModifierSetting.NONE)
-        listener.metaPress(TerminalKeyListener.OUR_CTRL_ON)
+        listener.metaPress(TerminalKeyListener.CTRL_ON, forceSticky = true)
         listener.clearTransients()
         assertEquals(ModifierLevel.OFF, listener.getModifierState().ctrlState)
 
-        listener.metaPress(TerminalKeyListener.OUR_CTRL_ON)
-        listener.metaPress(TerminalKeyListener.OUR_CTRL_ON)
+        listener.metaPress(TerminalKeyListener.CTRL_ON, forceSticky = true)
+        listener.metaPress(TerminalKeyListener.CTRL_ON, forceSticky = true)
         listener.clearTransients()
         assertEquals(ModifierLevel.LOCKED, listener.getModifierState().ctrlState)
     }
 
-    // ALT: alt goes OFF -> LOCKED -> OFF; ctrl/shift still use 3-state
+    // ALT: alt is sticky, others are not.
 
     @Test
-    fun `ALT alt first press goes to LOCKED`() {
+    fun `ALT alt first press goes to TRANSIENT even if not forced`() {
         val listener = TerminalKeyListener(noopDispatcher, StickyModifierSetting.ALT)
-        listener.metaPress(TerminalKeyListener.OUR_ALT_ON)
-        assertEquals(ModifierLevel.LOCKED, listener.getModifierState().altState)
+        listener.metaPress(TerminalKeyListener.ALT_ON, forceSticky = false)
+        assertEquals(ModifierLevel.TRANSIENT, listener.getModifierState().altState)
     }
 
     @Test
-    fun `ALT alt second press goes to OFF`() {
+    fun `ALT ctrl first press does nothing if not forced`() {
         val listener = TerminalKeyListener(noopDispatcher, StickyModifierSetting.ALT)
-        listener.metaPress(TerminalKeyListener.OUR_ALT_ON)
-        listener.metaPress(TerminalKeyListener.OUR_ALT_ON)
-        assertEquals(ModifierLevel.OFF, listener.getModifierState().altState)
+        listener.metaPress(TerminalKeyListener.CTRL_ON, forceSticky = false)
+        assertEquals(ModifierLevel.OFF, listener.getModifierState().ctrlState)
     }
 
+    // ALL: all modifiers are sticky.
+
     @Test
-    fun `ALT ctrl still uses 3-state`() {
-        val listener = TerminalKeyListener(noopDispatcher, StickyModifierSetting.ALT)
-        listener.metaPress(TerminalKeyListener.OUR_CTRL_ON)
+    fun `ALL ctrl first press goes to TRANSIENT even if not forced`() {
+        val listener = TerminalKeyListener(noopDispatcher, StickyModifierSetting.ALL)
+        listener.metaPress(TerminalKeyListener.CTRL_ON, forceSticky = false)
         assertEquals(ModifierLevel.TRANSIENT, listener.getModifierState().ctrlState)
-    }
-
-    // ALL: ctrl/shift/alt all go OFF -> LOCKED -> OFF
-
-    @Test
-    fun `ALL ctrl first press goes to LOCKED`() {
-        val listener = TerminalKeyListener(noopDispatcher, StickyModifierSetting.ALL)
-        listener.metaPress(TerminalKeyListener.OUR_CTRL_ON)
-        assertEquals(ModifierLevel.LOCKED, listener.getModifierState().ctrlState)
-    }
-
-    @Test
-    fun `ALL ctrl second press goes to OFF`() {
-        val listener = TerminalKeyListener(noopDispatcher, StickyModifierSetting.ALL)
-        listener.metaPress(TerminalKeyListener.OUR_CTRL_ON)
-        listener.metaPress(TerminalKeyListener.OUR_CTRL_ON)
-        assertEquals(ModifierLevel.OFF, listener.getModifierState().ctrlState)
-    }
-
-    @Test
-    fun `ALL clearTransients does not clear LOCKED state`() {
-        val listener = TerminalKeyListener(noopDispatcher, StickyModifierSetting.ALL)
-        listener.metaPress(TerminalKeyListener.OUR_CTRL_ON)
-        listener.clearTransients()
-        assertEquals(ModifierLevel.LOCKED, listener.getModifierState().ctrlState)
     }
 
     // sendPressedKey/sendTab/sendEscape clear TRANSIENT but preserve LOCKED
 
     @Test
     fun `sendPressedKey clears TRANSIENT ctrl`() {
-        val listener = TerminalKeyListener(noopDispatcher, StickyModifierSetting.NONE)
-        listener.metaPress(TerminalKeyListener.OUR_CTRL_ON)
+        val listener = TerminalKeyListener(noopDispatcher, StickyModifierSetting.ALL)
+        listener.metaPress(TerminalKeyListener.CTRL_ON)
         listener.sendPressedKey(0)
         assertEquals(ModifierLevel.OFF, listener.getModifierState().ctrlState)
     }
 
     @Test
     fun `sendPressedKey preserves LOCKED ctrl`() {
-        val listener = TerminalKeyListener(noopDispatcher, StickyModifierSetting.NONE)
-        listener.metaPress(TerminalKeyListener.OUR_CTRL_ON)
-        listener.metaPress(TerminalKeyListener.OUR_CTRL_ON)
+        val listener = TerminalKeyListener(noopDispatcher, StickyModifierSetting.ALL)
+        listener.metaPress(TerminalKeyListener.CTRL_ON)
+        listener.metaPress(TerminalKeyListener.CTRL_ON)
         listener.sendPressedKey(0)
-        assertEquals(ModifierLevel.LOCKED, listener.getModifierState().ctrlState)
-    }
-
-    @Test
-    fun `sendTab clears TRANSIENT ctrl`() {
-        val listener = TerminalKeyListener(noopDispatcher, StickyModifierSetting.NONE)
-        listener.metaPress(TerminalKeyListener.OUR_CTRL_ON)
-        listener.sendTab()
-        assertEquals(ModifierLevel.OFF, listener.getModifierState().ctrlState)
-    }
-
-    @Test
-    fun `sendTab preserves LOCKED ctrl`() {
-        val listener = TerminalKeyListener(noopDispatcher, StickyModifierSetting.NONE)
-        listener.metaPress(TerminalKeyListener.OUR_CTRL_ON)
-        listener.metaPress(TerminalKeyListener.OUR_CTRL_ON)
-        listener.sendTab()
-        assertEquals(ModifierLevel.LOCKED, listener.getModifierState().ctrlState)
-    }
-
-    @Test
-    fun `sendEscape clears TRANSIENT ctrl`() {
-        val listener = TerminalKeyListener(noopDispatcher, StickyModifierSetting.NONE)
-        listener.metaPress(TerminalKeyListener.OUR_CTRL_ON)
-        listener.sendEscape()
-        assertEquals(ModifierLevel.OFF, listener.getModifierState().ctrlState)
-    }
-
-    @Test
-    fun `sendEscape preserves LOCKED ctrl`() {
-        val listener = TerminalKeyListener(noopDispatcher, StickyModifierSetting.NONE)
-        listener.metaPress(TerminalKeyListener.OUR_CTRL_ON)
-        listener.metaPress(TerminalKeyListener.OUR_CTRL_ON)
-        listener.sendEscape()
-        assertEquals(ModifierLevel.LOCKED, listener.getModifierState().ctrlState)
-    }
-
-    // forceSticky jumps directly to LOCKED regardless of StickyModifierSetting
-
-    @Test
-    fun `forceSticky jumps to LOCKED from OFF when setting is NONE`() {
-        val listener = TerminalKeyListener(noopDispatcher, StickyModifierSetting.NONE)
-        listener.metaPress(TerminalKeyListener.OUR_CTRL_ON, forceSticky = true)
         assertEquals(ModifierLevel.LOCKED, listener.getModifierState().ctrlState)
     }
 }


### PR DESCRIPTION
The original intention for the stickyKeys argument was to help IME users be able to press the CTRL key and then a key on their IME. There is a separate toggle for hardware users to modify how their keyboards work. This uses the StickyModifierSetting enum now to indicate the hardware keyboard users preference.