### PR TITLE
chore(Relay): defend against Telnet violating contract

### DIFF
--- a/app/src/main/java/org/connectbot/service/Relay.kt
+++ b/app/src/main/java/org/connectbot/service/Relay.kt
@@ -42,7 +42,7 @@ class Relay(
     private val bridge: TerminalBridge,
     private val transport: AbsTransport,
     private val dispatchers: CoroutineDispatchers,
-    encoding: String
+    encoding: String,
 ) {
 
     private var currentCharset: Charset? = null
@@ -121,12 +121,7 @@ class Relay(
                     0
                 }
 
-                if (bytesRead == -1) {
-                    endOfInput = true
-                } else {
-                    // Advance position to reflect new data
-                    sourceBuffer.position(offset + bytesRead)
-                }
+                endOfInput = sourceBuffer.advanceAfterRead(bytesRead, length)
 
                 sourceBuffer.flip()
 
@@ -153,7 +148,7 @@ class Relay(
                                     bridge.terminalEmulator.writeInput(
                                         destBuffer.array(),
                                         0,
-                                        destBuffer.limit()
+                                        destBuffer.limit(),
                                     )
                                 }
                                 destBuffer.clear()
@@ -185,4 +180,20 @@ class Relay(
         private const val TAG = "CB.Relay"
         private const val BUFFER_SIZE = 4096
     }
+}
+
+internal fun ByteBuffer.advanceAfterRead(bytesRead: Int, requestedLength: Int): Boolean {
+    if (bytesRead == -1) {
+        return true
+    }
+
+    if (bytesRead < 0 || bytesRead > requestedLength) {
+        throw IOException(
+            "Transport read returned $bytesRead bytes for a $requestedLength byte request",
+        )
+    }
+
+    // Advance position to reflect new data.
+    position(position() + bytesRead)
+    return false
 }

--- a/app/src/test/kotlin/org/connectbot/service/RelayTest.kt
+++ b/app/src/test/kotlin/org/connectbot/service/RelayTest.kt
@@ -1,0 +1,73 @@
+/*
+ * ConnectBot: simple, powerful, open-source SSH client for Android
+ * Copyright 2026 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.connectbot.service
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.IOException
+import java.nio.ByteBuffer
+
+class RelayTest {
+
+    @Test
+    fun advanceAfterRead_validRead_advancesPosition() {
+        val buffer = ByteBuffer.allocate(8)
+        buffer.position(3)
+
+        val endOfInput = buffer.advanceAfterRead(bytesRead = 2, requestedLength = 5)
+
+        assertFalse(endOfInput)
+        assertEquals(5, buffer.position())
+    }
+
+    @Test
+    fun advanceAfterRead_remoteEof_reportsEndOfInput() {
+        val buffer = ByteBuffer.allocate(8)
+        buffer.position(3)
+
+        val endOfInput = buffer.advanceAfterRead(bytesRead = -1, requestedLength = 5)
+
+        assertTrue(endOfInput)
+        assertEquals(3, buffer.position())
+    }
+
+    @Test
+    fun advanceAfterRead_tooManyBytesRead_reportsIoFailure() {
+        val buffer = ByteBuffer.allocate(8)
+        buffer.position(3)
+
+        assertThrows(IOException::class.java) {
+            buffer.advanceAfterRead(bytesRead = 6, requestedLength = 5)
+        }
+        assertEquals(3, buffer.position())
+    }
+
+    @Test
+    fun advanceAfterRead_invalidNegativeCount_reportsIoFailure() {
+        val buffer = ByteBuffer.allocate(8)
+        buffer.position(3)
+
+        assertThrows(IOException::class.java) {
+            buffer.advanceAfterRead(bytesRead = -2, requestedLength = 5)
+        }
+        assertEquals(3, buffer.position())
+    }
+}


### PR DESCRIPTION
One item that has not been rewritten is the Telnet protocol handler. It seems to violate the Relay contract sometimes, so we will add a guard to make sure it does not crash the entire program.