### PR TITLE
Make JSON import permissive

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -307,20 +307,21 @@ val generateExportSchema by tasks.registering {
     val exportTables = setOf("profiles", "hosts", "port_forwards")
     val excludedFields = setOf("last_connect", "host_key_algo")
 
-    // Read schema version from ConnectBotDatabase.kt to avoid duplicate definitions
+    // Read schema version from Room's @Database annotation.
     val databaseFile = file("src/main/java/org/connectbot/data/ConnectBotDatabase.kt")
     val schemaVersion =
         databaseFile
             .readText()
-            .let { Regex("""const val SCHEMA_VERSION\s*=\s*(\d+)""").find(it) }
+            .let { Regex("""@Database\s*\([\s\S]*?version\s*=\s*(\d+)""").find(it) }
             ?.groupValues
             ?.get(1)
             ?.toInt()
-            ?: error("Could not find SCHEMA_VERSION in $databaseFile")
+            ?: error("Could not find @Database version in $databaseFile")
     val inputFile = file("schemas/org.connectbot.data.ConnectBotDatabase/$schemaVersion.json")
     val outputDir = file("build/generated/exportSchema")
     val outputFile = file("$outputDir/export_schema.json")
 
+    inputs.file(databaseFile)
     inputs.file(inputFile)
     outputs.file(outputFile)
 

--- a/app/src/main/java/org/connectbot/data/ConnectBotDatabase.kt
+++ b/app/src/main/java/org/connectbot/data/ConnectBotDatabase.kt
@@ -95,12 +95,6 @@ abstract class ConnectBotDatabase : RoomDatabase() {
 
     companion object {
         /**
-         * Current database schema version.
-         * This is also used for JSON export/import versioning.
-         */
-        const val SCHEMA_VERSION = 7
-
-        /**
          * Migration from version 4 to 5: Add profiles table and profile_id to hosts.
          * Also creates profiles from existing host settings and migrates hosts to use them.
          */

--- a/app/src/main/java/org/connectbot/data/SchemaBasedExporter.kt
+++ b/app/src/main/java/org/connectbot/data/SchemaBasedExporter.kt
@@ -40,7 +40,7 @@ import org.json.JSONObject
  */
 class SchemaBasedExporter(
     private val database: RoomDatabase,
-    private val schema: DatabaseSchema
+    private val schema: DatabaseSchema,
 ) {
 
     /**
@@ -66,7 +66,7 @@ class SchemaBasedExporter(
                 .map { it.columnName }
 
             val cursor = db.query(
-                "SELECT ${columns.joinToString(", ")} FROM $tableName"
+                "SELECT ${columns.joinToString(", ")} FROM $tableName",
             )
 
             cursor.use {
@@ -85,19 +85,18 @@ class SchemaBasedExporter(
     /**
      * Import data from JSON into database tables.
      *
+     * The JSON version is treated as advisory. Import is intentionally
+     * permissive so exports from nearby branch-specific schemas can still be
+     * restored when the fields used by this app version are compatible.
+     * Unknown tables and row fields are ignored by processing only the
+     * requested tables and the fields present in the current schema.
+     *
      * @param jsonString JSON string containing table data
      * @param tableNames List of table names to import (in order - parent tables first)
      * @return Map of table name to Pair of (inserted count, skipped count)
      */
     fun importFromJson(jsonString: String, tableNames: List<String>): Map<String, Pair<Int, Int>> {
         val json = JSONObject(jsonString)
-        val version = json.optInt("version", 1)
-
-        if (version > schema.version) {
-            throw IllegalArgumentException(
-                "Unsupported schema version: $version (max supported: ${schema.version})"
-            )
-        }
 
         val db = database.openHelper.writableDatabase
         val results = mutableMapOf<String, Pair<Int, Int>>()
@@ -195,7 +194,7 @@ class SchemaBasedExporter(
         row: JSONObject,
         foreignKeys: List<ForeignKeySchema>,
         idMappings: Map<String, Map<Long, Long>>,
-        entitySchema: EntitySchema
+        entitySchema: EntitySchema,
     ): JSONObject {
         val remapped = JSONObject(row.toString())
 
@@ -230,7 +229,7 @@ class SchemaBasedExporter(
         tableName: String,
         row: JSONObject,
         uniqueFields: List<String>,
-        entitySchema: EntitySchema
+        entitySchema: EntitySchema,
     ): Long? {
         val conditions = mutableListOf<String>()
         val args = mutableListOf<String>()
@@ -247,7 +246,7 @@ class SchemaBasedExporter(
 
         val cursor = db.query(
             "SELECT id FROM $tableName WHERE ${conditions.joinToString(" AND ")}",
-            args.toTypedArray()
+            args.toTypedArray(),
         )
 
         return cursor.use {
@@ -262,7 +261,7 @@ class SchemaBasedExporter(
         db: androidx.sqlite.db.SupportSQLiteDatabase,
         tableName: String,
         row: JSONObject,
-        entitySchema: EntitySchema
+        entitySchema: EntitySchema,
     ): Long {
         val values = jsonToContentValues(row, entitySchema, excludeId = true)
         return db.insert(tableName, 0, values)
@@ -276,7 +275,7 @@ class SchemaBasedExporter(
         tableName: String,
         id: Long,
         row: JSONObject,
-        entitySchema: EntitySchema
+        entitySchema: EntitySchema,
     ) {
         val values = jsonToContentValues(row, entitySchema, excludeId = true)
         db.update(tableName, 0, values, "id = ?", arrayOf(id.toString()))
@@ -290,7 +289,7 @@ class SchemaBasedExporter(
         tableName: String,
         entitySchema: EntitySchema,
         idMapping: Map<Long, Long>,
-        originalRows: JSONArray
+        originalRows: JSONArray,
     ) {
         // Find self-referencing fields (foreign keys that reference the same table)
         val selfRefFields = entitySchema.fields.filter { field ->
@@ -327,7 +326,7 @@ class SchemaBasedExporter(
 
                 db.execSQL(
                     "UPDATE $tableName SET ${field.columnName} = ? WHERE id = ?",
-                    arrayOf(newRefId, newId)
+                    arrayOf(newRefId, newId),
                 )
             }
         }
@@ -339,7 +338,7 @@ class SchemaBasedExporter(
     private fun jsonToContentValues(
         row: JSONObject,
         entitySchema: EntitySchema,
-        excludeId: Boolean
+        excludeId: Boolean,
     ): ContentValues {
         val values = ContentValues()
 

--- a/app/src/test/kotlin/org/connectbot/data/HostConfigJsonTest.kt
+++ b/app/src/test/kotlin/org/connectbot/data/HostConfigJsonTest.kt
@@ -1,0 +1,127 @@
+/*
+ * ConnectBot: simple, powerful, open-source SSH client for Android
+ * Copyright 2026 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.connectbot.data
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class HostConfigJsonTest {
+
+    private lateinit var database: ConnectBotDatabase
+
+    @Before
+    fun setUp() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        database = Room.inMemoryDatabaseBuilder(context, ConnectBotDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+    }
+
+    @After
+    fun tearDown() {
+        database.close()
+    }
+
+    @Test
+    fun importFromJson_ignoresNewerVersionAndUnknownFields() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+
+        val counts = HostConfigJson.importFromJson(
+            context,
+            database,
+            """
+            {
+              "version": 9,
+              "branchOnlyTopLevel": true,
+              "profiles": [
+                {
+                  "id": 1,
+                  "name": "Default",
+                  "iconColor": "blue",
+                  "colorSchemeId": -1,
+                  "fontFamily": null,
+                  "fontSize": 12,
+                  "delKey": "del",
+                  "encoding": "UTF-8",
+                  "emulation": "xterm-256color",
+                  "forceSizeRows": null,
+                  "forceSizeColumns": null,
+                  "branchOnlyProfileField": "ignored"
+                }
+              ],
+              "hosts": [
+                {
+                  "id": 10,
+                  "nickname": "branch-host",
+                  "protocol": "ssh",
+                  "username": "user",
+                  "hostname": "example.com",
+                  "port": 22,
+                  "color": "red",
+                  "useKeys": 1,
+                  "useAuthAgent": "no",
+                  "postLogin": null,
+                  "pubkeyId": -1,
+                  "wantSession": 1,
+                  "compression": 0,
+                  "stayConnected": 0,
+                  "quickDisconnect": 0,
+                  "scrollbackLines": 140,
+                  "useCtrlAltAsMetaKey": 0,
+                  "profileId": 1,
+                  "ipVersion": "IPV4_AND_IPV6",
+                  "branchOnlyHostField": "ignored"
+                }
+              ],
+              "port_forwards": [
+                {
+                  "id": 20,
+                  "hostId": 10,
+                  "nickname": "web",
+                  "type": "local",
+                  "sourceAddr": "0.0.0.0",
+                  "sourcePort": 8080,
+                  "destAddr": "localhost",
+                  "destPort": 80,
+                  "branchOnlyForwardField": "ignored"
+                }
+              ]
+            }
+            """.trimIndent(),
+        )
+
+        assertThat(counts.hostsImported).isEqualTo(1)
+        assertThat(counts.profilesImported).isEqualTo(1)
+
+        val host = database.hostDao().getAll().single()
+        assertThat(host.nickname).isEqualTo("branch-host")
+
+        val portForward = database.portForwardDao().getByHost(host.id).single()
+        assertThat(portForward.sourceAddr).isEqualTo("0.0.0.0")
+        assertThat(portForward.sourcePort).isEqualTo(8080)
+    }
+}


### PR DESCRIPTION
During the development of complex functionality like MOSH and FIDO2 support, database schema changes are required. Therefore, if the main branch updates the schema, I currently have to reinstall the app. To make that reinstall process easier, I’d like to make the host config JSON import a bit more permissive.
 - Make host config JSON import permissive by treating the JSON `version` as advisory instead of rejecting newer versions.
  - Ignore unknown top-level data and row fields by importing only the current app’s known export tables and schema fields.
  - Remove the duplicate `SCHEMA_VERSION` constant and generate the export schema version from Room’s `@Database` annotation.
  - Add coverage for importing higher-version JSON with branch-only fields.