### PR TITLE
feat: downloadable language packs

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -72,7 +72,7 @@ android {
 
     bundle {
         language {
-            enableSplit = false
+            enableSplit = true
         }
     }
 
@@ -150,6 +150,12 @@ android {
             assets.directories.add("build/generated/exportSchema")
         }
         getByName("test") {
+            kotlin.directories.add("src/sharedTest/kotlin")
+        }
+        getByName("testOss") {
+            kotlin.directories.add("src/sharedTest/kotlin")
+        }
+        getByName("testGoogle") {
             kotlin.directories.add("src/sharedTest/kotlin")
         }
         getByName("androidTest") {
@@ -375,6 +381,8 @@ dependencies {
     implementation(libs.androidx.navigation.testing)
     implementation(libs.androidx.ui)
     "googleImplementation"(libs.play.services.basement)
+    "googleImplementation"(libs.play.feature.delivery)
+    testImplementation(libs.play.feature.delivery)
     "ossImplementation"(libs.conscrypt.android)
 
     implementation(libs.androidx.recyclerview)

--- a/app/src/google/java/org/connectbot/di/SplitInstallManagerModule.kt
+++ b/app/src/google/java/org/connectbot/di/SplitInstallManagerModule.kt
@@ -1,0 +1,36 @@
+/*
+ * ConnectBot: simple, powerful, open-source SSH client for Android
+ * Copyright 2026 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.connectbot.di
+
+import android.content.Context
+import com.google.android.play.core.splitinstall.SplitInstallManager
+import com.google.android.play.core.splitinstall.SplitInstallManagerFactory
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object SplitInstallManagerModule {
+
+    @Provides
+    @Singleton
+    fun provideSplitInstallManager(@ApplicationContext context: Context): SplitInstallManager = SplitInstallManagerFactory.create(context)
+}

--- a/app/src/google/java/org/connectbot/util/LanguagePackManagerImpl.kt
+++ b/app/src/google/java/org/connectbot/util/LanguagePackManagerImpl.kt
@@ -1,0 +1,126 @@
+/*
+ * ConnectBot: simple, powerful, open-source SSH client for Android
+ * Copyright 2026 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.connectbot.util
+
+import android.os.Handler
+import android.os.Looper
+import com.google.android.play.core.splitinstall.SplitInstallManager
+import com.google.android.play.core.splitinstall.SplitInstallRequest
+import com.google.android.play.core.splitinstall.SplitInstallSessionState
+import com.google.android.play.core.splitinstall.SplitInstallStateUpdatedListener
+import com.google.android.play.core.splitinstall.model.SplitInstallSessionStatus
+import timber.log.Timber
+import java.util.Locale
+import javax.inject.Inject
+
+class LanguagePackManagerImpl @Inject constructor(
+    private val splitInstallManager: SplitInstallManager,
+) : LanguagePackManager {
+
+    private val mainHandler = Handler(Looper.getMainLooper())
+
+    override fun getInstalledLanguages(): Set<String> = try {
+        splitInstallManager.installedLanguages
+    } catch (e: Exception) {
+        Timber.w(e, "Failed to query installed languages")
+        emptySet()
+    }
+
+    override fun requestLanguagePack(languageTag: String, onResult: (success: Boolean) -> Unit) {
+        if (languageTag.isEmpty()) {
+            onResult(true)
+            return
+        }
+
+        val locale = Locale.forLanguageTag(languageTag)
+        val request = SplitInstallRequest.newBuilder()
+            .addLanguage(locale)
+            .build()
+
+        var targetSessionId = -1
+        // Buffer any state update that arrives before addOnSuccessListener assigns targetSessionId.
+        var pendingState: SplitInstallSessionState? = null
+
+        val listener = object : SplitInstallStateUpdatedListener {
+            override fun onStateUpdate(state: SplitInstallSessionState) {
+                if (targetSessionId == -1) {
+                    // Session ID not yet known; buffer and process after startInstall succeeds.
+                    pendingState = state
+                    return
+                }
+                if (state.sessionId() != targetSessionId) return
+                handleState(state, languageTag, this, onResult)
+            }
+        }
+
+        splitInstallManager.registerListener(listener)
+        splitInstallManager.startInstall(request)
+            .addOnSuccessListener { sessionId ->
+                if (sessionId == 0) {
+                    // Already installed — no state update will arrive.
+                    Timber.d("SplitInstall already installed for %s", languageTag)
+                    splitInstallManager.unregisterListener(listener)
+                    mainHandler.post { onResult(true) }
+                } else {
+                    targetSessionId = sessionId
+                    Timber.d("SplitInstall started for %s, sessionId=%d", languageTag, sessionId)
+                    // Replay any buffered state update now that the session ID is known.
+                    pendingState?.let { state ->
+                        pendingState = null
+                        if (state.sessionId() == targetSessionId) {
+                            handleState(state, languageTag, listener, onResult)
+                        }
+                    }
+                }
+            }
+            .addOnFailureListener { e ->
+                Timber.w(e, "SplitInstall startInstall failed for %s", languageTag)
+                splitInstallManager.unregisterListener(listener)
+                mainHandler.post { onResult(false) }
+            }
+    }
+
+    private fun handleState(
+        state: SplitInstallSessionState,
+        languageTag: String,
+        listener: SplitInstallStateUpdatedListener,
+        onResult: (Boolean) -> Unit,
+    ) {
+        Timber.d("SplitInstall state for %s: %d", languageTag, state.status())
+        when (state.status()) {
+            SplitInstallSessionStatus.INSTALLED -> {
+                splitInstallManager.unregisterListener(listener)
+                mainHandler.post { onResult(true) }
+            }
+
+            SplitInstallSessionStatus.FAILED,
+            SplitInstallSessionStatus.CANCELED,
+            SplitInstallSessionStatus.UNKNOWN,
+            -> {
+                Timber.w("SplitInstall failed/canceled/unknown for %s, errorCode=%d", languageTag, state.errorCode())
+                splitInstallManager.unregisterListener(listener)
+                mainHandler.post { onResult(false) }
+            }
+
+            SplitInstallSessionStatus.REQUIRES_USER_CONFIRMATION -> {
+                Timber.w("SplitInstall requires user confirmation for %s", languageTag)
+                splitInstallManager.unregisterListener(listener)
+                mainHandler.post { onResult(false) }
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/connectbot/di/LanguagePackModule.kt
+++ b/app/src/main/java/org/connectbot/di/LanguagePackModule.kt
@@ -1,0 +1,34 @@
+/*
+ * ConnectBot: simple, powerful, open-source SSH client for Android
+ * Copyright 2026 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.connectbot.di
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import org.connectbot.util.LanguagePackManager
+import org.connectbot.util.LanguagePackManagerImpl
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class LanguagePackModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindLanguagePackManager(impl: LanguagePackManagerImpl): LanguagePackManager
+}

--- a/app/src/main/java/org/connectbot/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/settings/SettingsScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
@@ -38,10 +39,13 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Download
+import androidx.compose.material.icons.filled.Error
 import androidx.compose.material.icons.filled.FolderOpen
 import androidx.compose.material.icons.filled.FontDownload
 import androidx.compose.material.icons.filled.Terminal
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -78,6 +82,7 @@ import org.connectbot.ui.PreviewScreen
 import org.connectbot.ui.common.getLocalizedFontDisplayName
 import org.connectbot.ui.components.FontDownloadProgressDialog
 import org.connectbot.ui.theme.ConnectBotTheme
+import org.connectbot.util.LanguageDownloadState
 import org.connectbot.util.LocalFontProvider
 import org.connectbot.util.PreferenceConstants
 import org.connectbot.util.TerminalFont
@@ -178,7 +183,7 @@ fun SettingsScreen(
         onDeleteLocalFont = viewModel::deleteLocalFont,
         onClearImportError = viewModel::clearFontImportError,
         onDefaultProfileChange = viewModel::updateDefaultProfile,
-        onLanguageChange = viewModel::updateLanguage,
+        onLanguageChange = viewModel::requestLanguage,
         onThemeModeChange = viewModel::updateThemeMode,
         onRotationChange = viewModel::updateRotation,
         onFullscreenChange = viewModel::updateFullscreen,
@@ -447,12 +452,14 @@ fun SettingsScreenContent(
                     languageEntries.find { it.first == uiState.language }?.second
                         ?: uiState.language
                 }
-                ListPreference(
+                LanguageListPreference(
                     title = stringResource(R.string.pref_language_title),
                     summary = currentLabel,
                     value = uiState.language,
                     entries = languageEntries.map { (tag, label) -> label to tag },
-                    onValueChange = onLanguageChange,
+                    downloadStates = uiState.languageDownloadStates,
+                    installedLanguages = uiState.installedLanguages,
+                    onEntryClick = onLanguageChange,
                 )
             }
 
@@ -876,6 +883,127 @@ private fun ListPreferenceDialog(
                     ListItem(
                         headlineContent = { Text(label) },
                         modifier = Modifier.clickable { onConfirm(entryValue) },
+                    )
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.delete_neg))
+            }
+        },
+    )
+}
+
+@Composable
+private fun LanguageListPreference(
+    title: String,
+    summary: String,
+    value: String,
+    entries: List<Pair<String, String>>,
+    downloadStates: Map<String, LanguageDownloadState>,
+    installedLanguages: Set<String>,
+    onEntryClick: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var showDialog by remember { mutableStateOf(false) }
+    var pendingDownloadTag by remember { mutableStateOf<String?>(null) }
+
+    // Close dialog once a pending download completes successfully (download state cleared + language installed)
+    LaunchedEffect(downloadStates, installedLanguages) {
+        val pendingTag = pendingDownloadTag
+        if (pendingTag != null && downloadStates[pendingTag] == null && installedLanguages.contains(pendingTag)) {
+            showDialog = false
+            pendingDownloadTag = null
+        }
+    }
+
+    Column(modifier = modifier) {
+        ListItem(
+            headlineContent = { Text(title) },
+            supportingContent = { Text(summary) },
+            modifier = Modifier.clickable { showDialog = true },
+        )
+        HorizontalDivider()
+
+        if (showDialog) {
+            LanguageListPreferenceDialog(
+                title = title,
+                value = value,
+                entries = entries,
+                downloadStates = downloadStates,
+                installedLanguages = installedLanguages,
+                onDismiss = {
+                    showDialog = false
+                    pendingDownloadTag = null
+                },
+                onEntryClick = { tag ->
+                    val needsDownload = tag.isNotEmpty() && !installedLanguages.contains(tag)
+                    onEntryClick(tag)
+                    if (needsDownload) {
+                        pendingDownloadTag = tag
+                    } else {
+                        showDialog = false
+                    }
+                },
+            )
+        }
+    }
+}
+
+@Composable
+private fun LanguageListPreferenceDialog(
+    title: String,
+    value: String,
+    entries: List<Pair<String, String>>,
+    downloadStates: Map<String, LanguageDownloadState>,
+    installedLanguages: Set<String>,
+    onDismiss: () -> Unit,
+    onEntryClick: (String) -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(title) },
+        text = {
+            Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
+                entries.forEach { (label, tag) ->
+                    val state = downloadStates[tag]
+                    val isDownloading = state is LanguageDownloadState.Downloading
+                    val needsDownload = tag.isNotEmpty() && !installedLanguages.contains(tag)
+                    ListItem(
+                        headlineContent = { Text(label) },
+                        trailingContent = when {
+                            isDownloading -> {
+                                {
+                                    CircularProgressIndicator(
+                                        modifier = Modifier.size(24.dp),
+                                        strokeWidth = 2.dp,
+                                    )
+                                }
+                            }
+
+                            state is LanguageDownloadState.Failed -> {
+                                {
+                                    Icon(
+                                        imageVector = Icons.Filled.Error,
+                                        contentDescription = stringResource(R.string.pref_language_download_failed),
+                                        tint = MaterialTheme.colorScheme.error,
+                                    )
+                                }
+                            }
+
+                            needsDownload -> {
+                                {
+                                    Icon(
+                                        imageVector = Icons.Filled.Download,
+                                        contentDescription = stringResource(R.string.pref_language_download),
+                                    )
+                                }
+                            }
+
+                            else -> null
+                        },
+                        modifier = if (isDownloading) Modifier else Modifier.clickable { onEntryClick(tag) },
                     )
                 }
             }

--- a/app/src/main/java/org/connectbot/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/settings/SettingsViewModel.kt
@@ -41,6 +41,8 @@ import kotlinx.coroutines.withContext
 import org.connectbot.data.ProfileRepository
 import org.connectbot.data.entity.Profile
 import org.connectbot.di.CoroutineDispatchers
+import org.connectbot.util.LanguageDownloadState
+import org.connectbot.util.LanguagePackManager
 import org.connectbot.util.LocalFontProvider
 import org.connectbot.util.PreferenceConstants
 import org.connectbot.util.TerminalFontProvider
@@ -84,6 +86,8 @@ data class SettingsUiState(
     val fontDownloadInProgress: Boolean = false,
     val themeMode: ThemeMode = ThemeMode.SYSTEM,
     val language: String = "",
+    val languageDownloadStates: Map<String, LanguageDownloadState> = emptyMap(),
+    val installedLanguages: Set<String> = emptySet(),
     val defaultProfileId: Long = 0L,
     val availableProfiles: List<Profile> = emptyList(),
 )
@@ -94,6 +98,7 @@ class SettingsViewModel @Inject constructor(
     private val profileRepository: ProfileRepository,
     @ApplicationContext private val context: Context,
     private val dispatchers: CoroutineDispatchers,
+    private val languagePackManager: LanguagePackManager,
 ) : ViewModel() {
     private val fontProvider = TerminalFontProvider(context, dispatchers.io)
     private val localFontProvider = LocalFontProvider(context)
@@ -115,12 +120,48 @@ class SettingsViewModel @Inject constructor(
 
     init {
         loadProfiles()
+        refreshInstalledLanguages()
     }
 
     private fun loadProfiles() {
         viewModelScope.launch {
             val profiles = profileRepository.getAll()
             _uiState.update { it.copy(availableProfiles = profiles) }
+        }
+    }
+
+    private fun refreshInstalledLanguages() {
+        viewModelScope.launch {
+            val languages = withContext(dispatchers.io) {
+                languagePackManager.getInstalledLanguages()
+            }
+            _uiState.update { it.copy(installedLanguages = it.installedLanguages + languages) }
+        }
+    }
+
+    fun requestLanguage(languageTag: String) {
+        val state = _uiState.value
+        if (languageTag.isEmpty() || state.installedLanguages.contains(languageTag)) {
+            updateLanguage(languageTag)
+            return
+        }
+        if (state.languageDownloadStates[languageTag] is LanguageDownloadState.Downloading) return
+        _uiState.update { it.copy(languageDownloadStates = it.languageDownloadStates + (languageTag to LanguageDownloadState.Downloading)) }
+        languagePackManager.requestLanguagePack(languageTag) { success ->
+            viewModelScope.launch {
+                if (success) {
+                    updateLanguage(languageTag)
+                    _uiState.update {
+                        it.copy(
+                            languageDownloadStates = it.languageDownloadStates - languageTag,
+                            installedLanguages = it.installedLanguages + languageTag,
+                        )
+                    }
+                    refreshInstalledLanguages()
+                } else {
+                    _uiState.update { it.copy(languageDownloadStates = it.languageDownloadStates + (languageTag to LanguageDownloadState.Failed)) }
+                }
+            }
         }
     }
 

--- a/app/src/main/java/org/connectbot/util/LanguagePackManager.kt
+++ b/app/src/main/java/org/connectbot/util/LanguagePackManager.kt
@@ -1,0 +1,27 @@
+/*
+ * ConnectBot: simple, powerful, open-source SSH client for Android
+ * Copyright 2026 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.connectbot.util
+
+sealed class LanguageDownloadState {
+    object Downloading : LanguageDownloadState()
+    object Failed : LanguageDownloadState()
+}
+
+interface LanguagePackManager {
+    fun getInstalledLanguages(): Set<String>
+    fun requestLanguagePack(languageTag: String, onResult: (success: Boolean) -> Unit)
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -271,6 +271,10 @@
 	<string name="pref_language_title">Language</string>
 	<!-- Default option for language preference that uses the system locale -->
 	<string name="pref_language_system_default">System default</string>
+	<!-- Description of clickable icon shown on language pack list item when it has not been downloaded. -->
+	<string name="pref_language_download">Download language pack</string>
+	<!-- Description of error icon shown on language pack list item when download failed. -->
+	<string name="pref_language_download_failed">Download failed, tap to retry</string>
 
 	<!-- Title of the theme mode selector preference in the User Interface settings section -->
 	<string name="pref_theme_title">Theme</string>

--- a/app/src/oss/java/org/connectbot/util/LanguagePackManagerImpl.kt
+++ b/app/src/oss/java/org/connectbot/util/LanguagePackManagerImpl.kt
@@ -1,0 +1,55 @@
+/*
+ * ConnectBot: simple, powerful, open-source SSH client for Android
+ * Copyright 2026 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.connectbot.util
+
+import android.content.Context
+import dagger.hilt.android.qualifiers.ApplicationContext
+import org.connectbot.R
+import org.xmlpull.v1.XmlPullParser
+import timber.log.Timber
+import javax.inject.Inject
+
+class LanguagePackManagerImpl @Inject constructor(
+    @ApplicationContext private val context: Context,
+) : LanguagePackManager {
+
+    override fun getInstalledLanguages(): Set<String> {
+        val languages = mutableSetOf<String>()
+        try {
+            val parser = context.resources.getXml(R.xml._generated_res_locale_config)
+            var event = parser.eventType
+            while (event != XmlPullParser.END_DOCUMENT) {
+                if (event == XmlPullParser.START_TAG && parser.name == "locale") {
+                    val tag = parser.getAttributeValue(
+                        "http://schemas.android.com/apk/res/android",
+                        "name",
+                    )
+                    if (!tag.isNullOrBlank()) languages.add(tag)
+                }
+                event = parser.next()
+            }
+            parser.close()
+        } catch (e: Exception) {
+            Timber.w(e, "Failed to parse locale config")
+        }
+        return languages
+    }
+
+    override fun requestLanguagePack(languageTag: String, onResult: (success: Boolean) -> Unit) {
+        onResult(true)
+    }
+}

--- a/app/src/sharedTest/kotlin/org/connectbot/di/TestLanguagePackModule.kt
+++ b/app/src/sharedTest/kotlin/org/connectbot/di/TestLanguagePackModule.kt
@@ -1,0 +1,69 @@
+/*
+ * ConnectBot: simple, powerful, open-source SSH client for Android
+ * Copyright 2026 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.connectbot.di
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.components.SingletonComponent
+import dagger.hilt.testing.TestInstallIn
+import org.connectbot.util.LanguagePackManager
+import javax.inject.Singleton
+
+@Module
+@TestInstallIn(
+    components = [SingletonComponent::class],
+    replaces = [LanguagePackModule::class],
+)
+object TestLanguagePackModule {
+
+    @Provides
+    @Singleton
+    fun provideLanguagePackManager(): LanguagePackManager = FakeLanguagePackManager()
+}
+
+class FakeLanguagePackManager : LanguagePackManager {
+    val fakeInstalledLanguages: MutableSet<String> = mutableSetOf()
+    var nextRequestResult: Boolean = true
+    var requestedLanguage: String? = null
+
+    /** When true, the callback is held until [completePendingRequest] is called. */
+    var deferCallback: Boolean = false
+
+    /** When true, a successful result does NOT add the tag to [fakeInstalledLanguages] (simulates bundled/session-0 language). */
+    var skipAddOnSuccess: Boolean = false
+    private var pendingCallback: (() -> Unit)? = null
+
+    override fun getInstalledLanguages(): Set<String> = fakeInstalledLanguages.toSet()
+
+    override fun requestLanguagePack(languageTag: String, onResult: (Boolean) -> Unit) {
+        requestedLanguage = languageTag
+        if (deferCallback) {
+            pendingCallback = {
+                if (nextRequestResult && !skipAddOnSuccess) fakeInstalledLanguages.add(languageTag)
+                onResult(nextRequestResult)
+            }
+        } else {
+            if (nextRequestResult && !skipAddOnSuccess) fakeInstalledLanguages.add(languageTag)
+            onResult(nextRequestResult)
+        }
+    }
+
+    fun completePendingRequest() {
+        pendingCallback?.invoke()
+        pendingCallback = null
+    }
+}

--- a/app/src/test/kotlin/org/connectbot/ui/screens/settings/SettingsViewModelLanguagePackTest.kt
+++ b/app/src/test/kotlin/org/connectbot/ui/screens/settings/SettingsViewModelLanguagePackTest.kt
@@ -1,0 +1,204 @@
+/*
+ * ConnectBot: simple, powerful, open-source SSH client for Android
+ * Copyright 2026 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.connectbot.ui.screens.settings
+
+import android.content.SharedPreferences
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.connectbot.data.ProfileRepository
+import org.connectbot.data.entity.Profile
+import org.connectbot.di.CoroutineDispatchers
+import org.connectbot.di.FakeLanguagePackManager
+import org.connectbot.util.LanguageDownloadState
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+class SettingsViewModelLanguagePackTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private val dispatchers = CoroutineDispatchers(
+        default = testDispatcher,
+        io = testDispatcher,
+        main = testDispatcher,
+    )
+    private lateinit var prefs: SharedPreferences
+    private lateinit var prefsEditor: SharedPreferences.Editor
+    private lateinit var profileRepository: ProfileRepository
+    private lateinit var languagePackManager: FakeLanguagePackManager
+    private lateinit var viewModel: SettingsViewModel
+
+    @Before
+    fun setUp() = runTest {
+        prefs = mock()
+        prefsEditor = mock()
+        profileRepository = mock()
+        languagePackManager = FakeLanguagePackManager()
+
+        whenever(prefs.edit()).thenReturn(prefsEditor)
+        whenever(prefsEditor.putString(any(), any())).thenReturn(prefsEditor)
+        whenever(prefsEditor.putBoolean(any(), any())).thenReturn(prefsEditor)
+        whenever(prefsEditor.putFloat(any(), any())).thenReturn(prefsEditor)
+        whenever(prefs.getBoolean(any(), any())).thenReturn(false)
+        whenever(prefs.getString(any(), any())).thenReturn("")
+        whenever(prefs.getFloat(any(), any())).thenReturn(0.25f)
+        whenever(profileRepository.getAll()).thenReturn(emptyList<Profile>())
+
+        viewModel = SettingsViewModel(
+            prefs,
+            profileRepository,
+            RuntimeEnvironment.getApplication(),
+            dispatchers,
+            languagePackManager,
+        )
+        advanceUntilIdle()
+    }
+
+    @Test
+    fun languageDownloadStates_isEmptyInitially() = runTest {
+        assertThat(viewModel.uiState.value.languageDownloadStates).isEmpty()
+    }
+
+    @Test
+    fun installedLanguages_reflectsManagerOnInit() = runTest(testDispatcher) {
+        languagePackManager.fakeInstalledLanguages.addAll(setOf("de", "fr"))
+        val vm = SettingsViewModel(
+            prefs,
+            profileRepository,
+            RuntimeEnvironment.getApplication(),
+            dispatchers,
+            languagePackManager,
+        )
+        advanceUntilIdle()
+        assertThat(vm.uiState.value.installedLanguages).containsAll(setOf("de", "fr"))
+    }
+
+    @Test
+    fun requestLanguage_whenInstalled_selectsImmediately() = runTest {
+        languagePackManager.fakeInstalledLanguages.add("de")
+        viewModel.requestLanguage("de")
+        advanceUntilIdle()
+
+        assertThat(viewModel.uiState.value.language).isEqualTo("de")
+        assertThat(viewModel.uiState.value.languageDownloadStates["de"]).isNull()
+    }
+
+    @Test
+    fun requestLanguage_emptyTag_selectsImmediately() = runTest {
+        viewModel.requestLanguage("")
+        advanceUntilIdle()
+
+        assertThat(viewModel.uiState.value.language).isEqualTo("")
+        assertThat(viewModel.uiState.value.languageDownloadStates).isEmpty()
+    }
+
+    @Test
+    fun requestLanguage_notInstalled_onSuccess_selectsAndClearsDownloadState() = runTest {
+        languagePackManager.nextRequestResult = true
+        viewModel.requestLanguage("fr")
+        advanceUntilIdle()
+
+        assertThat(viewModel.uiState.value.language).isEqualTo("fr")
+        assertThat(viewModel.uiState.value.languageDownloadStates["fr"]).isNull()
+    }
+
+    @Test
+    fun requestLanguage_notInstalled_onFailure_setsFailed() = runTest {
+        languagePackManager.nextRequestResult = false
+        viewModel.requestLanguage("ja")
+        advanceUntilIdle()
+
+        assertThat(viewModel.uiState.value.languageDownloadStates["ja"])
+            .isEqualTo(LanguageDownloadState.Failed)
+        assertThat(viewModel.uiState.value.language).isEqualTo("")
+    }
+
+    @Test
+    fun requestLanguage_onSuccess_updatesInstalledLanguages() = runTest(testDispatcher) {
+        languagePackManager.nextRequestResult = true
+        viewModel.requestLanguage("ko")
+        advanceUntilIdle()
+
+        assertThat(viewModel.uiState.value.installedLanguages).contains("ko")
+    }
+
+    @Test
+    fun requestLanguage_onSuccess_installedLanguagesUpdatedBeforeRefresh() = runTest(testDispatcher) {
+        // Simulates session-ID-0 case: Play confirms installed but won't appear in
+        // splitInstallManager.installedLanguages (bundled language, not a split).
+        // The tag must be in installedLanguages immediately after success, not only
+        // after refreshInstalledLanguages() completes.
+        languagePackManager.nextRequestResult = true
+        // Don't add to fakeInstalledLanguages so refreshInstalledLanguages won't find it
+        languagePackManager.skipAddOnSuccess = true
+        viewModel.requestLanguage("zh")
+        advanceUntilIdle()
+
+        assertThat(viewModel.uiState.value.installedLanguages).contains("zh")
+        assertThat(viewModel.uiState.value.languageDownloadStates["zh"]).isNull()
+    }
+
+    @Test
+    fun requestLanguage_whileDownloading_stateIsDownloading() = runTest(testDispatcher) {
+        languagePackManager.deferCallback = true
+        viewModel.requestLanguage("es")
+        advanceUntilIdle()
+
+        // Dialog should remain open: language not selected and state is Downloading
+        assertThat(viewModel.uiState.value.language).isEqualTo("")
+        assertThat(viewModel.uiState.value.languageDownloadStates["es"])
+            .isEqualTo(LanguageDownloadState.Downloading)
+    }
+
+    @Test
+    fun requestLanguage_whileDownloading_secondRequest_isIgnored() = runTest(testDispatcher) {
+        languagePackManager.deferCallback = true
+        viewModel.requestLanguage("es")
+        advanceUntilIdle()
+        viewModel.requestLanguage("es")
+        advanceUntilIdle()
+
+        assertThat(languagePackManager.requestedLanguage).isEqualTo("es")
+        assertThat(viewModel.uiState.value.languageDownloadStates["es"])
+            .isEqualTo(LanguageDownloadState.Downloading)
+    }
+
+    @Test
+    fun requestLanguage_onFailure_stateIsFailedAndLanguageUnchanged() = runTest(testDispatcher) {
+        languagePackManager.deferCallback = true
+        languagePackManager.nextRequestResult = false
+        viewModel.requestLanguage("pt")
+        advanceUntilIdle()
+        languagePackManager.completePendingRequest()
+        advanceUntilIdle()
+
+        // Dialog should remain open: language not selected and state is Failed
+        assertThat(viewModel.uiState.value.language).isEqualTo("")
+        assertThat(viewModel.uiState.value.languageDownloadStates["pt"])
+            .isEqualTo(LanguageDownloadState.Failed)
+    }
+}

--- a/app/src/test/kotlin/org/connectbot/ui/screens/settings/SettingsViewModelPermissionTest.kt
+++ b/app/src/test/kotlin/org/connectbot/ui/screens/settings/SettingsViewModelPermissionTest.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.test.runTest
 import org.connectbot.data.ProfileRepository
 import org.connectbot.data.entity.Profile
 import org.connectbot.di.CoroutineDispatchers
+import org.connectbot.di.FakeLanguagePackManager
 import org.connectbot.util.PreferenceConstants
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -105,7 +106,7 @@ class SettingsViewModelPermissionTest {
         whenever(prefs.getBoolean(eq("bellnotification"), any())).thenReturn(false)
         whenever(prefs.getBoolean(eq(PreferenceConstants.NOTIFICATION_PERMISSION_DENIED), any())).thenReturn(false)
 
-        viewModel = SettingsViewModel(prefs, profileRepository, context, dispatchers)
+        viewModel = SettingsViewModel(prefs, profileRepository, context, dispatchers, FakeLanguagePackManager())
         advanceUntilIdle()
     }
 
@@ -161,7 +162,7 @@ class SettingsViewModelPermissionTest {
     fun updateConnPersist_TurningOff_UpdatesPreference() = runTest {
         // Setup connPersist as ON
         whenever(prefs.getBoolean(eq(PreferenceConstants.CONNECTION_PERSIST), any())).thenReturn(true)
-        viewModel = SettingsViewModel(prefs, profileRepository, context, dispatchers)
+        viewModel = SettingsViewModel(prefs, profileRepository, context, dispatchers, FakeLanguagePackManager())
         advanceUntilIdle()
 
         viewModel.updateConnPersist(false)
@@ -175,7 +176,7 @@ class SettingsViewModelPermissionTest {
     fun updateConnPersist_AlreadyOn_UpdatesPreference() = runTest {
         // Setup connPersist as ON
         whenever(prefs.getBoolean(eq(PreferenceConstants.CONNECTION_PERSIST), any())).thenReturn(true)
-        viewModel = SettingsViewModel(prefs, profileRepository, context, dispatchers)
+        viewModel = SettingsViewModel(prefs, profileRepository, context, dispatchers, FakeLanguagePackManager())
         advanceUntilIdle()
 
         viewModel.updateConnPersist(true)
@@ -206,7 +207,7 @@ class SettingsViewModelPermissionTest {
         // Verify denial state is persisted by recreating ViewModel
         whenever(prefs.getBoolean(eq(PreferenceConstants.CONNECTION_PERSIST), any())).thenReturn(false)
         // The NOTIFICATION_PERMISSION_DENIED flag is still false in SharedPreferences
-        viewModel = SettingsViewModel(prefs, profileRepository, context, dispatchers)
+        viewModel = SettingsViewModel(prefs, profileRepository, context, dispatchers, FakeLanguagePackManager())
         advanceUntilIdle()
 
         val permissionRequests = mutableListOf<Unit>()
@@ -263,7 +264,7 @@ class SettingsViewModelPermissionTest {
         whenever(prefs.getBoolean(eq(PreferenceConstants.NOTIFICATION_PERMISSION_DENIED), any())).thenReturn(true)
 
         // Recreate ViewModel (simulating process death/configuration change)
-        viewModel = SettingsViewModel(prefs, profileRepository, context, dispatchers)
+        viewModel = SettingsViewModel(prefs, profileRepository, context, dispatchers, FakeLanguagePackManager())
         advanceUntilIdle()
 
         // Try to turn on connPersist

--- a/app/src/test/kotlin/org/connectbot/ui/screens/settings/SettingsViewModelThemeTest.kt
+++ b/app/src/test/kotlin/org/connectbot/ui/screens/settings/SettingsViewModelThemeTest.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.test.runTest
 import org.connectbot.data.ProfileRepository
 import org.connectbot.data.entity.Profile
 import org.connectbot.di.CoroutineDispatchers
+import org.connectbot.di.FakeLanguagePackManager
 import org.connectbot.util.PreferenceConstants
 import org.connectbot.util.ThemeMode
 import org.junit.Assert.assertEquals
@@ -75,6 +76,7 @@ class SettingsViewModelThemeTest {
             profileRepository,
             RuntimeEnvironment.getApplication(),
             dispatchers,
+            FakeLanguagePackManager(),
         )
         advanceUntilIdle()
     }
@@ -92,6 +94,7 @@ class SettingsViewModelThemeTest {
             profileRepository,
             RuntimeEnvironment.getApplication(),
             dispatchers,
+            FakeLanguagePackManager(),
         )
         advanceUntilIdle()
 

--- a/app/src/testGoogle/kotlin/org/connectbot/di/TestSplitInstallManagerModule.kt
+++ b/app/src/testGoogle/kotlin/org/connectbot/di/TestSplitInstallManagerModule.kt
@@ -1,0 +1,37 @@
+/*
+ * ConnectBot: simple, powerful, open-source SSH client for Android
+ * Copyright 2026 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.connectbot.di
+
+import com.google.android.play.core.splitinstall.SplitInstallManager
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.components.SingletonComponent
+import dagger.hilt.testing.TestInstallIn
+import org.mockito.kotlin.mock
+import javax.inject.Singleton
+
+@Module
+@TestInstallIn(
+    components = [SingletonComponent::class],
+    replaces = [SplitInstallManagerModule::class],
+)
+object TestSplitInstallManagerModule {
+
+    @Provides
+    @Singleton
+    fun provideSplitInstallManager(): SplitInstallManager = mock()
+}

--- a/app/src/testGoogle/kotlin/org/connectbot/util/GoogleLanguagePackManagerTest.kt
+++ b/app/src/testGoogle/kotlin/org/connectbot/util/GoogleLanguagePackManagerTest.kt
@@ -1,0 +1,206 @@
+/*
+ * ConnectBot: simple, powerful, open-source SSH client for Android
+ * Copyright 2026 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.connectbot.util
+
+import com.google.android.gms.tasks.Tasks
+import com.google.android.play.core.splitinstall.SplitInstallManager
+import com.google.android.play.core.splitinstall.SplitInstallRequest
+import com.google.android.play.core.splitinstall.SplitInstallSessionState
+import com.google.android.play.core.splitinstall.SplitInstallStateUpdatedListener
+import com.google.android.play.core.splitinstall.model.SplitInstallSessionStatus
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows
+
+@RunWith(RobolectricTestRunner::class)
+class GoogleLanguagePackManagerTest {
+
+    private fun makeSessionState(status: Int, sessionId: Int = 42): SplitInstallSessionState = mock {
+        on { this.status() } doReturn status
+        on { this.sessionId() } doReturn sessionId
+    }
+
+    @Test
+    fun getInstalledLanguages_delegatesToSplitInstallManager() {
+        val splitInstallManager = mock<SplitInstallManager> {
+            on { installedLanguages } doReturn setOf("de", "fr")
+        }
+        val manager = LanguagePackManagerImpl(splitInstallManager)
+        assertThat(manager.getInstalledLanguages()).containsExactlyInAnyOrder("de", "fr")
+    }
+
+    @Test
+    fun requestLanguagePack_emptyTag_callsOnResultTrueImmediately() {
+        val splitInstallManager = mock<SplitInstallManager>()
+        val manager = LanguagePackManagerImpl(splitInstallManager)
+
+        var result: Boolean? = null
+        manager.requestLanguagePack("") { result = it }
+
+        assertThat(result).isTrue()
+        verify(splitInstallManager, never()).startInstall(any())
+    }
+
+    @Test
+    fun requestLanguagePack_installed_callsOnResultTrue() {
+        val listenerCaptor = argumentCaptor<SplitInstallStateUpdatedListener>()
+        val splitInstallManager = mock<SplitInstallManager> {
+            on { startInstall(any<SplitInstallRequest>()) } doReturn Tasks.forResult(42)
+        }
+        val manager = LanguagePackManagerImpl(splitInstallManager)
+
+        var result: Boolean? = null
+        manager.requestLanguagePack("de") { result = it }
+
+        verify(splitInstallManager).registerListener(listenerCaptor.capture())
+        // Idle the looper so Tasks.forResult fires addOnSuccessListener and sets targetSessionId = 42
+        Shadows.shadowOf(android.os.Looper.getMainLooper()).idle()
+        listenerCaptor.firstValue.onStateUpdate(makeSessionState(SplitInstallSessionStatus.INSTALLED))
+        Shadows.shadowOf(android.os.Looper.getMainLooper()).idle()
+
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun requestLanguagePack_failed_callsOnResultFalse() {
+        val listenerCaptor = argumentCaptor<SplitInstallStateUpdatedListener>()
+        val sessionState = mock<SplitInstallSessionState> {
+            on { status() } doReturn SplitInstallSessionStatus.FAILED
+            on { sessionId() } doReturn 42
+            on { errorCode() } doReturn 0
+        }
+        val splitInstallManager = mock<SplitInstallManager> {
+            on { startInstall(any<SplitInstallRequest>()) } doReturn Tasks.forResult(42)
+        }
+        val manager = LanguagePackManagerImpl(splitInstallManager)
+
+        var result: Boolean? = null
+        manager.requestLanguagePack("fr") { result = it }
+
+        verify(splitInstallManager).registerListener(listenerCaptor.capture())
+        // Idle the looper so Tasks.forResult fires addOnSuccessListener and sets targetSessionId = 42
+        Shadows.shadowOf(android.os.Looper.getMainLooper()).idle()
+        listenerCaptor.firstValue.onStateUpdate(sessionState)
+        Shadows.shadowOf(android.os.Looper.getMainLooper()).idle()
+
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun requestLanguagePack_unrelatedSession_isIgnored() {
+        val listenerCaptor = argumentCaptor<SplitInstallStateUpdatedListener>()
+        val splitInstallManager = mock<SplitInstallManager> {
+            on { startInstall(any<SplitInstallRequest>()) } doReturn Tasks.forResult(42)
+        }
+        val manager = LanguagePackManagerImpl(splitInstallManager)
+
+        var result: Boolean? = null
+        manager.requestLanguagePack("de") { result = it }
+
+        verify(splitInstallManager).registerListener(listenerCaptor.capture())
+        Shadows.shadowOf(android.os.Looper.getMainLooper()).idle()
+        // Send INSTALLED for a different session — should be ignored
+        listenerCaptor.firstValue.onStateUpdate(makeSessionState(SplitInstallSessionStatus.INSTALLED, sessionId = 99))
+        Shadows.shadowOf(android.os.Looper.getMainLooper()).idle()
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun requestLanguagePack_sessionIdZero_alreadyInstalled_callsOnResultTrue() {
+        val splitInstallManager = mock<SplitInstallManager> {
+            on { startInstall(any<SplitInstallRequest>()) } doReturn Tasks.forResult(0)
+        }
+        val manager = LanguagePackManagerImpl(splitInstallManager)
+
+        var result: Boolean? = null
+        manager.requestLanguagePack("de") { result = it }
+
+        Shadows.shadowOf(android.os.Looper.getMainLooper()).idle()
+
+        assertThat(result).isTrue()
+        verify(splitInstallManager).unregisterListener(any())
+    }
+
+    @Test
+    fun requestLanguagePack_requiresUserConfirmation_callsOnResultFalse() {
+        val listenerCaptor = argumentCaptor<SplitInstallStateUpdatedListener>()
+        val splitInstallManager = mock<SplitInstallManager> {
+            on { startInstall(any<SplitInstallRequest>()) } doReturn Tasks.forResult(42)
+        }
+        val manager = LanguagePackManagerImpl(splitInstallManager)
+
+        var result: Boolean? = null
+        manager.requestLanguagePack("de") { result = it }
+
+        verify(splitInstallManager).registerListener(listenerCaptor.capture())
+        Shadows.shadowOf(android.os.Looper.getMainLooper()).idle()
+        listenerCaptor.firstValue.onStateUpdate(makeSessionState(SplitInstallSessionStatus.REQUIRES_USER_CONFIRMATION))
+        Shadows.shadowOf(android.os.Looper.getMainLooper()).idle()
+
+        assertThat(result).isFalse()
+        verify(splitInstallManager).unregisterListener(any())
+    }
+
+    @Test
+    fun requestLanguagePack_stateArrivesBeforeSessionId_isBufferedAndProcessed() {
+        val listenerCaptor = argumentCaptor<SplitInstallStateUpdatedListener>()
+        // Use a deferred task so addOnSuccessListener hasn't fired when onStateUpdate is called
+        val taskSource = com.google.android.gms.tasks.TaskCompletionSource<Int>()
+        val splitInstallManager = mock<SplitInstallManager> {
+            on { startInstall(any<SplitInstallRequest>()) } doReturn taskSource.task
+        }
+        val manager = LanguagePackManagerImpl(splitInstallManager)
+
+        var result: Boolean? = null
+        manager.requestLanguagePack("de") { result = it }
+
+        verify(splitInstallManager).registerListener(listenerCaptor.capture())
+        // Deliver state update before session ID is known (addOnSuccessListener not yet called)
+        listenerCaptor.firstValue.onStateUpdate(makeSessionState(SplitInstallSessionStatus.INSTALLED, sessionId = 42))
+        assertThat(result).isNull() // buffered, not yet processed
+
+        // Now resolve the task — addOnSuccessListener fires, replays the buffered state
+        taskSource.setResult(42)
+        Shadows.shadowOf(android.os.Looper.getMainLooper()).idle()
+
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun requestLanguagePack_startInstallFails_callsOnResultFalse() {
+        val splitInstallManager = mock<SplitInstallManager> {
+            on { startInstall(any<SplitInstallRequest>()) } doReturn Tasks.forException(RuntimeException("network"))
+        }
+        val manager = LanguagePackManagerImpl(splitInstallManager)
+
+        var result: Boolean? = null
+        manager.requestLanguagePack("ja") { result = it }
+
+        Shadows.shadowOf(android.os.Looper.getMainLooper()).idle()
+
+        assertThat(result).isFalse()
+    }
+}

--- a/app/src/testOss/kotlin/org/connectbot/util/OssLanguagePackManagerTest.kt
+++ b/app/src/testOss/kotlin/org/connectbot/util/OssLanguagePackManagerTest.kt
@@ -1,0 +1,54 @@
+/*
+ * ConnectBot: simple, powerful, open-source SSH client for Android
+ * Copyright 2026 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.connectbot.util
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+class OssLanguagePackManagerTest {
+
+    private lateinit var manager: LanguagePackManager
+
+    @Before
+    fun setUp() {
+        manager = LanguagePackManagerImpl(RuntimeEnvironment.getApplication())
+    }
+
+    @Test
+    fun getInstalledLanguages_returnsNonEmptySet() {
+        assertThat(manager.getInstalledLanguages()).isNotEmpty()
+    }
+
+    @Test
+    fun requestLanguagePack_anyTag_callsOnResultTrue() {
+        var result: Boolean? = null
+        manager.requestLanguagePack("de") { result = it }
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun requestLanguagePack_emptyTag_callsOnResultTrue() {
+        var result: Boolean? = null
+        manager.requestLanguagePack("") { result = it }
+        assertThat(result).isTrue()
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,7 @@ activityCompose = "1.13.0"
 sshlib = "2.2.46"
 termlib = "0.0.39"
 playServicesBasement = "18.10.0"
+playFeatureDelivery = "2.1.0"
 conscrypt = "2.5.3"
 conscryptOpenJdk = "2.5.2"
 coroutines = "1.10.2"
@@ -58,6 +59,7 @@ core = "1.18.0"
 sshlib = { module = "org.connectbot:sshlib", version.ref = "sshlib" }
 termlib = { module = "org.connectbot:termlib", version.ref = "termlib" }
 play-services-basement = { module = "com.google.android.gms:play-services-basement", version.ref = "playServicesBasement" }
+play-feature-delivery = { module = "com.google.android.play:feature-delivery-ktx", version.ref = "playFeatureDelivery" }
 conscrypt-android = { module = "org.conscrypt:conscrypt-android", version.ref = "conscrypt" }
 
 androidx-recyclerview = { module = "androidx.recyclerview:recyclerview", version.ref = "recyclerview" }


### PR DESCRIPTION
Implement downloadable language packs. This saves overall space when downloading from Play Store. Only the languages the user needs or requests is downloaded. The user can also go to Settings and choose to download a language after installing.