### PR TITLE
Add EUC-JP and expanded terminal encoding support

### DIFF
--- a/app/src/main/java/org/connectbot/service/Relay.kt
+++ b/app/src/main/java/org/connectbot/service/Relay.kt
@@ -42,7 +42,7 @@ class Relay(
     private val bridge: TerminalBridge,
     private val transport: AbsTransport,
     private val dispatchers: CoroutineDispatchers,
-    encoding: String
+    encoding: String,
 ) {
 
     private var currentCharset: Charset? = null
@@ -149,7 +149,7 @@ class Relay(
                                     bridge.terminalEmulator.writeInput(
                                         destBuffer.array(),
                                         0,
-                                        destBuffer.limit()
+                                        destBuffer.limit(),
                                     )
                                 }
                                 destBuffer.clear()

--- a/app/src/main/java/org/connectbot/service/Relay.kt
+++ b/app/src/main/java/org/connectbot/service/Relay.kt
@@ -19,9 +19,9 @@ package org.connectbot.service
 
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.withContext
-import org.apache.harmony.niochar.charset.additional.IBM437
 import org.connectbot.di.CoroutineDispatchers
 import org.connectbot.transport.AbsTransport
+import org.connectbot.util.TerminalEncodings
 import timber.log.Timber
 import java.io.IOException
 import java.nio.ByteBuffer
@@ -69,11 +69,7 @@ class Relay(
     fun setCharset(encoding: String) {
         Timber.d("changing charset to $encoding")
 
-        val charset = if (encoding == "CP437") {
-            IBM437("IBM437", arrayOf("IBM437", "CP437"))
-        } else {
-            Charset.forName(encoding)
-        }
+        val charset = TerminalEncodings.charsetFor(encoding)
 
         if (charset == currentCharset) {
             return

--- a/app/src/main/java/org/connectbot/service/TerminalBridge.kt
+++ b/app/src/main/java/org/connectbot/service/TerminalBridge.kt
@@ -53,6 +53,7 @@ import org.connectbot.transport.SSH
 import org.connectbot.transport.TransportFactory
 import org.connectbot.util.HostConstants
 import org.connectbot.util.PreferenceConstants
+import org.connectbot.util.TerminalEncodings
 import timber.log.Timber
 import java.io.IOException
 import java.nio.charset.Charset
@@ -246,7 +247,7 @@ class TerminalBridge {
             defaultForeground = Color(defaultFgColor),
             defaultBackground = Color(defaultBgColor),
             onKeyboardInput = { data ->
-                transportOperations.trySend(TransportOperation.WriteData(data))
+                writeTerminalInput(data)
             },
             onBell = {
                 scope.launch {
@@ -528,7 +529,13 @@ class TerminalBridge {
         }
 
         transportOperations.trySend(
-            TransportOperation.WriteData(string.toByteArray(charset(encoding))),
+            TransportOperation.WriteData(string.toByteArray(TerminalEncodings.charsetFor(encoding))),
+        )
+    }
+
+    private fun writeTerminalInput(data: ByteArray) {
+        transportOperations.trySend(
+            TransportOperation.WriteData(TerminalEncodings.encodeTerminalInput(data, encoding)),
         )
     }
 

--- a/app/src/main/java/org/connectbot/ui/screens/hosteditor/HostEditorScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/hosteditor/HostEditorScreen.kt
@@ -84,7 +84,7 @@ import org.connectbot.util.TerminalFont
 fun HostEditorScreen(
     onNavigateBack: () -> Unit,
     modifier: Modifier = Modifier,
-    viewModel: HostEditorViewModel = hiltViewModel()
+    viewModel: HostEditorViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsState()
 
@@ -112,7 +112,7 @@ fun HostEditorScreen(
         onPasswordChange = viewModel::updatePassword,
         onClearPassword = viewModel::clearSavedPassword,
         onSaveHost = { expandedMode -> viewModel.saveHost(expandedMode) },
-        modifier = modifier
+        modifier = modifier,
     )
 }
 
@@ -142,7 +142,7 @@ fun HostEditorScreenContent(
     onPasswordChange: (String) -> Unit,
     onClearPassword: () -> Unit,
     onSaveHost: (Boolean) -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     var showProtocolMenu by remember { mutableStateOf(false) }
     var expandedMode by remember { mutableStateOf(hostId != -1L) }
@@ -157,14 +157,14 @@ fun HostEditorScreenContent(
                             stringResource(R.string.hostpref_add_host)
                         } else {
                             stringResource(R.string.hostpref_setting_title)
-                        }
+                        },
                     )
                 },
                 navigationIcon = {
                     IconButton(onClick = onNavigateBack) {
                         Icon(
                             Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = stringResource(R.string.button_navigate_up)
+                            contentDescription = stringResource(R.string.button_navigate_up),
                         )
                     }
                 },
@@ -180,14 +180,14 @@ fun HostEditorScreenContent(
                             uiState.protocol == "local" || uiState.hostname.isNotBlank()
                         } else {
                             uiState.quickConnect.isNotBlank()
-                        }
+                        },
                     ) {
                         Text(stringResource(if (hostId == -1L) R.string.hostpref_add_host else R.string.hostpref_save_host))
                     }
-                }
+                },
             )
         },
-        modifier = modifier
+        modifier = modifier,
     ) { padding ->
         Column(
             modifier = Modifier
@@ -195,7 +195,7 @@ fun HostEditorScreenContent(
                 .fillMaxSize()
                 .verticalScroll(rememberScrollState())
                 .padding(16.dp)
-                .imePadding()
+                .imePadding(),
         ) {
             if (!expandedMode) {
                 // Quick connect mode
@@ -206,25 +206,25 @@ fun HostEditorScreenContent(
                     placeholder = { Text(stringResource(R.string.host_editor_quick_connect_placeholder)) },
                     supportingText = { Text(stringResource(R.string.host_editor_quick_connect_example)) },
                     modifier = Modifier.fillMaxWidth(),
-                    singleLine = true
+                    singleLine = true,
                 )
 
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
                         .clickable { expandedMode = true }
-                        .padding(vertical = 8.dp)
+                        .padding(vertical = 8.dp),
                 ) {
                     Text(
                         text = stringResource(R.string.host_editor_show_advanced),
                         style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.primary
+                        color = MaterialTheme.colorScheme.primary,
                     )
                     Spacer(Modifier.width(4.dp))
                     Icon(
                         Icons.Default.ExpandMore,
                         contentDescription = stringResource(R.string.expand),
-                        tint = MaterialTheme.colorScheme.primary
+                        tint = MaterialTheme.colorScheme.primary,
                     )
                 }
             } else {
@@ -234,7 +234,7 @@ fun HostEditorScreenContent(
                     onValueChange = onNicknameChange,
                     label = { Text(stringResource(R.string.hostpref_nickname_title)) },
                     modifier = Modifier.fillMaxWidth(),
-                    singleLine = true
+                    singleLine = true,
                 )
 
                 // Show collapse button only if this is a new host (not editing existing)
@@ -243,18 +243,18 @@ fun HostEditorScreenContent(
                         modifier = Modifier
                             .fillMaxWidth()
                             .clickable { expandedMode = false }
-                            .padding(vertical = 8.dp)
+                            .padding(vertical = 8.dp),
                     ) {
                         Text(
                             text = stringResource(R.string.host_editor_hide_advanced),
                             style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.primary
+                            color = MaterialTheme.colorScheme.primary,
                         )
                         Spacer(Modifier.width(4.dp))
                         Icon(
                             Icons.Default.ExpandLess,
                             contentDescription = stringResource(R.string.button_collapse),
-                            tint = MaterialTheme.colorScheme.primary
+                            tint = MaterialTheme.colorScheme.primary,
                         )
                     }
                 }
@@ -268,7 +268,7 @@ fun HostEditorScreenContent(
                     onExpandedChange = { showProtocolMenu = it },
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(top = 8.dp)
+                        .padding(top = 8.dp),
                 ) {
                     OutlinedTextField(
                         value = uiState.protocol,
@@ -282,12 +282,12 @@ fun HostEditorScreenContent(
                         colors = ExposedDropdownMenuDefaults.outlinedTextFieldColors(),
                         modifier = Modifier
                             .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable)
-                            .fillMaxWidth()
+                            .fillMaxWidth(),
                     )
 
                     ExposedDropdownMenu(
                         expanded = showProtocolMenu,
-                        onDismissRequest = { showProtocolMenu = false }
+                        onDismissRequest = { showProtocolMenu = false },
                     ) {
                         protocols.forEach { protocol ->
                             DropdownMenuItem(
@@ -296,7 +296,7 @@ fun HostEditorScreenContent(
                                     onProtocolChange(protocol)
                                     showProtocolMenu = false
                                 },
-                                contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding
+                                contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding,
                             )
                         }
                     }
@@ -311,7 +311,7 @@ fun HostEditorScreenContent(
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(top = 8.dp),
-                        singleLine = true
+                        singleLine = true,
                     )
 
                     OutlinedTextField(
@@ -322,7 +322,7 @@ fun HostEditorScreenContent(
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(top = 8.dp),
-                        singleLine = true
+                        singleLine = true,
                     )
 
                     OutlinedTextField(
@@ -332,7 +332,7 @@ fun HostEditorScreenContent(
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(top = 8.dp),
-                        singleLine = true
+                        singleLine = true,
                     )
 
                     // IP version selector (disabled for literal IP addresses)
@@ -340,7 +340,7 @@ fun HostEditorScreenContent(
                         ipVersion = uiState.ipVersion,
                         hostname = uiState.hostname,
                         onIpVersionSelect = onIpVersionChange,
-                        modifier = Modifier.padding(top = 8.dp)
+                        modifier = Modifier.padding(top = 8.dp),
                     )
 
                     // Save password section (SSH only)
@@ -355,7 +355,7 @@ fun HostEditorScreenContent(
                                         stringResource(R.string.hostpref_password_unchanged)
                                     } else {
                                         stringResource(R.string.hostpref_password_title)
-                                    }
+                                    },
                                 )
                             },
                             supportingText = {
@@ -364,13 +364,13 @@ fun HostEditorScreenContent(
                             visualTransformation = PasswordVisualTransformation(),
                             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
                             modifier = Modifier.fillMaxWidth(),
-                            singleLine = true
+                            singleLine = true,
                         )
 
                         if (uiState.hasExistingPassword) {
                             TextButton(
                                 onClick = onClearPassword,
-                                modifier = Modifier.padding(top = 4.dp)
+                                modifier = Modifier.padding(top = 4.dp),
                             ) {
                                 Text(stringResource(R.string.hostpref_clear_password))
                             }
@@ -383,7 +383,7 @@ fun HostEditorScreenContent(
             HorizontalDivider(modifier = Modifier.padding(vertical = 16.dp))
             ColorSelector(
                 selectedColor = uiState.color,
-                onColorSelect = onColorChange
+                onColorSelect = onColorChange,
             )
 
             // Pubkey selector
@@ -391,7 +391,7 @@ fun HostEditorScreenContent(
             PubkeySelector(
                 pubkeyId = uiState.pubkeyId,
                 availablePubkeys = uiState.availablePubkeys,
-                onPubkeySelect = onPubkeyChange
+                onPubkeySelect = onPubkeyChange,
             )
 
             // Profile selector
@@ -399,7 +399,7 @@ fun HostEditorScreenContent(
             ProfileSelector(
                 profileId = uiState.profileId,
                 availableProfiles = uiState.availableProfiles,
-                onProfileSelect = onProfileChange
+                onProfileSelect = onProfileChange,
             )
 
             // Jump host selector (only for SSH protocol)
@@ -408,7 +408,7 @@ fun HostEditorScreenContent(
                 JumpHostSelector(
                     jumpHostId = uiState.jumpHostId,
                     availableJumpHosts = uiState.availableJumpHosts,
-                    onJumpHostSelect = onJumpHostChange
+                    onJumpHostSelect = onJumpHostChange,
                 )
             }
 
@@ -419,7 +419,7 @@ fun HostEditorScreenContent(
                 checked = uiState.useAuthAgent != "no",
                 onCheckedChange = { checked ->
                     onUseAuthAgentChange(if (checked) "yes" else "no")
-                }
+                },
             )
 
             if (uiState.useAuthAgent != "no") {
@@ -428,7 +428,7 @@ fun HostEditorScreenContent(
                     checked = uiState.useAuthAgent == "confirm",
                     onCheckedChange = { checked ->
                         onUseAuthAgentChange(if (checked) "confirm" else "yes")
-                    }
+                    },
                 )
             }
 
@@ -438,7 +438,7 @@ fun HostEditorScreenContent(
                 title = stringResource(R.string.hostpref_compression_title),
                 summary = stringResource(R.string.hostpref_compression_summary),
                 checked = uiState.compression,
-                onCheckedChange = onCompressionChange
+                onCheckedChange = onCompressionChange,
             )
 
             // Want session
@@ -447,7 +447,7 @@ fun HostEditorScreenContent(
                 title = stringResource(R.string.hostpref_wantsession_title),
                 summary = stringResource(R.string.hostpref_wantsession_summary),
                 checked = uiState.wantSession,
-                onCheckedChange = onWantSessionChange
+                onCheckedChange = onWantSessionChange,
             )
 
             // Stay connected
@@ -456,7 +456,7 @@ fun HostEditorScreenContent(
                 title = stringResource(R.string.hostpref_stayconnected_title),
                 summary = stringResource(R.string.hostpref_stayconnected_summary),
                 checked = uiState.stayConnected,
-                onCheckedChange = onStayConnectedChange
+                onCheckedChange = onStayConnectedChange,
             )
 
             // Quick disconnect
@@ -465,7 +465,7 @@ fun HostEditorScreenContent(
                 title = stringResource(R.string.hostpref_quickdisconnect_title),
                 summary = stringResource(R.string.hostpref_quickdisconnect_summary),
                 checked = uiState.quickDisconnect,
-                onCheckedChange = onQuickDisconnectChange
+                onCheckedChange = onQuickDisconnectChange,
             )
 
             // Post-login automation
@@ -479,7 +479,7 @@ fun HostEditorScreenContent(
                 maxLines = 8,
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(top = 8.dp)
+                    .padding(top = 8.dp),
             )
         }
     }
@@ -490,7 +490,7 @@ fun HostEditorScreenContent(
 private fun ColorSelector(
     selectedColor: String,
     onColorSelect: (String) -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     var expanded by remember { mutableStateOf(false) }
     val iconColors = getIconColors()
@@ -505,12 +505,12 @@ private fun ColorSelector(
         Text(
             text = stringResource(R.string.hostpref_color_title),
             style = MaterialTheme.typography.titleMedium,
-            modifier = Modifier.padding(bottom = 8.dp)
+            modifier = Modifier.padding(bottom = 8.dp),
         )
 
         ExposedDropdownMenuBox(
             expanded = expanded,
-            onExpandedChange = { expanded = it }
+            onExpandedChange = { expanded = it },
         ) {
             OutlinedTextField(
                 value = selectedDisplayName,
@@ -523,12 +523,12 @@ private fun ColorSelector(
                 colors = ExposedDropdownMenuDefaults.outlinedTextFieldColors(),
                 modifier = Modifier
                     .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable)
-                    .fillMaxWidth()
+                    .fillMaxWidth(),
             )
 
             ExposedDropdownMenu(
                 expanded = expanded,
-                onDismissRequest = { expanded = false }
+                onDismissRequest = { expanded = false },
             ) {
                 iconColors.forEach { color ->
                     DropdownMenuItem(
@@ -538,7 +538,7 @@ private fun ColorSelector(
                             onColorSelect(color.hexValue)
                             expanded = false
                         },
-                        contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding
+                        contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding,
                     )
                 }
             }
@@ -551,40 +551,40 @@ private fun FontSizeSelector(
     fontSize: Int,
     onFontSizeChange: (Int) -> Unit,
     modifier: Modifier = Modifier,
-    enabled: Boolean = true
+    enabled: Boolean = true,
 ) {
     Column(modifier = modifier) {
         Text(
             text = stringResource(R.string.hostpref_fontsize_title),
             style = MaterialTheme.typography.titleMedium,
             color = if (enabled) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f),
-            modifier = Modifier.padding(bottom = 8.dp)
+            modifier = Modifier.padding(bottom = 8.dp),
         )
         if (!enabled) {
             Text(
                 text = stringResource(R.string.profile_controlled_setting),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.padding(bottom = 8.dp)
+                modifier = Modifier.padding(bottom = 8.dp),
             )
         }
 
         Row(
             modifier = Modifier.fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically
+            verticalAlignment = Alignment.CenterVertically,
         ) {
             Slider(
                 value = fontSize.toFloat(),
                 onValueChange = { onFontSizeChange(it.toInt()) },
                 valueRange = 8f..32f,
                 enabled = enabled,
-                modifier = Modifier.weight(1f)
+                modifier = Modifier.weight(1f),
             )
             Text(
                 text = fontSize.toString(),
                 modifier = Modifier.padding(start = 16.dp),
                 style = MaterialTheme.typography.bodyLarge,
-                color = if (enabled) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
+                color = if (enabled) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f),
             )
         }
     }
@@ -598,7 +598,7 @@ private fun FontFamilySelector(
     localFonts: List<Pair<String, String>>,
     onFontFamilySelect: (String?) -> Unit,
     modifier: Modifier = Modifier,
-    enabled: Boolean = true
+    enabled: Boolean = true,
 ) {
     var expanded by remember { mutableStateOf(false) }
 
@@ -625,20 +625,20 @@ private fun FontFamilySelector(
             text = stringResource(R.string.hostpref_fontfamily_title),
             style = MaterialTheme.typography.titleMedium,
             color = if (enabled) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f),
-            modifier = Modifier.padding(bottom = 8.dp)
+            modifier = Modifier.padding(bottom = 8.dp),
         )
         if (!enabled) {
             Text(
                 text = stringResource(R.string.profile_controlled_setting),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.padding(bottom = 8.dp)
+                modifier = Modifier.padding(bottom = 8.dp),
             )
         }
 
         ExposedDropdownMenuBox(
             expanded = expanded && enabled,
-            onExpandedChange = { if (enabled) expanded = it }
+            onExpandedChange = { if (enabled) expanded = it },
         ) {
             OutlinedTextField(
                 value = if (fontFamily == null) {
@@ -656,12 +656,12 @@ private fun FontFamilySelector(
                 colors = ExposedDropdownMenuDefaults.outlinedTextFieldColors(),
                 modifier = Modifier
                     .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable)
-                    .fillMaxWidth()
+                    .fillMaxWidth(),
             )
 
             ExposedDropdownMenu(
                 expanded = expanded && enabled,
-                onDismissRequest = { expanded = false }
+                onDismissRequest = { expanded = false },
             ) {
                 allOptions.forEach { (label, value) ->
                     DropdownMenuItem(
@@ -670,7 +670,7 @@ private fun FontFamilySelector(
                             onFontFamilySelect(value)
                             expanded = false
                         },
-                        contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding
+                        contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding,
                     )
                 }
             }
@@ -685,7 +685,7 @@ private fun ColorSchemeSelector(
     availableSchemes: List<ColorScheme>,
     onColorSchemeSelect: (Long) -> Unit,
     modifier: Modifier = Modifier,
-    enabled: Boolean = true
+    enabled: Boolean = true,
 ) {
     var expanded by remember { mutableStateOf(false) }
 
@@ -694,20 +694,20 @@ private fun ColorSchemeSelector(
             text = stringResource(R.string.hostpref_colorscheme_title),
             style = MaterialTheme.typography.titleMedium,
             color = if (enabled) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f),
-            modifier = Modifier.padding(bottom = 8.dp)
+            modifier = Modifier.padding(bottom = 8.dp),
         )
         if (!enabled) {
             Text(
                 text = stringResource(R.string.profile_controlled_setting),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.padding(bottom = 8.dp)
+                modifier = Modifier.padding(bottom = 8.dp),
             )
         }
 
         ExposedDropdownMenuBox(
             expanded = expanded && enabled,
-            onExpandedChange = { if (enabled) expanded = it }
+            onExpandedChange = { if (enabled) expanded = it },
         ) {
             OutlinedTextField(
                 value = availableSchemes.find { it.id == colorSchemeId }?.name ?: stringResource(R.string.colorscheme_default),
@@ -721,12 +721,12 @@ private fun ColorSchemeSelector(
                 colors = ExposedDropdownMenuDefaults.outlinedTextFieldColors(),
                 modifier = Modifier
                     .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable)
-                    .fillMaxWidth()
+                    .fillMaxWidth(),
             )
 
             ExposedDropdownMenu(
                 expanded = expanded,
-                onDismissRequest = { expanded = false }
+                onDismissRequest = { expanded = false },
             ) {
                 availableSchemes.forEach { scheme ->
                     DropdownMenuItem(
@@ -738,7 +738,7 @@ private fun ColorSchemeSelector(
                                     Text(
                                         text = localizedDescription,
                                         style = MaterialTheme.typography.bodySmall,
-                                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
                                     )
                                 }
                             }
@@ -747,7 +747,7 @@ private fun ColorSchemeSelector(
                             onColorSchemeSelect(scheme.id)
                             expanded = false
                         },
-                        contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding
+                        contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding,
                     )
                 }
             }
@@ -761,14 +761,14 @@ private fun PubkeySelector(
     pubkeyId: Long,
     availablePubkeys: List<Pubkey>,
     onPubkeySelect: (Long) -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     var expanded by remember { mutableStateOf(false) }
 
     // Build options list: first the default options, then individual keys
     val defaultOptions = listOf(
         stringResource(R.string.list_pubkeyids_any) to -1L,
-        stringResource(R.string.list_pubkeyids_none) to -2L
+        stringResource(R.string.list_pubkeyids_none) to -2L,
     )
 
     val pubkeyOptions = availablePubkeys.map { pubkey ->
@@ -781,12 +781,12 @@ private fun PubkeySelector(
         Text(
             text = stringResource(R.string.hostpref_pubkeyid_title),
             style = MaterialTheme.typography.titleMedium,
-            modifier = Modifier.padding(bottom = 8.dp)
+            modifier = Modifier.padding(bottom = 8.dp),
         )
 
         ExposedDropdownMenuBox(
             expanded = expanded,
-            onExpandedChange = { expanded = it }
+            onExpandedChange = { expanded = it },
         ) {
             OutlinedTextField(
                 value = when (pubkeyId) {
@@ -808,12 +808,12 @@ private fun PubkeySelector(
                 colors = ExposedDropdownMenuDefaults.outlinedTextFieldColors(),
                 modifier = Modifier
                     .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable)
-                    .fillMaxWidth()
+                    .fillMaxWidth(),
             )
 
             ExposedDropdownMenu(
                 expanded = expanded,
-                onDismissRequest = { expanded = false }
+                onDismissRequest = { expanded = false },
             ) {
                 allOptions.forEach { (label, id) ->
                     DropdownMenuItem(
@@ -822,7 +822,7 @@ private fun PubkeySelector(
                             onPubkeySelect(id)
                             expanded = false
                         },
-                        contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding
+                        contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding,
                     )
                 }
             }
@@ -836,7 +836,7 @@ private fun ProfileSelector(
     profileId: Long?,
     availableProfiles: List<Profile>,
     onProfileSelect: (Long?) -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     var expanded by remember { mutableStateOf(false) }
 
@@ -844,18 +844,18 @@ private fun ProfileSelector(
         Text(
             text = stringResource(R.string.hostpref_profile_title),
             style = MaterialTheme.typography.titleMedium,
-            modifier = Modifier.padding(bottom = 4.dp)
+            modifier = Modifier.padding(bottom = 4.dp),
         )
         Text(
             text = stringResource(R.string.hostpref_profile_summary),
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.padding(bottom = 8.dp)
+            modifier = Modifier.padding(bottom = 8.dp),
         )
 
         ExposedDropdownMenuBox(
             expanded = expanded,
-            onExpandedChange = { expanded = it }
+            onExpandedChange = { expanded = it },
         ) {
             OutlinedTextField(
                 value = when {
@@ -875,12 +875,12 @@ private fun ProfileSelector(
                 colors = ExposedDropdownMenuDefaults.outlinedTextFieldColors(),
                 modifier = Modifier
                     .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable)
-                    .fillMaxWidth()
+                    .fillMaxWidth(),
             )
 
             ExposedDropdownMenu(
                 expanded = expanded,
-                onDismissRequest = { expanded = false }
+                onDismissRequest = { expanded = false },
             ) {
                 // "None" option
                 DropdownMenuItem(
@@ -889,7 +889,7 @@ private fun ProfileSelector(
                         onProfileSelect(null)
                         expanded = false
                     },
-                    contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding
+                    contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding,
                 )
 
                 // Available profiles
@@ -900,7 +900,7 @@ private fun ProfileSelector(
                             onProfileSelect(profile.id)
                             expanded = false
                         },
-                        contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding
+                        contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding,
                     )
                 }
             }
@@ -914,7 +914,7 @@ private fun IpVersionSelector(
     ipVersion: String,
     hostname: String,
     onIpVersionSelect: (String) -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     var expanded by remember { mutableStateOf(false) }
 
@@ -925,7 +925,7 @@ private fun IpVersionSelector(
     val options = listOf(
         HostConstants.IPVERSION_IPV4_AND_IPV6 to stringResource(R.string.ipversion_auto),
         HostConstants.IPVERSION_IPV4_ONLY to stringResource(R.string.ipversion_ipv4),
-        HostConstants.IPVERSION_IPV6_ONLY to stringResource(R.string.ipversion_ipv6)
+        HostConstants.IPVERSION_IPV6_ONLY to stringResource(R.string.ipversion_ipv6),
     )
 
     val displayLabel = when {
@@ -940,7 +940,7 @@ private fun IpVersionSelector(
     ExposedDropdownMenuBox(
         expanded = expanded && !isLiteralIp,
         onExpandedChange = { if (!isLiteralIp) expanded = it },
-        modifier = modifier.fillMaxWidth()
+        modifier = modifier.fillMaxWidth(),
     ) {
         OutlinedTextField(
             value = displayLabel,
@@ -957,12 +957,12 @@ private fun IpVersionSelector(
             colors = ExposedDropdownMenuDefaults.outlinedTextFieldColors(),
             modifier = Modifier
                 .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable)
-                .fillMaxWidth()
+                .fillMaxWidth(),
         )
 
         ExposedDropdownMenu(
             expanded = expanded && !isLiteralIp,
-            onDismissRequest = { expanded = false }
+            onDismissRequest = { expanded = false },
         ) {
             options.forEach { (value, label) ->
                 DropdownMenuItem(
@@ -971,7 +971,7 @@ private fun IpVersionSelector(
                         onIpVersionSelect(value)
                         expanded = false
                     },
-                    contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding
+                    contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding,
                 )
             }
         }
@@ -984,7 +984,7 @@ private fun JumpHostSelector(
     jumpHostId: Long?,
     availableJumpHosts: List<Host>,
     onJumpHostSelect: (Long?) -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     var expanded by remember { mutableStateOf(false) }
 
@@ -992,18 +992,18 @@ private fun JumpHostSelector(
         Text(
             text = stringResource(R.string.hostpref_jumphost_title),
             style = MaterialTheme.typography.titleMedium,
-            modifier = Modifier.padding(bottom = 4.dp)
+            modifier = Modifier.padding(bottom = 4.dp),
         )
         Text(
             text = stringResource(R.string.hostpref_jumphost_summary),
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.padding(bottom = 8.dp)
+            modifier = Modifier.padding(bottom = 8.dp),
         )
 
         ExposedDropdownMenuBox(
             expanded = expanded,
-            onExpandedChange = { expanded = it }
+            onExpandedChange = { expanded = it },
         ) {
             OutlinedTextField(
                 value = when {
@@ -1023,12 +1023,12 @@ private fun JumpHostSelector(
                 colors = ExposedDropdownMenuDefaults.outlinedTextFieldColors(),
                 modifier = Modifier
                     .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable)
-                    .fillMaxWidth()
+                    .fillMaxWidth(),
             )
 
             ExposedDropdownMenu(
                 expanded = expanded,
-                onDismissRequest = { expanded = false }
+                onDismissRequest = { expanded = false },
             ) {
                 // "None" option for direct connection
                 DropdownMenuItem(
@@ -1037,7 +1037,7 @@ private fun JumpHostSelector(
                         onJumpHostSelect(null)
                         expanded = false
                     },
-                    contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding
+                    contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding,
                 )
 
                 // Available jump hosts
@@ -1048,7 +1048,7 @@ private fun JumpHostSelector(
                             onJumpHostSelect(host.id)
                             expanded = false
                         },
-                        contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding
+                        contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding,
                     )
                 }
             }
@@ -1062,7 +1062,7 @@ private fun DelKeySelector(
     delKey: String,
     onDelKeySelect: (String) -> Unit,
     modifier: Modifier = Modifier,
-    enabled: Boolean = true
+    enabled: Boolean = true,
 ) {
     var expanded by remember { mutableStateOf(false) }
     val options = listOf("del", "backspace")
@@ -1072,20 +1072,20 @@ private fun DelKeySelector(
             text = stringResource(R.string.hostpref_delkey_title),
             style = MaterialTheme.typography.titleMedium,
             color = if (enabled) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f),
-            modifier = Modifier.padding(bottom = 8.dp)
+            modifier = Modifier.padding(bottom = 8.dp),
         )
         if (!enabled) {
             Text(
                 text = stringResource(R.string.profile_controlled_setting),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.padding(bottom = 8.dp)
+                modifier = Modifier.padding(bottom = 8.dp),
             )
         }
 
         ExposedDropdownMenuBox(
             expanded = expanded && enabled,
-            onExpandedChange = { if (enabled) expanded = it }
+            onExpandedChange = { if (enabled) expanded = it },
         ) {
             OutlinedTextField(
                 value = delKey,
@@ -1099,12 +1099,12 @@ private fun DelKeySelector(
                 colors = ExposedDropdownMenuDefaults.outlinedTextFieldColors(),
                 modifier = Modifier
                     .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable)
-                    .fillMaxWidth()
+                    .fillMaxWidth(),
             )
 
             ExposedDropdownMenu(
                 expanded = expanded && enabled,
-                onDismissRequest = { expanded = false }
+                onDismissRequest = { expanded = false },
             ) {
                 options.forEach { option ->
                     DropdownMenuItem(
@@ -1113,7 +1113,7 @@ private fun DelKeySelector(
                             onDelKeySelect(option)
                             expanded = false
                         },
-                        contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding
+                        contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding,
                     )
                 }
             }
@@ -1127,7 +1127,7 @@ private fun EncodingSelector(
     encoding: String,
     onEncodingSelect: (String) -> Unit,
     modifier: Modifier = Modifier,
-    enabled: Boolean = true
+    enabled: Boolean = true,
 ) {
     var expanded by remember { mutableStateOf(false) }
     val encodings = TerminalEncodings.commonEncodings
@@ -1137,20 +1137,20 @@ private fun EncodingSelector(
             text = stringResource(R.string.hostpref_encoding_title),
             style = MaterialTheme.typography.titleMedium,
             color = if (enabled) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f),
-            modifier = Modifier.padding(bottom = 8.dp)
+            modifier = Modifier.padding(bottom = 8.dp),
         )
         if (!enabled) {
             Text(
                 text = stringResource(R.string.profile_controlled_setting),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.padding(bottom = 8.dp)
+                modifier = Modifier.padding(bottom = 8.dp),
             )
         }
 
         ExposedDropdownMenuBox(
             expanded = expanded && enabled,
-            onExpandedChange = { if (enabled) expanded = it }
+            onExpandedChange = { if (enabled) expanded = it },
         ) {
             OutlinedTextField(
                 value = encoding,
@@ -1164,12 +1164,12 @@ private fun EncodingSelector(
                 colors = ExposedDropdownMenuDefaults.outlinedTextFieldColors(),
                 modifier = Modifier
                     .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable)
-                    .fillMaxWidth()
+                    .fillMaxWidth(),
             )
 
             ExposedDropdownMenu(
                 expanded = expanded && enabled,
-                onDismissRequest = { expanded = false }
+                onDismissRequest = { expanded = false },
             ) {
                 encodings.forEach { enc ->
                     DropdownMenuItem(
@@ -1178,7 +1178,7 @@ private fun EncodingSelector(
                             onEncodingSelect(enc)
                             expanded = false
                         },
-                        contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding
+                        contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding,
                     )
                 }
             }
@@ -1192,31 +1192,31 @@ private fun SwitchPreference(
     checked: Boolean,
     onCheckedChange: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
-    summary: String? = null
+    summary: String? = null,
 ) {
     Row(
         modifier = modifier
             .fillMaxWidth()
             .clickable { onCheckedChange(!checked) }
             .padding(vertical = 8.dp),
-        verticalAlignment = Alignment.CenterVertically
+        verticalAlignment = Alignment.CenterVertically,
     ) {
         Column(modifier = Modifier.weight(1f)) {
             Text(
                 text = title,
-                style = MaterialTheme.typography.bodyLarge
+                style = MaterialTheme.typography.bodyLarge,
             )
             if (summary != null) {
                 Text(
                     text = summary,
                     style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
         }
         Switch(
             checked = checked,
-            onCheckedChange = onCheckedChange
+            onCheckedChange = onCheckedChange,
         )
     }
 }
@@ -1246,15 +1246,15 @@ private fun HostEditorScreenPreview() {
                         encrypted = false,
                         startup = false,
                         confirmation = false,
-                        createdDate = System.currentTimeMillis()
-                    )
+                        createdDate = System.currentTimeMillis(),
+                    ),
                 ),
                 useAuthAgent = "yes",
                 compression = true,
                 wantSession = true,
                 stayConnected = false,
                 quickDisconnect = false,
-                postLogin = "cd /var/www"
+                postLogin = "cd /var/www",
             ),
             onNavigateBack = {},
             onQuickConnectChange = {},
@@ -1276,7 +1276,7 @@ private fun HostEditorScreenPreview() {
             onIpVersionChange = {},
             onPasswordChange = {},
             onClearPassword = {},
-            onSaveHost = {}
+            onSaveHost = {},
         )
     }
 }

--- a/app/src/main/java/org/connectbot/ui/screens/hosteditor/HostEditorScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/hosteditor/HostEditorScreen.kt
@@ -76,6 +76,7 @@ import org.connectbot.ui.common.getLocalizedFontDisplayName
 import org.connectbot.ui.theme.ConnectBotTheme
 import org.connectbot.util.HostConstants
 import org.connectbot.util.LocalFontProvider
+import org.connectbot.util.TerminalEncodings
 import org.connectbot.util.TerminalFont
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -1129,7 +1130,7 @@ private fun EncodingSelector(
     enabled: Boolean = true
 ) {
     var expanded by remember { mutableStateOf(false) }
-    val encodings = listOf("UTF-8", "ISO-8859-1", "US-ASCII", "Windows-1252")
+    val encodings = TerminalEncodings.commonEncodings
 
     Column(modifier = modifier) {
         Text(

--- a/app/src/main/java/org/connectbot/ui/screens/profiles/ProfileEditorScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/profiles/ProfileEditorScreen.kt
@@ -81,7 +81,7 @@ fun ProfileEditorScreen(
     onNavigateBack: () -> Unit,
     modifier: Modifier = Modifier,
     onNavigateToColors: () -> Unit = {},
-    viewModel: ProfileEditorViewModel = hiltViewModel()
+    viewModel: ProfileEditorViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsState()
     val snackbarHostState = remember { SnackbarHostState() }
@@ -106,44 +106,44 @@ fun ProfileEditorScreen(
                             stringResource(R.string.profile_editor_title_new)
                         } else {
                             stringResource(R.string.profile_editor_title_edit)
-                        }
+                        },
                     )
                 },
                 navigationIcon = {
                     IconButton(onClick = onNavigateBack) {
                         Icon(
                             imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = stringResource(R.string.button_navigate_up)
+                            contentDescription = stringResource(R.string.button_navigate_up),
                         )
                     }
-                }
+                },
             )
         },
         floatingActionButton = {
             FloatingActionButton(
-                onClick = { viewModel.save(onNavigateBack) }
+                onClick = { viewModel.save(onNavigateBack) },
             ) {
                 if (uiState.isSaving) {
                     CircularProgressIndicator(
                         modifier = Modifier.padding(12.dp),
-                        color = MaterialTheme.colorScheme.onPrimaryContainer
+                        color = MaterialTheme.colorScheme.onPrimaryContainer,
                     )
                 } else {
                     Icon(
                         imageVector = Icons.Default.Check,
-                        contentDescription = stringResource(R.string.profile_editor_save)
+                        contentDescription = stringResource(R.string.profile_editor_save),
                     )
                 }
             }
         },
-        snackbarHost = { SnackbarHost(snackbarHostState) }
+        snackbarHost = { SnackbarHost(snackbarHostState) },
     ) { paddingValues ->
         if (uiState.isLoading) {
             Box(
                 modifier = Modifier
                     .fillMaxSize()
                     .padding(paddingValues),
-                contentAlignment = Alignment.Center
+                contentAlignment = Alignment.Center,
             ) {
                 CircularProgressIndicator()
             }
@@ -153,7 +153,7 @@ fun ProfileEditorScreen(
                     .fillMaxSize()
                     .padding(paddingValues)
                     .padding(16.dp)
-                    .verticalScroll(rememberScrollState())
+                    .verticalScroll(rememberScrollState()),
             ) {
                 // Profile Name
                 OutlinedTextField(
@@ -162,7 +162,7 @@ fun ProfileEditorScreen(
                     label = { Text(stringResource(R.string.profile_editor_name_label)) },
                     singleLine = true,
                     isError = uiState.saveError != null,
-                    modifier = Modifier.fillMaxWidth()
+                    modifier = Modifier.fillMaxWidth(),
                 )
 
                 Spacer(modifier = Modifier.height(24.dp))
@@ -171,13 +171,13 @@ fun ProfileEditorScreen(
                 Text(
                     text = stringResource(R.string.profile_editor_section_icon_color),
                     style = MaterialTheme.typography.titleLarge,
-                    modifier = Modifier.padding(bottom = 8.dp)
+                    modifier = Modifier.padding(bottom = 8.dp),
                 )
 
                 IconColorSelector(
                     selectedColor = uiState.iconColor,
                     onSelectColor = { viewModel.updateIconColor(it) },
-                    modifier = Modifier.fillMaxWidth()
+                    modifier = Modifier.fillMaxWidth(),
                 )
 
                 Spacer(modifier = Modifier.height(24.dp))
@@ -185,17 +185,17 @@ fun ProfileEditorScreen(
                 // Color Scheme Section
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
-                    modifier = Modifier.padding(bottom = 8.dp)
+                    modifier = Modifier.padding(bottom = 8.dp),
                 ) {
                     Text(
                         text = stringResource(R.string.profile_editor_section_color_scheme),
                         style = MaterialTheme.typography.titleLarge,
-                        modifier = Modifier.weight(1f)
+                        modifier = Modifier.weight(1f),
                     )
                     IconButton(onClick = onNavigateToColors) {
                         Icon(
                             Icons.Default.Palette,
-                            contentDescription = stringResource(R.string.menu_manage_colors)
+                            contentDescription = stringResource(R.string.menu_manage_colors),
                         )
                     }
                 }
@@ -204,7 +204,7 @@ fun ProfileEditorScreen(
                     colorSchemeId = uiState.colorSchemeId,
                     availableSchemes = uiState.availableColorSchemes,
                     onSelectColorScheme = { viewModel.updateColorSchemeId(it) },
-                    modifier = Modifier.fillMaxWidth()
+                    modifier = Modifier.fillMaxWidth(),
                 )
 
                 Spacer(modifier = Modifier.height(24.dp))
@@ -213,7 +213,7 @@ fun ProfileEditorScreen(
                 Text(
                     text = stringResource(R.string.profile_editor_section_font),
                     style = MaterialTheme.typography.titleLarge,
-                    modifier = Modifier.padding(bottom = 8.dp)
+                    modifier = Modifier.padding(bottom = 8.dp),
                 )
 
                 FontFamilySelector(
@@ -221,7 +221,7 @@ fun ProfileEditorScreen(
                     customFonts = uiState.customFonts,
                     localFonts = uiState.localFonts,
                     onSelectFontFamily = { viewModel.updateFontFamily(it) },
-                    modifier = Modifier.fillMaxWidth()
+                    modifier = Modifier.fillMaxWidth(),
                 )
 
                 Spacer(modifier = Modifier.height(16.dp))
@@ -229,7 +229,7 @@ fun ProfileEditorScreen(
                 FontSizeSelector(
                     fontSize = uiState.fontSize,
                     onFontSizeChange = { viewModel.updateFontSize(it) },
-                    modifier = Modifier.fillMaxWidth()
+                    modifier = Modifier.fillMaxWidth(),
                 )
 
                 Spacer(modifier = Modifier.height(24.dp))
@@ -238,14 +238,14 @@ fun ProfileEditorScreen(
                 Text(
                     text = stringResource(R.string.profile_editor_section_terminal),
                     style = MaterialTheme.typography.titleLarge,
-                    modifier = Modifier.padding(bottom = 8.dp)
+                    modifier = Modifier.padding(bottom = 8.dp),
                 )
 
                 EmulationSelector(
                     emulation = uiState.emulation,
                     customTerminalTypes = uiState.customTerminalTypes,
                     onSelectEmulation = { viewModel.updateEmulation(it) },
-                    modifier = Modifier.fillMaxWidth()
+                    modifier = Modifier.fillMaxWidth(),
                 )
 
                 Spacer(modifier = Modifier.height(16.dp))
@@ -253,7 +253,7 @@ fun ProfileEditorScreen(
                 DelKeySelector(
                     delKey = uiState.delKey,
                     onSelectDelKey = { viewModel.updateDelKey(it) },
-                    modifier = Modifier.fillMaxWidth()
+                    modifier = Modifier.fillMaxWidth(),
                 )
 
                 Spacer(modifier = Modifier.height(16.dp))
@@ -263,7 +263,7 @@ fun ProfileEditorScreen(
                     commonEncodings = viewModel.commonEncodings,
                     allEncodings = viewModel.allEncodings,
                     onSelectEncoding = { viewModel.updateEncoding(it) },
-                    modifier = Modifier.fillMaxWidth()
+                    modifier = Modifier.fillMaxWidth(),
                 )
 
                 Spacer(modifier = Modifier.height(16.dp))
@@ -275,7 +275,7 @@ fun ProfileEditorScreen(
                     onEnabledChange = { viewModel.updateForceSizeEnabled(it) },
                     onRowsChange = { viewModel.updateForceSizeRows(it) },
                     onColumnsChange = { viewModel.updateForceSizeColumns(it) },
-                    modifier = Modifier.fillMaxWidth()
+                    modifier = Modifier.fillMaxWidth(),
                 )
 
                 Spacer(modifier = Modifier.height(32.dp))
@@ -291,7 +291,7 @@ private fun FontFamilySelector(
     customFonts: List<String>,
     localFonts: List<Pair<String, String>>,
     onSelectFontFamily: (String?) -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     var expanded by remember { mutableStateOf(false) }
 
@@ -318,12 +318,12 @@ private fun FontFamilySelector(
         Text(
             text = stringResource(R.string.profile_editor_font_family_title),
             style = MaterialTheme.typography.titleMedium,
-            modifier = Modifier.padding(bottom = 8.dp)
+            modifier = Modifier.padding(bottom = 8.dp),
         )
 
         ExposedDropdownMenuBox(
             expanded = expanded,
-            onExpandedChange = { expanded = it }
+            onExpandedChange = { expanded = it },
         ) {
             OutlinedTextField(
                 value = getLocalizedFontDisplayName(fontFamily),
@@ -336,12 +336,12 @@ private fun FontFamilySelector(
                 colors = ExposedDropdownMenuDefaults.outlinedTextFieldColors(),
                 modifier = Modifier
                     .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable)
-                    .fillMaxWidth()
+                    .fillMaxWidth(),
             )
 
             ExposedDropdownMenu(
                 expanded = expanded,
-                onDismissRequest = { expanded = false }
+                onDismissRequest = { expanded = false },
             ) {
                 allOptions.forEach { (displayName, value) ->
                     DropdownMenuItem(
@@ -350,7 +350,7 @@ private fun FontFamilySelector(
                             onSelectFontFamily(value)
                             expanded = false
                         },
-                        contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding
+                        contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding,
                     )
                 }
             }
@@ -362,13 +362,13 @@ private fun FontFamilySelector(
 private fun FontSizeSelector(
     fontSize: Int,
     onFontSizeChange: (Int) -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     Column(modifier = modifier) {
         Text(
             text = stringResource(R.string.profile_editor_font_size_title, fontSize),
             style = MaterialTheme.typography.titleMedium,
-            modifier = Modifier.padding(bottom = 8.dp)
+            modifier = Modifier.padding(bottom = 8.dp),
         )
 
         Slider(
@@ -376,7 +376,7 @@ private fun FontSizeSelector(
             onValueChange = { onFontSizeChange(it.toInt()) },
             valueRange = 6f..30f,
             steps = 23,
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier.fillMaxWidth(),
         )
     }
 }
@@ -387,7 +387,7 @@ private fun EmulationSelector(
     emulation: String,
     customTerminalTypes: List<String>,
     onSelectEmulation: (String) -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     var expanded by remember { mutableStateOf(false) }
     val presetOptions = listOf(
@@ -400,19 +400,19 @@ private fun EmulationSelector(
         "screen",
         "screen-256color",
         "linux",
-        "dumb"
+        "dumb",
     )
 
     Column(modifier = modifier) {
         Text(
             text = stringResource(R.string.pref_emulation_title),
             style = MaterialTheme.typography.titleMedium,
-            modifier = Modifier.padding(bottom = 8.dp)
+            modifier = Modifier.padding(bottom = 8.dp),
         )
 
         ExposedDropdownMenuBox(
             expanded = expanded,
-            onExpandedChange = { expanded = it }
+            onExpandedChange = { expanded = it },
         ) {
             OutlinedTextField(
                 value = emulation,
@@ -425,12 +425,12 @@ private fun EmulationSelector(
                 colors = ExposedDropdownMenuDefaults.outlinedTextFieldColors(),
                 modifier = Modifier
                     .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable)
-                    .fillMaxWidth()
+                    .fillMaxWidth(),
             )
 
             ExposedDropdownMenu(
                 expanded = expanded,
-                onDismissRequest = { expanded = false }
+                onDismissRequest = { expanded = false },
             ) {
                 presetOptions.forEach { option ->
                     DropdownMenuItem(
@@ -439,7 +439,7 @@ private fun EmulationSelector(
                             onSelectEmulation(option)
                             expanded = false
                         },
-                        contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding
+                        contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding,
                     )
                 }
                 if (customTerminalTypes.isNotEmpty()) {
@@ -449,14 +449,14 @@ private fun EmulationSelector(
                             text = {
                                 Text(
                                     text = option,
-                                    color = MaterialTheme.colorScheme.primary
+                                    color = MaterialTheme.colorScheme.primary,
                                 )
                             },
                             onClick = {
                                 onSelectEmulation(option)
                                 expanded = false
                             },
-                            contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding
+                            contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding,
                         )
                     }
                 }
@@ -470,7 +470,7 @@ private fun EmulationSelector(
 private fun DelKeySelector(
     delKey: String,
     onSelectDelKey: (String) -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     var expanded by remember { mutableStateOf(false) }
     val options = listOf("del", "backspace")
@@ -479,12 +479,12 @@ private fun DelKeySelector(
         Text(
             text = stringResource(R.string.hostpref_delkey_title),
             style = MaterialTheme.typography.titleMedium,
-            modifier = Modifier.padding(bottom = 8.dp)
+            modifier = Modifier.padding(bottom = 8.dp),
         )
 
         ExposedDropdownMenuBox(
             expanded = expanded,
-            onExpandedChange = { expanded = it }
+            onExpandedChange = { expanded = it },
         ) {
             OutlinedTextField(
                 value = delKey,
@@ -497,12 +497,12 @@ private fun DelKeySelector(
                 colors = ExposedDropdownMenuDefaults.outlinedTextFieldColors(),
                 modifier = Modifier
                     .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable)
-                    .fillMaxWidth()
+                    .fillMaxWidth(),
             )
 
             ExposedDropdownMenu(
                 expanded = expanded,
-                onDismissRequest = { expanded = false }
+                onDismissRequest = { expanded = false },
             ) {
                 options.forEach { option ->
                     DropdownMenuItem(
@@ -511,7 +511,7 @@ private fun DelKeySelector(
                             onSelectDelKey(option)
                             expanded = false
                         },
-                        contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding
+                        contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding,
                     )
                 }
             }
@@ -526,7 +526,7 @@ private fun EncodingSelector(
     commonEncodings: List<String>,
     allEncodings: List<String>,
     onSelectEncoding: (String) -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     var expanded by remember { mutableStateOf(false) }
     var filterText by remember { mutableStateOf("") }
@@ -542,7 +542,7 @@ private fun EncodingSelector(
         Text(
             text = stringResource(R.string.hostpref_encoding_title),
             style = MaterialTheme.typography.titleMedium,
-            modifier = Modifier.padding(bottom = 8.dp)
+            modifier = Modifier.padding(bottom = 8.dp),
         )
 
         ExposedDropdownMenuBox(
@@ -552,7 +552,7 @@ private fun EncodingSelector(
                     filterText = ""
                 }
                 expanded = it
-            }
+            },
         ) {
             OutlinedTextField(
                 value = if (expanded) filterText else encoding,
@@ -565,7 +565,7 @@ private fun EncodingSelector(
                 colors = ExposedDropdownMenuDefaults.outlinedTextFieldColors(),
                 modifier = Modifier
                     .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryEditable)
-                    .fillMaxWidth()
+                    .fillMaxWidth(),
             )
 
             ExposedDropdownMenu(
@@ -573,7 +573,7 @@ private fun EncodingSelector(
                 onDismissRequest = {
                     filterText = ""
                     expanded = false
-                }
+                },
             ) {
                 filteredCommon.forEach { enc ->
                     DropdownMenuItem(
@@ -583,7 +583,7 @@ private fun EncodingSelector(
                             filterText = ""
                             expanded = false
                         },
-                        contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding
+                        contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding,
                     )
                 }
                 if (showDivider) {
@@ -597,7 +597,7 @@ private fun EncodingSelector(
                             filterText = ""
                             expanded = false
                         },
-                        contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding
+                        contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding,
                     )
                 }
             }
@@ -611,14 +611,14 @@ private fun ColorSchemeSelector(
     colorSchemeId: Long,
     availableSchemes: List<ColorScheme>,
     onSelectColorScheme: (Long) -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     var expanded by remember { mutableStateOf(false) }
 
     Column(modifier = modifier) {
         ExposedDropdownMenuBox(
             expanded = expanded,
-            onExpandedChange = { expanded = it }
+            onExpandedChange = { expanded = it },
         ) {
             OutlinedTextField(
                 value = availableSchemes.find { it.id == colorSchemeId }?.name ?: stringResource(R.string.colorscheme_default),
@@ -631,12 +631,12 @@ private fun ColorSchemeSelector(
                 colors = ExposedDropdownMenuDefaults.outlinedTextFieldColors(),
                 modifier = Modifier
                     .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable)
-                    .fillMaxWidth()
+                    .fillMaxWidth(),
             )
 
             ExposedDropdownMenu(
                 expanded = expanded,
-                onDismissRequest = { expanded = false }
+                onDismissRequest = { expanded = false },
             ) {
                 availableSchemes.forEach { scheme ->
                     DropdownMenuItem(
@@ -648,7 +648,7 @@ private fun ColorSchemeSelector(
                                     Text(
                                         text = localizedDescription,
                                         style = MaterialTheme.typography.bodySmall,
-                                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
                                     )
                                 }
                             }
@@ -657,7 +657,7 @@ private fun ColorSchemeSelector(
                             onSelectColorScheme(scheme.id)
                             expanded = false
                         },
-                        contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding
+                        contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding,
                     )
                 }
             }
@@ -670,7 +670,7 @@ private fun ColorSchemeSelector(
 private fun IconColorSelector(
     selectedColor: String?,
     onSelectColor: (String?) -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     var expanded by remember { mutableStateOf(false) }
     val iconColors = getIconColors()
@@ -688,7 +688,7 @@ private fun IconColorSelector(
     Column(modifier = modifier) {
         ExposedDropdownMenuBox(
             expanded = expanded,
-            onExpandedChange = { expanded = it }
+            onExpandedChange = { expanded = it },
         ) {
             OutlinedTextField(
                 value = selectedDisplayName,
@@ -701,12 +701,12 @@ private fun IconColorSelector(
                 colors = ExposedDropdownMenuDefaults.outlinedTextFieldColors(),
                 modifier = Modifier
                     .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable)
-                    .fillMaxWidth()
+                    .fillMaxWidth(),
             )
 
             ExposedDropdownMenu(
                 expanded = expanded,
-                onDismissRequest = { expanded = false }
+                onDismissRequest = { expanded = false },
             ) {
                 // None option
                 DropdownMenuItem(
@@ -715,7 +715,7 @@ private fun IconColorSelector(
                         onSelectColor(null)
                         expanded = false
                     },
-                    contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding
+                    contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding,
                 )
                 // Color options
                 iconColors.forEach { color ->
@@ -726,7 +726,7 @@ private fun IconColorSelector(
                             onSelectColor(color.hexValue)
                             expanded = false
                         },
-                        contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding
+                        contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding,
                     )
                 }
             }
@@ -742,33 +742,33 @@ private fun ForceSizeSelector(
     onEnabledChange: (Boolean) -> Unit,
     onRowsChange: (Int) -> Unit,
     onColumnsChange: (Int) -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     Column(modifier = modifier) {
         Text(
             text = stringResource(R.string.profile_editor_force_size_title),
             style = MaterialTheme.typography.titleMedium,
-            modifier = Modifier.padding(bottom = 4.dp)
+            modifier = Modifier.padding(bottom = 4.dp),
         )
         Text(
             text = stringResource(R.string.profile_editor_force_size_summary),
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.padding(bottom = 8.dp)
+            modifier = Modifier.padding(bottom = 8.dp),
         )
 
         Row(
             verticalAlignment = androidx.compose.ui.Alignment.CenterVertically,
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier.fillMaxWidth(),
         ) {
             Text(
                 text = stringResource(R.string.profile_editor_force_size_enable),
                 style = MaterialTheme.typography.bodyLarge,
-                modifier = Modifier.weight(1f)
+                modifier = Modifier.weight(1f),
             )
             Switch(
                 checked = enabled,
-                onCheckedChange = onEnabledChange
+                onCheckedChange = onEnabledChange,
             )
         }
 
@@ -776,7 +776,7 @@ private fun ForceSizeSelector(
             Spacer(modifier = Modifier.height(8.dp))
 
             Row(
-                modifier = Modifier.fillMaxWidth()
+                modifier = Modifier.fillMaxWidth(),
             ) {
                 OutlinedTextField(
                     value = columns.toString(),
@@ -786,7 +786,7 @@ private fun ForceSizeSelector(
                     label = { Text(stringResource(R.string.profile_editor_force_size_columns)) },
                     keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                     singleLine = true,
-                    modifier = Modifier.weight(1f)
+                    modifier = Modifier.weight(1f),
                 )
 
                 Spacer(modifier = Modifier.width(16.dp))
@@ -799,7 +799,7 @@ private fun ForceSizeSelector(
                     label = { Text(stringResource(R.string.profile_editor_force_size_rows)) },
                     keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                     singleLine = true,
-                    modifier = Modifier.weight(1f)
+                    modifier = Modifier.weight(1f),
                 )
             }
         }

--- a/app/src/main/java/org/connectbot/ui/screens/profiles/ProfileEditorScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/profiles/ProfileEditorScreen.kt
@@ -532,7 +532,10 @@ private fun EncodingSelector(
     var filterText by remember { mutableStateOf("") }
 
     val filteredCommon = commonEncodings.filter { it.contains(filterText, ignoreCase = true) }
-    val filteredAll = allEncodings.filter { it.contains(filterText, ignoreCase = true) }
+    val commonEncodingSet = commonEncodings.toSet()
+    val filteredAll = allEncodings.filter {
+        it !in commonEncodingSet && it.contains(filterText, ignoreCase = true)
+    }
     val showDivider = filteredCommon.isNotEmpty() && filteredAll.isNotEmpty()
 
     Column(modifier = modifier) {

--- a/app/src/main/java/org/connectbot/ui/screens/profiles/ProfileEditorViewModel.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/profiles/ProfileEditorViewModel.kt
@@ -60,7 +60,7 @@ data class ProfileEditorUiState(
     val isLoading: Boolean = true,
     val isSaving: Boolean = false,
     val saveError: String? = null,
-    val fontDownloadInProgress: Boolean = false
+    val fontDownloadInProgress: Boolean = false,
 )
 
 @HiltViewModel
@@ -70,7 +70,7 @@ class ProfileEditorViewModel @Inject constructor(
     private val colorSchemeRepository: ColorSchemeRepository,
     private val prefs: SharedPreferences,
     @ApplicationContext private val context: Context,
-    private val dispatchers: CoroutineDispatchers
+    private val dispatchers: CoroutineDispatchers,
 ) : ViewModel() {
 
     val commonEncodings: List<String> = TerminalEncodings.commonEncodings
@@ -147,7 +147,7 @@ class ProfileEditorViewModel @Inject constructor(
                         forceSizeEnabled = forceSizeEnabled,
                         forceSizeRows = profile.forceSizeRows ?: 24,
                         forceSizeColumns = profile.forceSizeColumns ?: 80,
-                        isLoading = false
+                        isLoading = false,
                     )
                 }
             } else {
@@ -244,7 +244,7 @@ class ProfileEditorViewModel @Inject constructor(
                 encoding = state.encoding,
                 emulation = state.emulation,
                 forceSizeRows = if (state.forceSizeEnabled) state.forceSizeRows else null,
-                forceSizeColumns = if (state.forceSizeEnabled) state.forceSizeColumns else null
+                forceSizeColumns = if (state.forceSizeEnabled) state.forceSizeColumns else null,
             )
 
             profileRepository.save(profile)

--- a/app/src/main/java/org/connectbot/ui/screens/profiles/ProfileEditorViewModel.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/profiles/ProfileEditorViewModel.kt
@@ -35,9 +35,9 @@ import org.connectbot.data.entity.ColorScheme
 import org.connectbot.data.entity.Profile
 import org.connectbot.di.CoroutineDispatchers
 import org.connectbot.util.LocalFontProvider
+import org.connectbot.util.TerminalEncodings
 import org.connectbot.util.TerminalFont
 import org.connectbot.util.TerminalFontProvider
-import java.nio.charset.Charset
 import javax.inject.Inject
 
 data class ProfileEditorUiState(
@@ -73,19 +73,9 @@ class ProfileEditorViewModel @Inject constructor(
     private val dispatchers: CoroutineDispatchers
 ) : ViewModel() {
 
-    val commonEncodings: List<String> = listOf(
-        "UTF-8",
-        "ISO-8859-1",
-        "US-ASCII",
-        "windows-1252",
-        "CP437"
-    )
+    val commonEncodings: List<String> = TerminalEncodings.commonEncodings
 
-    val allEncodings: List<String> = run {
-        val charsets = Charset.availableCharsets().keys.toMutableSet()
-        charsets.add("CP437")
-        charsets.sortedWith(String.CASE_INSENSITIVE_ORDER)
-    }
+    val allEncodings: List<String> = TerminalEncodings.allEncodings
 
     private val profileId: Long = savedStateHandle.get<Long>("profileId") ?: -1L
     private val localFontProvider = LocalFontProvider(context)

--- a/app/src/main/java/org/connectbot/util/TerminalEncodings.kt
+++ b/app/src/main/java/org/connectbot/util/TerminalEncodings.kt
@@ -1,0 +1,88 @@
+/*
+ * ConnectBot: simple, powerful, open-source SSH client for Android
+ * Copyright 2026 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.connectbot.util
+
+import org.apache.harmony.niochar.charset.additional.IBM437
+import java.nio.charset.Charset
+import java.nio.charset.IllegalCharsetNameException
+import java.util.TreeSet
+
+/**
+ * Supported terminal encodings for host/profile configuration and terminal I/O.
+ */
+object TerminalEncodings {
+    const val DEFAULT = "UTF-8"
+    const val CP437 = "CP437"
+
+    private val customEncodings = setOf(CP437)
+
+    private val preferredEncodings = listOf(
+        "UTF-8",
+        "EUC-JP",
+        "Shift_JIS",
+        "windows-31j",
+        "ISO-2022-JP",
+        "GB18030",
+        "Big5",
+        "EUC-KR",
+        "ISO-8859-1",
+        "ISO-8859-15",
+        "US-ASCII",
+        "windows-1252",
+        CP437,
+    )
+
+    val commonEncodings: List<String> = preferredEncodings.filter(::isSupported)
+
+    val allEncodings: List<String> = run {
+        TreeSet(String.CASE_INSENSITIVE_ORDER).apply {
+            addAll(commonEncodings)
+            addAll(customEncodings)
+            addAll(Charset.availableCharsets().keys)
+        }.toList()
+    }
+
+    fun isSupported(encoding: String): Boolean {
+        return encoding.equals(CP437, ignoreCase = true) ||
+            try {
+                Charset.isSupported(encoding)
+            } catch (_: IllegalCharsetNameException) {
+                false
+            }
+    }
+
+    fun charsetFor(encoding: String): Charset {
+        return if (encoding.equals(CP437, ignoreCase = true)) {
+            IBM437("IBM437", arrayOf(CP437))
+        } else {
+            Charset.forName(encoding)
+        }
+    }
+
+    /**
+     * libvterm emits printable keyboard input as UTF-8. Remote hosts using a legacy
+     * encoding need those bytes transcoded before they are written to the transport.
+     */
+    fun encodeTerminalInput(data: ByteArray, encoding: String): ByteArray {
+        if (data.isEmpty() || encoding.equals(DEFAULT, ignoreCase = true)) {
+            return data
+        }
+
+        return data.toString(Charsets.UTF_8).toByteArray(charsetFor(encoding))
+    }
+}

--- a/app/src/main/java/org/connectbot/util/TerminalEncodings.kt
+++ b/app/src/main/java/org/connectbot/util/TerminalEncodings.kt
@@ -57,21 +57,17 @@ object TerminalEncodings {
         }.toList()
     }
 
-    fun isSupported(encoding: String): Boolean {
-        return encoding.equals(CP437, ignoreCase = true) ||
-            try {
-                Charset.isSupported(encoding)
-            } catch (_: IllegalCharsetNameException) {
-                false
-            }
-    }
-
-    fun charsetFor(encoding: String): Charset {
-        return if (encoding.equals(CP437, ignoreCase = true)) {
-            IBM437("IBM437", arrayOf(CP437))
-        } else {
-            Charset.forName(encoding)
+    fun isSupported(encoding: String): Boolean = encoding.equals(CP437, ignoreCase = true) ||
+        try {
+            Charset.isSupported(encoding)
+        } catch (_: IllegalCharsetNameException) {
+            false
         }
+
+    fun charsetFor(encoding: String): Charset = if (encoding.equals(CP437, ignoreCase = true)) {
+        IBM437("IBM437", arrayOf(CP437))
+    } else {
+        Charset.forName(encoding)
     }
 
     /**

--- a/app/src/test/java/org/connectbot/ui/screens/profiles/ProfileEditorViewModelTest.kt
+++ b/app/src/test/java/org/connectbot/ui/screens/profiles/ProfileEditorViewModelTest.kt
@@ -83,12 +83,16 @@ class ProfileEditorViewModelTest {
     )
 
     @Test
-    fun commonEncodings_hasExpectedFiveEntriesInOrder() {
+    fun commonEncodings_containsExpectedPreferredEntriesInOrder() {
         val viewModel = createViewModel()
-        assertEquals(
-            listOf("UTF-8", "ISO-8859-1", "US-ASCII", "windows-1252", "CP437"),
-            viewModel.commonEncodings
-        )
+        val common = viewModel.commonEncodings
+
+        assertEquals("UTF-8", common.first())
+        assertTrue("commonEncodings must contain EUC-JP", common.contains("EUC-JP"))
+        assertTrue("commonEncodings must contain Shift_JIS", common.contains("Shift_JIS"))
+        assertTrue("commonEncodings must contain ISO-2022-JP", common.contains("ISO-2022-JP"))
+        assertTrue("commonEncodings must contain CP437", common.contains("CP437"))
+        assertTrue("EUC-JP should be preferred before Shift_JIS", common.indexOf("EUC-JP") < common.indexOf("Shift_JIS"))
     }
 
     @Test
@@ -107,8 +111,7 @@ class ProfileEditorViewModelTest {
     @Test
     fun allEncodings_containsAllCommonEncodings() {
         val viewModel = createViewModel()
-        val common = listOf("UTF-8", "ISO-8859-1", "US-ASCII", "windows-1252", "CP437")
-        common.forEach { encoding ->
+        viewModel.commonEncodings.forEach { encoding ->
             assertTrue("allEncodings must contain $encoding", viewModel.allEncodings.contains(encoding))
         }
     }

--- a/app/src/test/java/org/connectbot/ui/screens/profiles/ProfileEditorViewModelTest.kt
+++ b/app/src/test/java/org/connectbot/ui/screens/profiles/ProfileEditorViewModelTest.kt
@@ -48,7 +48,7 @@ class ProfileEditorViewModelTest {
     private val dispatchers = CoroutineDispatchers(
         default = testDispatcher,
         io = testDispatcher,
-        main = testDispatcher
+        main = testDispatcher,
     )
     private lateinit var context: Context
     private lateinit var profileRepository: ProfileRepository
@@ -79,7 +79,7 @@ class ProfileEditorViewModelTest {
         colorSchemeRepository = colorSchemeRepository,
         prefs = sharedPreferences,
         context = context,
-        dispatchers = dispatchers
+        dispatchers = dispatchers,
     )
 
     @Test

--- a/app/src/test/java/org/connectbot/util/TerminalEncodingsTest.kt
+++ b/app/src/test/java/org/connectbot/util/TerminalEncodingsTest.kt
@@ -1,0 +1,60 @@
+/*
+ * ConnectBot: simple, powerful, open-source SSH client for Android
+ * Copyright 2026 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.connectbot.util
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.nio.charset.Charset
+
+class TerminalEncodingsTest {
+    @Test
+    fun commonEncodings_includeJapaneseEncodings() {
+        assertTrue(TerminalEncodings.commonEncodings.contains("EUC-JP"))
+        assertTrue(TerminalEncodings.commonEncodings.contains("Shift_JIS"))
+        assertTrue(TerminalEncodings.commonEncodings.contains("ISO-2022-JP"))
+    }
+
+    @Test
+    fun allEncodings_containsEucJpAndCp437() {
+        assertTrue(TerminalEncodings.allEncodings.contains("EUC-JP"))
+        assertTrue(TerminalEncodings.allEncodings.contains("CP437"))
+    }
+
+    @Test
+    fun encodeTerminalInput_leavesUtf8Unchanged() {
+        val input = "日本語".toByteArray(Charsets.UTF_8)
+
+        assertArrayEquals(input, TerminalEncodings.encodeTerminalInput(input, "UTF-8"))
+    }
+
+    @Test
+    fun encodeTerminalInput_transcodesUtf8ToEucJp() {
+        val text = "日本語"
+        val input = text.toByteArray(Charsets.UTF_8)
+        val expected = text.toByteArray(Charset.forName("EUC-JP"))
+
+        assertArrayEquals(expected, TerminalEncodings.encodeTerminalInput(input, "EUC-JP"))
+    }
+
+    @Test
+    fun charsetFor_supportsCp437Alias() {
+        assertEquals("IBM437", TerminalEncodings.charsetFor("CP437").name())
+    }
+}


### PR DESCRIPTION
## Summary
- Add a shared `TerminalEncodings` utility for terminal/profile encoding support.
- Include EUC-JP plus other common legacy/CJK encodings such as Shift_JIS, windows-31j, ISO-2022-JP, GB18030, Big5, and EUC-KR.
- Use the shared encoding list in profile and host editor UI.
- Transcode terminal keyboard/input bytes from libvterm UTF-8 into the selected host/profile encoding before writing to the transport.
- Preserve existing CP437 support through the custom IBM437 charset.

## Background
I noticed feedback from a Japanese user around v1.10.0 that ConnectBot lacked EUC-JP support. This adds EUC-JP as a preferred encoding and broadens the available terminal encoding choices for users connecting to legacy or locale-specific systems.

## Testing
- `./gradlew :app:testOssDebugUnitTest --tests org.connectbot.util.TerminalEncodingsTest --tests org.connectbot.ui.screens.profiles.ProfileEditorViewModelTest`
- `git diff --check`