### PR TITLE
fix: grant notifications permissions in test

### DIFF
--- a/app/src/androidTest/java/org/connectbot/MainActivityTest.kt
+++ b/app/src/androidTest/java/org/connectbot/MainActivityTest.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.rule.GrantPermissionRule
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import kotlinx.coroutines.runBlocking
@@ -38,6 +39,7 @@ import org.junit.Assume.assumeTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.TestRule
 import org.junit.runner.RunWith
 
 @HiltAndroidTest
@@ -45,6 +47,14 @@ import org.junit.runner.RunWith
 class MainActivityTest {
     @get:Rule(order = 0)
     val hiltRule = HiltAndroidRule(this)
+
+    @get:Rule(order = 1)
+    val runtimePermissionRule: TestRule =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            GrantPermissionRule.grant(android.Manifest.permission.POST_NOTIFICATIONS)
+        } else {
+            TestRule { base, _ -> base }
+        }
 
     private val context = ApplicationProvider.getApplicationContext<Context>()
 

--- a/app/src/androidTest/java/org/connectbot/service/TerminalBridgeWriteSerializationTest.kt
+++ b/app/src/androidTest/java/org/connectbot/service/TerminalBridgeWriteSerializationTest.kt
@@ -13,9 +13,11 @@ package org.connectbot.service
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import android.os.Build
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.rule.GrantPermissionRule
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import kotlinx.coroutines.Dispatchers
@@ -33,6 +35,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.TestRule
 import org.junit.runner.RunWith
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -65,6 +68,14 @@ class TerminalBridgeWriteSerializationTest {
 
     @get:Rule(order = 0)
     val hiltRule = HiltAndroidRule(this)
+
+    @get:Rule(order = 1)
+    val runtimePermissionRule: TestRule =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            GrantPermissionRule.grant(android.Manifest.permission.POST_NOTIFICATIONS)
+        } else {
+            TestRule { base, _ -> base }
+        }
 
     private val context: Context = ApplicationProvider.getApplicationContext()
 


### PR DESCRIPTION
The snackbar will show the request to grant notifications permission otherwise.