### PR TITLE
Restore ConsoleScreen rotation preference

### DIFF
--- a/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
@@ -22,6 +22,7 @@ import android.content.ActivityNotFoundException
 import android.content.ClipboardManager
 import android.content.Context
 import android.content.Intent
+import android.content.pm.ActivityInfo
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
@@ -74,6 +75,7 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.collectAsState
@@ -168,14 +170,29 @@ fun ConsoleScreen(
 
     // Read preferences
     val prefs = remember { PreferenceManager.getDefaultSharedPreferences(context) }
-    val keyboardAlwaysVisible = remember { prefs.getBoolean("alwaysvisible", false) }
-    var fullscreen by remember { mutableStateOf(prefs.getBoolean("fullscreen", false)) }
-    var titleBarHide by remember { mutableStateOf(prefs.getBoolean("titlebarhide", false)) }
+    val keyboardAlwaysVisible = remember { prefs.getBoolean(PreferenceConstants.KEY_ALWAYS_VISIBLE, false) }
+    var fullscreen by remember { mutableStateOf(prefs.getBoolean(PreferenceConstants.FULLSCREEN, false)) }
+    var titleBarHide by remember { mutableStateOf(prefs.getBoolean(PreferenceConstants.TITLEBARHIDE, false)) }
     val volumeKeysChangeFontSize = remember { prefs.getBoolean(PreferenceConstants.VOLUME_FONT, true) }
 
     // Keyboard state
     val hasHardwareKeyboard = rememberHasHardwareKeyboard()
     var showSoftwareKeyboard by remember { mutableStateOf(!hasHardwareKeyboard) }
+
+    var rotation by remember(hasHardwareKeyboard) {
+        val prefValue = prefs.getString(PreferenceConstants.ROTATION, PreferenceConstants.ROTATION_DEFAULT)
+        mutableStateOf(
+            if (prefValue == PreferenceConstants.ROTATION_DEFAULT) {
+                if (hasHardwareKeyboard) {
+                    PreferenceConstants.ROTATION_LANDSCAPE
+                } else {
+                    PreferenceConstants.ROTATION_PORTRAIT
+                }
+            } else {
+                prefValue
+            },
+        )
+    }
 
     val termFocusRequester = remember { FocusRequester() }
 
@@ -215,6 +232,28 @@ fun ConsoleScreen(
         } catch (e: IllegalArgumentException) {
             // Handle foldable device state issues
             Timber.e(e, "Error setting fullscreen mode (foldable device?)")
+        }
+    }
+
+    // Restore original orientation on dispose
+    val activity = context as? Activity
+    if (activity != null) {
+        DisposableEffect(activity) {
+            val originalOrientation = activity.requestedOrientation
+            onDispose {
+                activity.requestedOrientation = originalOrientation
+            }
+        }
+    }
+
+    // Apply orientation settings based on user preference
+    LaunchedEffect(rotation) {
+        if (activity == null) return@LaunchedEffect
+        activity.requestedOrientation = when (rotation) {
+            PreferenceConstants.ROTATION_LANDSCAPE -> ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
+            PreferenceConstants.ROTATION_PORTRAIT -> ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+            PreferenceConstants.ROTATION_AUTO -> ActivityInfo.SCREEN_ORIENTATION_SENSOR
+            else -> ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
         }
     }
 
@@ -740,11 +779,13 @@ fun ConsoleScreen(
 
                     // More menu
                     Box {
-                        IconButton(onClick = {
-                            // Refresh menu state to update enabled/disabled items
-                            viewModel.refreshMenuState()
-                            showMenu = true
-                        }) {
+                        IconButton(
+                            onClick = {
+                                // Refresh menu state to update enabled/disabled items
+                                viewModel.refreshMenuState()
+                                showMenu = true
+                            },
+                        ) {
                             Icon(
                                 Icons.Default.MoreVert,
                                 contentDescription = stringResource(R.string.button_more_options),

--- a/app/src/main/java/org/connectbot/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/settings/SettingsScreen.kt
@@ -73,6 +73,7 @@ import org.connectbot.ui.components.FontDownloadProgressDialog
 import org.connectbot.ui.theme.ConnectBotTheme
 import org.connectbot.util.LocalFontProvider
 import org.connectbot.util.NotificationPermissionHelper
+import org.connectbot.util.PreferenceConstants
 import org.connectbot.util.TerminalFont
 import org.connectbot.util.ThemeMode
 import org.xmlpull.v1.XmlPullParser
@@ -441,18 +442,18 @@ fun SettingsScreenContent(
                 ListPreference(
                     title = stringResource(R.string.pref_rotation_title),
                     summary = when (uiState.rotation) {
-                        "Default" -> stringResource(R.string.list_rotation_default)
-                        "Force landscape" -> stringResource(R.string.list_rotation_land)
-                        "Force portrait" -> stringResource(R.string.list_rotation_port)
-                        "Automatic" -> stringResource(R.string.list_rotation_auto)
+                        PreferenceConstants.ROTATION_DEFAULT -> stringResource(R.string.list_rotation_default)
+                        PreferenceConstants.ROTATION_LANDSCAPE -> stringResource(R.string.list_rotation_land)
+                        PreferenceConstants.ROTATION_PORTRAIT -> stringResource(R.string.list_rotation_port)
+                        PreferenceConstants.ROTATION_AUTO -> stringResource(R.string.list_rotation_auto)
                         else -> uiState.rotation
                     },
                     value = uiState.rotation,
                     entries = listOf(
-                        stringResource(R.string.list_rotation_default) to "Default",
-                        stringResource(R.string.list_rotation_land) to "Force landscape",
-                        stringResource(R.string.list_rotation_port) to "Force portrait",
-                        stringResource(R.string.list_rotation_auto) to "Automatic",
+                        stringResource(R.string.list_rotation_default) to PreferenceConstants.ROTATION_DEFAULT,
+                        stringResource(R.string.list_rotation_land) to PreferenceConstants.ROTATION_LANDSCAPE,
+                        stringResource(R.string.list_rotation_port) to PreferenceConstants.ROTATION_PORTRAIT,
+                        stringResource(R.string.list_rotation_auto) to PreferenceConstants.ROTATION_AUTO,
                     ),
                     onValueChange = onRotationChange,
                 )

--- a/app/src/main/java/org/connectbot/util/PreferenceConstants.kt
+++ b/app/src/main/java/org/connectbot/util/PreferenceConstants.kt
@@ -32,6 +32,7 @@ object PreferenceConstants {
     const val ROTATION_DEFAULT: String = "Default"
     const val ROTATION_LANDSCAPE: String = "Force landscape"
     const val ROTATION_PORTRAIT: String = "Force portrait"
+    const val ROTATION_AUTO: String = "Automatic"
 
     const val FULLSCREEN: String = "fullscreen"
     const val TITLEBARHIDE: String = "titlebarhide"

--- a/app/src/test/kotlin/org/connectbot/ConsoleScreenTest.kt
+++ b/app/src/test/kotlin/org/connectbot/ConsoleScreenTest.kt
@@ -17,6 +17,12 @@
 
 package org.connectbot
 
+import android.content.Context
+import android.content.pm.ActivityInfo.SCREEN_ORIENTATION_BEHIND
+import android.content.pm.ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
+import android.content.pm.ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+import android.content.pm.ActivityInfo.SCREEN_ORIENTATION_SENSOR
+import android.content.pm.ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
@@ -28,16 +34,22 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
 import androidx.navigation.testing.TestNavHostController
+import androidx.preference.PreferenceManager
+import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import org.connectbot.ui.screens.console.ConsoleScreen
 import org.connectbot.ui.theme.ConnectBotTheme
+import org.connectbot.util.PreferenceConstants
+import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
 
 @HiltAndroidTest
 @RunWith(AndroidJUnit4::class)
@@ -53,6 +65,15 @@ class ConsoleScreenTest {
     @Before
     fun setUp() {
         hiltRule.inject()
+    }
+
+    @After
+    fun tearDown() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        PreferenceManager.getDefaultSharedPreferences(context).edit().clear().commit()
+    }
+
+    private fun setContent() {
         composeTestRule.setContent {
             val context = LocalContext.current
             navController = TestNavHostController(context)
@@ -82,6 +103,7 @@ class ConsoleScreenTest {
 
     @Test
     fun consoleScreen_displaysBackButton() {
+        setContent()
         navigateToConsoleScreen()
 
         composeTestRule
@@ -91,6 +113,7 @@ class ConsoleScreenTest {
 
     @Test
     fun consoleScreen_backButtonNavigatesUp() {
+        setContent()
         navigateToConsoleScreen()
 
         composeTestRule
@@ -104,6 +127,7 @@ class ConsoleScreenTest {
 
     @Test
     fun consoleScreen_displaysTextInputButton() {
+        setContent()
         navigateToConsoleScreen()
 
         composeTestRule
@@ -113,10 +137,96 @@ class ConsoleScreenTest {
 
     @Test
     fun consoleScreen_displaysPasteButton() {
+        setContent()
         navigateToConsoleScreen()
 
         composeTestRule
             .onNodeWithContentDescription("Paste")
             .assertIsDisplayed()
+    }
+
+    @Test
+    fun consoleScreen_setsLandscapeOrientation_whenPreferenceSet() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        PreferenceManager.getDefaultSharedPreferences(context).edit().putString(
+            PreferenceConstants.ROTATION,
+            PreferenceConstants.ROTATION_LANDSCAPE,
+        ).commit()
+
+        setContent()
+        navigateToConsoleScreen()
+
+        composeTestRule.runOnIdle {
+            assertEquals(SCREEN_ORIENTATION_LANDSCAPE, composeTestRule.activity.requestedOrientation)
+        }
+    }
+
+    @Test
+    fun consoleScreen_setsPortraitOrientation_whenPreferenceSet() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        PreferenceManager.getDefaultSharedPreferences(context).edit().putString(
+            PreferenceConstants.ROTATION,
+            PreferenceConstants.ROTATION_PORTRAIT,
+        ).commit()
+
+        setContent()
+        navigateToConsoleScreen()
+
+        composeTestRule.runOnIdle {
+            assertEquals(SCREEN_ORIENTATION_PORTRAIT, composeTestRule.activity.requestedOrientation)
+        }
+    }
+
+    @Test
+    fun consoleScreen_setsSensorOrientation_whenAutoPreferenceSet() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        PreferenceManager.getDefaultSharedPreferences(context).edit().putString(
+            PreferenceConstants.ROTATION,
+            PreferenceConstants.ROTATION_AUTO,
+        ).commit()
+
+        setContent()
+        navigateToConsoleScreen()
+
+        composeTestRule.runOnIdle {
+            assertEquals(SCREEN_ORIENTATION_SENSOR, composeTestRule.activity.requestedOrientation)
+        }
+    }
+
+    @Test
+    fun consoleScreen_setsPortraitOrientation_whenDefaultPreferenceAndNoHardwareKeyboard() {
+        setContent()
+        navigateToConsoleScreen()
+
+        composeTestRule.runOnIdle {
+            assertEquals(SCREEN_ORIENTATION_PORTRAIT, composeTestRule.activity.requestedOrientation)
+        }
+    }
+
+    @Test
+    fun consoleScreen_restoresOriginalOrientation_onNavigateBack() {
+        // Set an initial orientation that's different from what ConsoleScreen might set
+        composeTestRule.runOnUiThread {
+            composeTestRule.activity.requestedOrientation = SCREEN_ORIENTATION_BEHIND
+        }
+
+        setContent()
+        navigateToConsoleScreen()
+
+        // Verify orientation changed
+        composeTestRule.runOnIdle {
+            // Default rotation is portrait (without keyboard in tests)
+            assertEquals(SCREEN_ORIENTATION_PORTRAIT, composeTestRule.activity.requestedOrientation)
+        }
+
+        // Navigate back
+        composeTestRule
+            .onNodeWithContentDescription("Back")
+            .performClick()
+
+        // Verify orientation restored
+        composeTestRule.runOnIdle {
+            assertEquals(SCREEN_ORIENTATION_BEHIND, composeTestRule.activity.requestedOrientation)
+        }
     }
 }


### PR DESCRIPTION
The preference for what rotation the console was in was not wired up in the new Jetpack Compose screen. Add it back since we are pretty stable now.