### PR TITLE
Refactor disconnect policy into a testable unit

### DIFF
--- a/app/src/main/java/org/connectbot/service/DisconnectAction.kt
+++ b/app/src/main/java/org/connectbot/service/DisconnectAction.kt
@@ -17,11 +17,13 @@
 
 package org.connectbot.service
 
-enum class DisconnectReason {
-    USER_REQUESTED,
-    REMOTE_EOF,
-    IO_ERROR,
-    NETWORK_LOST,
-    AUTH_FAIL,
-    UNKNOWN,
+sealed class DisconnectAction {
+    /** Remove the bridge and navigate away from the terminal screen immediately. */
+    object CloseImmediately : DisconnectAction()
+
+    /** Keep the bridge visible; show "Reconnect" and "Close" buttons so the user can read output. */
+    object ShowReconnectOverlay : DisconnectAction()
+
+    /** Silently attempt a new connection without showing the overlay. */
+    object AutoReconnect : DisconnectAction()
 }

--- a/app/src/main/java/org/connectbot/service/DisconnectPolicy.kt
+++ b/app/src/main/java/org/connectbot/service/DisconnectPolicy.kt
@@ -17,11 +17,17 @@
 
 package org.connectbot.service
 
-enum class DisconnectReason {
-    USER_REQUESTED,
-    REMOTE_EOF,
-    IO_ERROR,
-    NETWORK_LOST,
-    AUTH_FAIL,
-    UNKNOWN,
+object DisconnectPolicy {
+    fun decide(
+        reason: DisconnectReason,
+        quickDisconnect: Boolean,
+        stayConnected: Boolean,
+    ): DisconnectAction {
+        if (reason == DisconnectReason.USER_REQUESTED) return DisconnectAction.CloseImmediately
+        if (quickDisconnect) return DisconnectAction.CloseImmediately
+        // Never auto-reconnect on auth failures — looping would lock accounts
+        if (reason == DisconnectReason.AUTH_FAIL) return DisconnectAction.ShowReconnectOverlay
+        if (stayConnected) return DisconnectAction.AutoReconnect
+        return DisconnectAction.ShowReconnectOverlay
+    }
 }

--- a/app/src/main/java/org/connectbot/service/TerminalBridge.kt
+++ b/app/src/main/java/org/connectbot/service/TerminalBridge.kt
@@ -633,15 +633,15 @@ class TerminalBridge {
     /**
      * Force disconnection of this terminal bridge.
      *
-     * Intentional reasons ([DisconnectReason.isIntentional]) always take the
-     * immediate-close path, even if the bridge already reached the
-     * disconnected state — this is how the "Close" button on the reconnect
-     * overlay tears down a session that an IO_ERROR already marked disconnected.
+     * [DisconnectReason.USER_REQUESTED] always takes the immediate-close path,
+     * even if the bridge already reached the disconnected state — this is how
+     * the "Close" button on the reconnect overlay tears down a session that an
+     * IO_ERROR already marked disconnected.
      */
     fun dispatchDisconnect(reason: DisconnectReason) {
         // We don't need to do this multiple times.
         synchronized(this) {
-            if (disconnected && !reason.isIntentional) {
+            if (disconnected && reason != DisconnectReason.USER_REQUESTED) {
                 return
             }
 
@@ -665,15 +665,20 @@ class TerminalBridge {
             }
         }
 
-        if (reason.isIntentional || (host.quickDisconnect && !host.stayConnected)) {
-            awaitingClose = true
-            triggerDisconnectListener()
-        } else {
-            if (host.stayConnected) {
-                manager.requestReconnect(this)
+        when (DisconnectPolicy.decide(reason, host.quickDisconnect, host.stayConnected)) {
+            is DisconnectAction.CloseImmediately -> {
+                awaitingClose = true
+                triggerDisconnectListener()
             }
-            // Notify UI so the reconnect/close overlay appears (or updates)
-            manager.notifyBridgeStateChanged()
+
+            is DisconnectAction.AutoReconnect -> {
+                manager.requestReconnect(this)
+                manager.notifyBridgeStateChanged()
+            }
+
+            is DisconnectAction.ShowReconnectOverlay -> {
+                manager.notifyBridgeStateChanged()
+            }
         }
     }
 

--- a/app/src/test/java/org/connectbot/service/DisconnectPolicyTest.kt
+++ b/app/src/test/java/org/connectbot/service/DisconnectPolicyTest.kt
@@ -1,0 +1,164 @@
+/*
+ * ConnectBot: simple, powerful, open-source SSH client for Android
+ * Copyright 2026 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.connectbot.service
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DisconnectPolicyTest {
+
+    private fun decide(
+        reason: DisconnectReason,
+        quickDisconnect: Boolean = false,
+        stayConnected: Boolean = false,
+    ) = DisconnectPolicy.decide(reason, quickDisconnect, stayConnected)
+
+    // USER_REQUESTED always closes immediately regardless of flags
+
+    @Test
+    fun userRequested_defaultFlags_closesImmediately() {
+        assertTrue(decide(DisconnectReason.USER_REQUESTED) is DisconnectAction.CloseImmediately)
+    }
+
+    @Test
+    fun userRequested_quickDisconnect_closesImmediately() {
+        assertTrue(decide(DisconnectReason.USER_REQUESTED, quickDisconnect = true) is DisconnectAction.CloseImmediately)
+    }
+
+    @Test
+    fun userRequested_stayConnected_closesImmediately() {
+        assertTrue(decide(DisconnectReason.USER_REQUESTED, stayConnected = true) is DisconnectAction.CloseImmediately)
+    }
+
+    @Test
+    fun userRequested_bothFlags_closesImmediately() {
+        assertTrue(decide(DisconnectReason.USER_REQUESTED, quickDisconnect = true, stayConnected = true) is DisconnectAction.CloseImmediately)
+    }
+
+    // quickDisconnect=true closes immediately for all non-user reasons
+
+    @Test
+    fun remoteEof_quickDisconnect_closesImmediately() {
+        assertTrue(decide(DisconnectReason.REMOTE_EOF, quickDisconnect = true) is DisconnectAction.CloseImmediately)
+    }
+
+    @Test
+    fun ioError_quickDisconnect_closesImmediately() {
+        assertTrue(decide(DisconnectReason.IO_ERROR, quickDisconnect = true) is DisconnectAction.CloseImmediately)
+    }
+
+    @Test
+    fun networkLost_quickDisconnect_closesImmediately() {
+        assertTrue(decide(DisconnectReason.NETWORK_LOST, quickDisconnect = true) is DisconnectAction.CloseImmediately)
+    }
+
+    @Test
+    fun authFail_quickDisconnect_closesImmediately() {
+        assertTrue(decide(DisconnectReason.AUTH_FAIL, quickDisconnect = true) is DisconnectAction.CloseImmediately)
+    }
+
+    @Test
+    fun unknown_quickDisconnect_closesImmediately() {
+        assertTrue(decide(DisconnectReason.UNKNOWN, quickDisconnect = true) is DisconnectAction.CloseImmediately)
+    }
+
+    // quickDisconnect wins even when stayConnected is also true
+
+    @Test
+    fun remoteEof_bothFlags_closesImmediately() {
+        assertTrue(decide(DisconnectReason.REMOTE_EOF, quickDisconnect = true, stayConnected = true) is DisconnectAction.CloseImmediately)
+    }
+
+    @Test
+    fun ioError_bothFlags_closesImmediately() {
+        assertTrue(decide(DisconnectReason.IO_ERROR, quickDisconnect = true, stayConnected = true) is DisconnectAction.CloseImmediately)
+    }
+
+    @Test
+    fun networkLost_bothFlags_closesImmediately() {
+        assertTrue(decide(DisconnectReason.NETWORK_LOST, quickDisconnect = true, stayConnected = true) is DisconnectAction.CloseImmediately)
+    }
+
+    @Test
+    fun unknown_bothFlags_closesImmediately() {
+        assertTrue(decide(DisconnectReason.UNKNOWN, quickDisconnect = true, stayConnected = true) is DisconnectAction.CloseImmediately)
+    }
+
+    // Default flags (both false) — show overlay so user can read terminal output
+
+    @Test
+    fun remoteEof_defaultFlags_showsReconnectOverlay() {
+        // Key regression test: REMOTE_EOF must NOT close immediately by default
+        assertTrue(decide(DisconnectReason.REMOTE_EOF) is DisconnectAction.ShowReconnectOverlay)
+    }
+
+    @Test
+    fun ioError_defaultFlags_showsReconnectOverlay() {
+        assertTrue(decide(DisconnectReason.IO_ERROR) is DisconnectAction.ShowReconnectOverlay)
+    }
+
+    @Test
+    fun networkLost_defaultFlags_showsReconnectOverlay() {
+        assertTrue(decide(DisconnectReason.NETWORK_LOST) is DisconnectAction.ShowReconnectOverlay)
+    }
+
+    @Test
+    fun authFail_defaultFlags_showsReconnectOverlay() {
+        assertTrue(decide(DisconnectReason.AUTH_FAIL) is DisconnectAction.ShowReconnectOverlay)
+    }
+
+    @Test
+    fun unknown_defaultFlags_showsReconnectOverlay() {
+        assertTrue(decide(DisconnectReason.UNKNOWN) is DisconnectAction.ShowReconnectOverlay)
+    }
+
+    // stayConnected=true auto-reconnects (except AUTH_FAIL)
+
+    @Test
+    fun remoteEof_stayConnected_autoReconnects() {
+        assertTrue(decide(DisconnectReason.REMOTE_EOF, stayConnected = true) is DisconnectAction.AutoReconnect)
+    }
+
+    @Test
+    fun ioError_stayConnected_autoReconnects() {
+        assertTrue(decide(DisconnectReason.IO_ERROR, stayConnected = true) is DisconnectAction.AutoReconnect)
+    }
+
+    @Test
+    fun networkLost_stayConnected_autoReconnects() {
+        assertTrue(decide(DisconnectReason.NETWORK_LOST, stayConnected = true) is DisconnectAction.AutoReconnect)
+    }
+
+    @Test
+    fun unknown_stayConnected_autoReconnects() {
+        assertTrue(decide(DisconnectReason.UNKNOWN, stayConnected = true) is DisconnectAction.AutoReconnect)
+    }
+
+    // AUTH_FAIL never auto-reconnects even with stayConnected — would lock accounts
+
+    @Test
+    fun authFail_stayConnected_showsReconnectOverlay() {
+        assertTrue(decide(DisconnectReason.AUTH_FAIL, stayConnected = true) is DisconnectAction.ShowReconnectOverlay)
+    }
+
+    @Test
+    fun authFail_bothFlags_closesImmediately() {
+        // quickDisconnect wins over AUTH_FAIL special case
+        assertTrue(decide(DisconnectReason.AUTH_FAIL, quickDisconnect = true, stayConnected = true) is DisconnectAction.CloseImmediately)
+    }
+}


### PR DESCRIPTION
REMOTE_EOF should not close immediately unless "quick disconnect" is enabled. Factor the decision engine out so it can be tested.