### PR TITLE
Swipe term

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -166,7 +166,7 @@ android {
     lint {
         abortOnError = false
         lintConfig = file("lint.xml")
-        checkTestSources = false
+        checkTestSources = true
     }
 
     packaging {

--- a/app/src/main/java/org/connectbot/service/TerminalBridge.kt
+++ b/app/src/main/java/org/connectbot/service/TerminalBridge.kt
@@ -184,9 +184,9 @@ class TerminalBridge {
     val terminalEmulator: TerminalEmulator
 
     /**
-     * Callback invoked when text input dialog is requested (e.g., from camera button)
+     * Callback invoked to request the text input dialog (e.g., from camera button)
      */
-    var onTextInputRequested: (() -> Unit)? = null
+    var onTextInputRequest: (() -> Unit)? = null
 
     private val _bellEvents = MutableSharedFlow<Unit>(replay = 0, extraBufferCapacity = 10)
     val bellEvents: SharedFlow<Unit> = _bellEvents.asSharedFlow()
@@ -632,7 +632,7 @@ class TerminalBridge {
      * Called from hardware camera button or other triggers.
      */
     fun requestOpenTextInput() {
-        onTextInputRequested?.invoke()
+        onTextInputRequest?.invoke()
     }
 
     /**

--- a/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
@@ -496,8 +496,8 @@ private fun ConsoleTerminalPage(
                     }
                 }
             }
+        }
     }
-}
 }
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)

--- a/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
@@ -63,7 +63,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.PrimaryTabRow
+import androidx.compose.material3.PrimaryScrollableTabRow
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.ScaffoldDefaults
 import androidx.compose.material3.SnackbarDuration
@@ -427,7 +427,10 @@ fun ConsoleScreen(
         wasBiometricPromptActive = isBiometricPromptActive
     }
 
-    val currentBridge = uiState.bridges.getOrNull(uiState.currentBridgeIndex)
+    val currentBridge = uiState.bridges
+        .getOrNull(uiState.currentBridgeIndex)
+        ?.takeUnless { uiState.isLoading }
+    val showSessionSwitcher = uiState.bridges.size > 1 && !uiState.isLoading
     // These values are computed from bridge state and will recompute when uiState.revision changes
     val sessionOpen = currentBridge?.isSessionOpen == true
     val disconnected = currentBridge?.isDisconnected == true
@@ -449,6 +452,9 @@ fun ConsoleScreen(
     // Reset selection controller when bridge changes
     LaunchedEffect(currentBridge) {
         selectionController = null
+        if (currentBridge != null) {
+            termFocusRequester.requestFocus()
+        }
     }
 
     // Initialize forceSize from profile when bridge changes
@@ -541,28 +547,6 @@ fun ConsoleScreen(
         contentWindowInsets = ScaffoldDefaults.contentWindowInsets
             .union(WindowInsets.imeAnimationTarget),
     ) { innerPadding ->
-        // Show tabs if multiple terminals
-        if (uiState.bridges.size > 1) {
-            PrimaryTabRow(
-                selectedTabIndex = uiState.currentBridgeIndex,
-                modifier = Modifier.fillMaxWidth(),
-            ) {
-                uiState.bridges.forEachIndexed { index, bridge ->
-                    Tab(
-                        selected = index == uiState.currentBridgeIndex,
-                        onClick = { viewModel.selectBridge(index) },
-                        text = {
-                            Text(
-                                bridge.host.nickname,
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis,
-                            )
-                        },
-                    )
-                }
-            }
-        }
-
         val handleShortcut: (KeyEvent) -> Boolean = { keyEvent ->
             handleConsoleShortcut(
                 keyEvent = keyEvent,
@@ -575,42 +559,53 @@ fun ConsoleScreen(
         }
 
         // Terminal content with keyboard overlay
-        // This Box is transparent to accessibility - it's just for layout
         val layoutDirection = LocalLayoutDirection.current
-        Box(
+        Column(
             modifier = Modifier
                 .fillMaxSize()
                 .consumeWindowInsets(innerPadding)
                 .padding(
                     start = innerPadding.calculateStartPadding(layoutDirection),
                     end = innerPadding.calculateEndPadding(layoutDirection),
-                    top = if (!titleBarHide) 0.dp else innerPadding.calculateTopPadding(),
+                    top = if (!titleBarHide) titleBarHeight else innerPadding.calculateTopPadding(),
                     bottom = innerPadding.calculateBottomPadding(),
                 )
                 .windowInsetsPadding(WindowInsets.imeAnimationTarget)
                 .onPreviewKeyEvent(handleShortcut),
         ) {
+            if (showSessionSwitcher) {
+                PrimaryScrollableTabRow(
+                    selectedTabIndex = uiState.currentBridgeIndex,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    uiState.bridges.forEachIndexed { index, bridge ->
+                        Tab(
+                            selected = index == uiState.currentBridgeIndex,
+                            onClick = { viewModel.selectBridge(index) },
+                            text = {
+                                Text(
+                                    bridge.host.nickname,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
+                                )
+                            },
+                        )
+                    }
+                }
+            }
+
             when {
                 uiState.isLoading -> {
                     LoadingScreen(modifier = Modifier.fillMaxSize())
                 }
 
                 uiState.bridges.isNotEmpty() -> {
-                    // TODO(Terminal): Re-implement support for switching between terminals
-                    // For now, just show the current bridge directly without HorizontalPager
-                    // to avoid accessibility issues. Maybe a tab strip across the top for
-                    // small screen devices and a list of hosts on the left for large screen.
-
                     val bridge = uiState.bridges[uiState.currentBridgeIndex]
 
-                    // Terminal view fills entire space with insets padding
-                    // to avoid content being cut off by screen curves/notches
                     Box(
                         modifier = Modifier
-                            .fillMaxSize()
-                            .padding(
-                                top = if (!titleBarHide) titleBarHeight else 0.dp,
-                            ),
+                            .fillMaxWidth()
+                            .weight(1f),
                     ) {
                         // Get font from profile (stored in bridge)
                         val fontResult = rememberTerminalTypefaceResultFromStoredValue(bridge.fontFamily)
@@ -920,6 +915,26 @@ fun ConsoleScreen(
                                     leadingIcon = {
                                         Icon(Icons.Default.Refresh, contentDescription = null)
                                     },
+                                )
+                            }
+
+                            if (uiState.bridges.size > 1) {
+                                DropdownMenuItem(
+                                    text = { Text(stringResource(R.string.console_previous_session)) },
+                                    onClick = {
+                                        showMenu = false
+                                        viewModel.selectPreviousBridge()
+                                    },
+                                    enabled = uiState.currentBridgeIndex > 0
+                                )
+
+                                DropdownMenuItem(
+                                    text = { Text(stringResource(R.string.console_next_session)) },
+                                    onClick = {
+                                        showMenu = false
+                                        viewModel.selectNextBridge()
+                                    },
+                                    enabled = uiState.currentBridgeIndex < uiState.bridges.lastIndex
                                 )
                             }
 

--- a/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
@@ -232,8 +232,9 @@ internal fun sessionSwipeTarget(
     dragY: Float,
     viewportWidth: Int,
     touchSlop: Float,
+    selectionActive: Boolean = false,
 ): Int? {
-    if (sessionCount < 2 || viewportWidth <= 0) {
+    if (selectionActive || sessionCount < 2 || viewportWidth <= 0) {
         return null
     }
 
@@ -279,9 +280,14 @@ internal fun shouldPreserveSoftwareKeyboardForBridgeChange(
 private fun Modifier.sessionSwipeNavigation(
     currentIndex: Int,
     sessionCount: Int,
+    selectionActive: Boolean,
     onSwipeToSession: (Int) -> Unit,
     onInteraction: () -> Unit,
-): Modifier = pointerInput(currentIndex, sessionCount) {
+): Modifier = pointerInput(currentIndex, sessionCount, selectionActive) {
+    if (selectionActive) {
+        return@pointerInput
+    }
+
     awaitEachGesture {
         val down = awaitFirstDown(requireUnconsumed = false, pass = PointerEventPass.Initial)
         val pointerId = down.id
@@ -324,6 +330,7 @@ private fun Modifier.sessionSwipeNavigation(
                 dragY = dragY,
                 viewportWidth = size.width,
                 touchSlop = viewConfiguration.touchSlop,
+                selectionActive = selectionActive,
             )?.let { target ->
                 onInteraction()
                 onSwipeToSession(target)
@@ -741,6 +748,7 @@ fun ConsoleScreen(
 
     val hasMultipleSessions = uiState.bridges.size > 1 && !uiState.isLoading
     val swipeBetweenSessions = swipeSessionsEnabled && hasMultipleSessions
+    val terminalSelectionActive = selectionController?.isSelectionActive == true
     // These values are computed from bridge state and will recompute when uiState.revision changes
     val sessionOpen = currentBridge?.isSessionOpen == true
     val disconnected = currentBridge?.isDisconnected == true
@@ -973,6 +981,7 @@ fun ConsoleScreen(
                                     terminalModifier = Modifier.sessionSwipeNavigation(
                                         currentIndex = uiState.currentBridgeIndex,
                                         sessionCount = uiState.bridges.size,
+                                        selectionActive = terminalSelectionActive,
                                         onSwipeToSession = { index -> selectBridgePreservingKeyboard(index) },
                                         onInteraction = { handleTerminalInteraction(isInteraction = false) },
                                     ),

--- a/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
@@ -101,10 +101,10 @@ import androidx.compose.ui.input.key.isShiftPressed
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
-import androidx.compose.ui.keepScreenOn
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.input.pointer.positionChange
+import androidx.compose.ui.keepScreenOn
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
@@ -250,6 +250,31 @@ internal fun sessionSwipeTarget(
 
     return targetIndex.takeIf { it != currentIndex }
 }
+
+@VisibleForTesting
+internal fun shouldShowSoftwareKeyboardForSessionOpen(
+    previousBridgeId: Long?,
+    previousSessionOpen: Boolean,
+    currentBridgeId: Long?,
+    sessionOpen: Boolean,
+    hasHardwareKeyboard: Boolean,
+): Boolean = currentBridgeId != null &&
+    currentBridgeId == previousBridgeId &&
+    sessionOpen &&
+    !previousSessionOpen &&
+    !hasHardwareKeyboard
+
+@VisibleForTesting
+internal fun shouldPreserveSoftwareKeyboardForBridgeChange(
+    previousBridgeId: Long?,
+    currentBridgeId: Long?,
+    showSoftwareKeyboard: Boolean,
+    hasHardwareKeyboard: Boolean,
+): Boolean = previousBridgeId != null &&
+    currentBridgeId != null &&
+    previousBridgeId != currentBridgeId &&
+    showSoftwareKeyboard &&
+    !hasHardwareKeyboard
 
 private fun Modifier.sessionSwipeNavigation(
     currentIndex: Int,
@@ -543,12 +568,19 @@ fun ConsoleScreen(
     var selectionController by remember { mutableStateOf<SelectionController?>(null) }
     var imeVisible by remember { mutableStateOf(false) }
     var keyboardScrollInProgress by remember { mutableStateOf(false) }
+    var previousBridgeIdForImeState by remember { mutableStateOf<Long?>(null) }
+    var ignoreImeHiddenForBridgeId by remember { mutableStateOf<Long?>(null) }
+    var previousBridgeIdForSessionOpen by remember { mutableStateOf<Long?>(null) }
+    var previousSessionOpen by remember { mutableStateOf(false) }
+
+    val currentBridge = uiState.bridges
+        .getOrNull(uiState.currentBridgeIndex)
+    val currentBridgeId = currentBridge?.host?.id
 
     // Get current prompt state to check if biometric prompt is active
-    val currentBridgeForPrompt = uiState.bridges.getOrNull(uiState.currentBridgeIndex)
-    val promptState by currentBridgeForPrompt?.promptManager?.promptState?.collectAsState()
+    val promptState by currentBridge?.promptManager?.promptState?.collectAsState()
         ?: remember { mutableStateOf(null) }
-    val authBanners by currentBridgeForPrompt?.authBanners?.collectAsState()
+    val authBanners by currentBridge?.authBanners?.collectAsState()
         ?: remember { mutableStateOf(emptyList()) }
     val currentAuthBanner = authBanners.firstOrNull()
     var wasBiometricPromptActive by remember { mutableStateOf(false) }
@@ -613,6 +645,21 @@ fun ConsoleScreen(
         }
     }
 
+    fun selectBridgePreservingKeyboard(index: Int) {
+        val targetBridgeId = uiState.bridges.getOrNull(index)?.host?.id
+        if (
+            shouldPreserveSoftwareKeyboardForBridgeChange(
+                previousBridgeId = currentBridgeId,
+                currentBridgeId = targetBridgeId,
+                showSoftwareKeyboard = showSoftwareKeyboard,
+                hasHardwareKeyboard = hasHardwareKeyboard,
+            )
+        ) {
+            ignoreImeHiddenForBridgeId = targetBridgeId
+        }
+        viewModel.selectBridge(index)
+    }
+
     // Sync our state when user dismisses modals or prompts
     LaunchedEffect(anyModalActive) {
         if (!anyModalActive) {
@@ -664,16 +711,22 @@ fun ConsoleScreen(
     val imeHeight = with(density) { imeInsets.getBottom(density).toDp() }
     val systemImeVisible = imeHeight > 0.dp
     var hasImeBeenVisible by remember { mutableStateOf(false) }
+    val latestCurrentBridgeId by rememberUpdatedState(currentBridgeId)
 
     // Sync our state when user dismisses IME externally (back button)
     LaunchedEffect(systemImeVisible) {
         if (systemImeVisible) {
             hasImeBeenVisible = true
+            ignoreImeHiddenForBridgeId = null
         }
         // Only sync to hidden state after IME has been visible at least once.
         // This prevents canceling the keyboard before it has a chance to show.
         if (hasImeBeenVisible && !systemImeVisible && showSoftwareKeyboard) {
-            showSoftwareKeyboard = false
+            if (ignoreImeHiddenForBridgeId == latestCurrentBridgeId) {
+                termFocusRequester.requestFocus()
+            } else {
+                showSoftwareKeyboard = false
+            }
         }
         imeVisible = systemImeVisible
     }
@@ -686,9 +739,6 @@ fun ConsoleScreen(
         wasBiometricPromptActive = isBiometricPromptActive
     }
 
-    val currentBridge = uiState.bridges
-        .getOrNull(uiState.currentBridgeIndex)
-        ?.takeUnless { uiState.isLoading }
     val hasMultipleSessions = uiState.bridges.size > 1 && !uiState.isLoading
     val swipeBetweenSessions = swipeSessionsEnabled && hasMultipleSessions
     // These values are computed from bridge state and will recompute when uiState.revision changes
@@ -700,12 +750,36 @@ fun ConsoleScreen(
     val isConnectionActive = currentBridge != null && !disconnected
     val keepScreenOn = keepScreenAwake && isConnectionActive
 
-    // Show software keyboard when session becomes open (if no hardware keyboard)
-    // Also show when switching to a different bridge that's already open
-    LaunchedEffect(currentBridge, sessionOpen, hasHardwareKeyboard) {
-        if (sessionOpen && !hasHardwareKeyboard) {
+    LaunchedEffect(currentBridgeId) {
+        if (
+            shouldPreserveSoftwareKeyboardForBridgeChange(
+                previousBridgeId = previousBridgeIdForImeState,
+                currentBridgeId = currentBridgeId,
+                showSoftwareKeyboard = showSoftwareKeyboard,
+                hasHardwareKeyboard = hasHardwareKeyboard,
+            )
+        ) {
+            ignoreImeHiddenForBridgeId = currentBridgeId
+        }
+        previousBridgeIdForImeState = currentBridgeId
+    }
+
+    // Show software keyboard when the current session transitions to open,
+    // while preserving the user's current keyboard state across bridge switches.
+    LaunchedEffect(currentBridgeId, sessionOpen, hasHardwareKeyboard) {
+        if (
+            shouldShowSoftwareKeyboardForSessionOpen(
+                previousBridgeId = previousBridgeIdForSessionOpen,
+                previousSessionOpen = previousSessionOpen,
+                currentBridgeId = currentBridgeId,
+                sessionOpen = sessionOpen,
+                hasHardwareKeyboard = hasHardwareKeyboard,
+            )
+        ) {
             showSoftwareKeyboard = true
         }
+        previousBridgeIdForSessionOpen = currentBridgeId
+        previousSessionOpen = sessionOpen
     }
 
     // Reset selection controller when bridge changes
@@ -851,7 +925,7 @@ fun ConsoleScreen(
 
                             LaunchedEffect(pagerState.currentPage) {
                                 if (pagerState.currentPage != uiState.currentBridgeIndex) {
-                                    viewModel.selectBridge(pagerState.currentPage)
+                                    selectBridgePreservingKeyboard(pagerState.currentPage)
                                 }
                             }
 
@@ -899,8 +973,8 @@ fun ConsoleScreen(
                                     terminalModifier = Modifier.sessionSwipeNavigation(
                                         currentIndex = uiState.currentBridgeIndex,
                                         sessionCount = uiState.bridges.size,
-                                        onSwipeToSession = { index -> viewModel.selectBridge(index) },
-                                        onInteraction = { handleTerminalInteraction(isTerminalTap = true) },
+                                        onSwipeToSession = { index -> selectBridgePreservingKeyboard(index) },
+                                        onInteraction = { handleTerminalInteraction(isInteraction = false) },
                                     ),
                                 )
                             }
@@ -956,7 +1030,7 @@ fun ConsoleScreen(
             AuthBannerDialog(
                 banner = banner,
                 onDismiss = {
-                    currentBridgeForPrompt?.dismissAuthBanner(banner.id)
+                    currentBridge?.dismissAuthBanner(banner.id)
                 },
             )
         }
@@ -995,7 +1069,7 @@ fun ConsoleScreen(
                 onDismiss = { showSessionPickerDialog = false },
                 onSelectBridge = { index ->
                     showSessionPickerDialog = false
-                    viewModel.selectBridge(index)
+                    selectBridgePreservingKeyboard(index)
                 },
             )
         }
@@ -1127,7 +1201,7 @@ fun ConsoleScreen(
                                     text = { Text(stringResource(R.string.console_previous_session)) },
                                     onClick = {
                                         showMenu = false
-                                        viewModel.selectPreviousBridge()
+                                        selectBridgePreservingKeyboard(uiState.currentBridgeIndex - 1)
                                     },
                                     enabled = uiState.currentBridgeIndex > 0,
                                 )
@@ -1136,7 +1210,7 @@ fun ConsoleScreen(
                                     text = { Text(stringResource(R.string.console_next_session)) },
                                     onClick = {
                                         showMenu = false
-                                        viewModel.selectNextBridge()
+                                        selectBridgePreservingKeyboard(uiState.currentBridgeIndex + 1)
                                     },
                                     enabled = uiState.currentBridgeIndex < uiState.bridges.lastIndex,
                                 )

--- a/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
@@ -40,11 +40,13 @@ import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.imeAnimationTarget
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.union
 import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.ContentPaste
@@ -53,6 +55,7 @@ import androidx.compose.material.icons.filled.Link
 import androidx.compose.material.icons.filled.LinkOff
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.SwapHoriz
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Checkbox
@@ -63,14 +66,12 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.PrimaryScrollableTabRow
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.ScaffoldDefaults
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult
-import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
@@ -270,6 +271,7 @@ fun ConsoleScreen(
     var showUrlScanDialog by remember { mutableStateOf(false) }
     var showResizeDialog by remember { mutableStateOf(false) }
     var showDisconnectDialog by remember { mutableStateOf(false) }
+    var showSessionPickerDialog by remember { mutableStateOf(false) }
     var showTextInputDialog by remember { mutableStateOf(false) }
     var showExtraKeyboard by remember { mutableStateOf(true) } // Start visible to show animation
     var hasPlayedKeyboardAnimation by remember { mutableStateOf(false) }
@@ -430,7 +432,7 @@ fun ConsoleScreen(
     val currentBridge = uiState.bridges
         .getOrNull(uiState.currentBridgeIndex)
         ?.takeUnless { uiState.isLoading }
-    val showSessionSwitcher = uiState.bridges.size > 1 && !uiState.isLoading
+    val hasMultipleSessions = uiState.bridges.size > 1 && !uiState.isLoading
     // These values are computed from bridge state and will recompute when uiState.revision changes
     val sessionOpen = currentBridge?.isSessionOpen == true
     val disconnected = currentBridge?.isDisconnected == true
@@ -573,27 +575,6 @@ fun ConsoleScreen(
                 .windowInsetsPadding(WindowInsets.imeAnimationTarget)
                 .onPreviewKeyEvent(handleShortcut),
         ) {
-            if (showSessionSwitcher) {
-                PrimaryScrollableTabRow(
-                    selectedTabIndex = uiState.currentBridgeIndex,
-                    modifier = Modifier.fillMaxWidth(),
-                ) {
-                    uiState.bridges.forEachIndexed { index, bridge ->
-                        Tab(
-                            selected = index == uiState.currentBridgeIndex,
-                            onClick = { viewModel.selectBridge(index) },
-                            text = {
-                                Text(
-                                    bridge.host.nickname,
-                                    maxLines = 1,
-                                    overflow = TextOverflow.Ellipsis,
-                                )
-                            },
-                        )
-                    }
-                }
-            }
-
             when {
                 uiState.isLoading -> {
                     LoadingScreen(modifier = Modifier.fillMaxSize())
@@ -805,6 +786,18 @@ fun ConsoleScreen(
             )
         }
 
+        if (showSessionPickerDialog && hasMultipleSessions) {
+            SessionPickerDialog(
+                bridges = uiState.bridges,
+                currentBridgeIndex = uiState.currentBridgeIndex,
+                onDismiss = { showSessionPickerDialog = false },
+                onSelectBridge = { index ->
+                    showSessionPickerDialog = false
+                    viewModel.selectBridge(index)
+                },
+            )
+        }
+
         if (showTextInputDialog && promptState == null && currentBridge != null) {
             // TODO: Get selected text from TerminalEmulator when selection is implemented
             val selectedText = ""
@@ -855,6 +848,15 @@ fun ConsoleScreen(
                     TopAppBarDefaults.topAppBarColors()
                 },
                 actions = {
+                    if (hasMultipleSessions) {
+                        IconButton(onClick = { showSessionPickerDialog = true }) {
+                            Icon(
+                                Icons.Default.SwapHoriz,
+                                contentDescription = stringResource(R.string.console_switch_session),
+                            )
+                        }
+                    }
+
                     // Text Input button
                     IconButton(
                         onClick = { showTextInputDialog = true },
@@ -918,14 +920,14 @@ fun ConsoleScreen(
                                 )
                             }
 
-                            if (uiState.bridges.size > 1) {
+                            if (hasMultipleSessions) {
                                 DropdownMenuItem(
                                     text = { Text(stringResource(R.string.console_previous_session)) },
                                     onClick = {
                                         showMenu = false
                                         viewModel.selectPreviousBridge()
                                     },
-                                    enabled = uiState.currentBridgeIndex > 0
+                                    enabled = uiState.currentBridgeIndex > 0,
                                 )
 
                                 DropdownMenuItem(
@@ -934,7 +936,7 @@ fun ConsoleScreen(
                                         showMenu = false
                                         viewModel.selectNextBridge()
                                     },
-                                    enabled = uiState.currentBridgeIndex < uiState.bridges.lastIndex
+                                    enabled = uiState.currentBridgeIndex < uiState.bridges.lastIndex,
                                 )
                             }
 
@@ -1087,6 +1089,53 @@ private fun HostDisconnectDialog(
         dismissButton = {
             TextButton(onClick = onDismiss) {
                 Text(stringResource(R.string.button_no))
+            }
+        },
+    )
+}
+
+@Composable
+private fun SessionPickerDialog(
+    bridges: List<org.connectbot.service.TerminalBridge>,
+    currentBridgeIndex: Int,
+    onDismiss: () -> Unit,
+    onSelectBridge: (Int) -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = {
+            Text(stringResource(R.string.console_switch_session))
+        },
+        text = {
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = 320.dp),
+            ) {
+                items(
+                    count = bridges.size,
+                    key = { index -> bridges[index].host.id },
+                ) { index ->
+                    val bridge = bridges[index]
+                    TextButton(
+                        onClick = { onSelectBridge(index) },
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        Text(
+                            text = if (index == currentBridgeIndex) {
+                                "\u2022 ${bridge.host.nickname}"
+                            } else {
+                                bridge.host.nickname
+                            },
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.button_cancel))
             }
         },
     )

--- a/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
@@ -320,11 +320,11 @@ private fun ConsoleTerminalPage(
     imeVisible: Boolean,
     handleTerminalInteraction: () -> Unit,
     onShowSoftwareKeyboardChange: (Boolean) -> Unit,
-    onImeVisibilityChanged: (Boolean) -> Unit,
-    onTextInputRequested: () -> Unit,
-    onDisconnectRequested: () -> Unit,
+    onImeVisibilityChange: (Boolean) -> Unit,
+    onTextInputRequest: () -> Unit,
+    onDisconnectRequest: () -> Unit,
     onKeyboardScrollInProgressChange: (Boolean) -> Unit,
-    onSelectionControllerAvailable: (SelectionController) -> Unit,
+    onSelectionControllerChange: (SelectionController) -> Unit,
     onOpenUrl: (String) -> Unit,
     onPasteRequest: () -> Unit,
     onInterceptKey: (KeyEvent) -> Boolean,
@@ -365,13 +365,13 @@ private fun ConsoleTerminalPage(
             modifierManager = bridge.keyHandler,
             onSelectionControllerAvailable = { controller ->
                 if (isActive) {
-                    onSelectionControllerAvailable(controller)
+                    onSelectionControllerChange(controller)
                 }
             },
             onTerminalTap = { handleTerminalInteraction() },
             onImeVisibilityChanged = { visible ->
                 if (isActive) {
-                    onImeVisibilityChanged(visible)
+                    onImeVisibilityChange(visible)
                 }
             },
             onHyperlinkClick = onOpenUrl,
@@ -381,7 +381,7 @@ private fun ConsoleTerminalPage(
         )
 
         SideEffect {
-            bridge.onTextInputRequested = onTextInputRequested
+            bridge.onTextInputRequested = onTextInputRequest
         }
 
         if (isActive) {
@@ -402,7 +402,7 @@ private fun ConsoleTerminalPage(
                     onShowIme = {
                         onShowSoftwareKeyboardChange(true)
                     },
-                    onOpenTextInput = onTextInputRequested,
+                    onOpenTextInput = onTextInputRequest,
                     onScrollInProgressChange = onKeyboardScrollInProgressChange,
                     imeVisible = imeVisible,
                     playAnimation = !hasPlayedKeyboardAnimation,
@@ -448,7 +448,7 @@ private fun ConsoleTerminalPage(
                         modifier = Modifier.fillMaxWidth(),
                         horizontalArrangement = Arrangement.End,
                     ) {
-                        TextButton(onClick = onDisconnectRequested) {
+                        TextButton(onClick = onDisconnectRequest) {
                             Text(
                                 stringResource(R.string.console_menu_close),
                                 color = terminalColors.overlayText,
@@ -885,16 +885,16 @@ fun ConsoleScreen(
                                     imeVisible = imeVisible,
                                     handleTerminalInteraction = { handleTerminalInteraction(isTerminalTap = true) },
                                     onShowSoftwareKeyboardChange = { showSoftwareKeyboard = it },
-                                    onImeVisibilityChanged = { imeVisible = it },
-                                    onTextInputRequested = { showTextInputDialog = true },
-                                    onDisconnectRequested = {
+                                    onImeVisibilityChange = { imeVisible = it },
+                                    onTextInputRequest = { showTextInputDialog = true },
+                                    onDisconnectRequest = {
                                         pageBridge.dispatchDisconnect(DisconnectReason.USER_REQUESTED)
                                     },
                                     onKeyboardScrollInProgressChange = { inProgress ->
                                         keyboardScrollInProgress = inProgress
                                         handleTerminalInteraction()
                                     },
-                                    onSelectionControllerAvailable = { selectionController = it },
+                                    onSelectionControllerChange = { selectionController = it },
                                     onOpenUrl = ::openUrl,
                                     onPasteRequest = ::pasteClipboardContents,
                                     onInterceptKey = handleShortcut,
@@ -917,16 +917,16 @@ fun ConsoleScreen(
                                 imeVisible = imeVisible,
                                 handleTerminalInteraction = { handleTerminalInteraction(isTerminalTap = true) },
                                 onShowSoftwareKeyboardChange = { showSoftwareKeyboard = it },
-                                onImeVisibilityChanged = { imeVisible = it },
-                                onTextInputRequested = { showTextInputDialog = true },
-                                onDisconnectRequested = {
+                                onImeVisibilityChange = { imeVisible = it },
+                                onTextInputRequest = { showTextInputDialog = true },
+                                onDisconnectRequest = {
                                     bridge.dispatchDisconnect(DisconnectReason.USER_REQUESTED)
                                 },
                                 onKeyboardScrollInProgressChange = { inProgress ->
                                     keyboardScrollInProgress = inProgress
                                     handleTerminalInteraction()
                                 },
-                                onSelectionControllerAvailable = { selectionController = it },
+                                onSelectionControllerChange = { selectionController = it },
                                 onOpenUrl = ::openUrl,
                                 onPasteRequest = ::pasteClipboardContents,
                                 onInterceptKey = handleShortcut,

--- a/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
@@ -381,7 +381,7 @@ private fun ConsoleTerminalPage(
         )
 
         SideEffect {
-            bridge.onTextInputRequested = onTextInputRequest
+            bridge.onTextInputRequest = onTextInputRequest
         }
 
         if (isActive) {

--- a/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
@@ -49,8 +49,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.union
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.pager.HorizontalPager
-import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.ContentPaste
@@ -85,6 +83,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -498,6 +497,7 @@ private fun ConsoleTerminalPage(
                 }
             }
     }
+}
 }
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
@@ -925,70 +925,20 @@ fun ConsoleScreen(
                             .fillMaxWidth()
                             .weight(1f),
                     ) {
-                        if (swipeBetweenSessions) {
-                            val pagerState = rememberPagerState(
-                                initialPage = uiState.currentBridgeIndex,
-                                pageCount = { uiState.bridges.size },
+                        val bridge = uiState.bridges[uiState.currentBridgeIndex]
+                        val terminalModifier = if (swipeBetweenSessions) {
+                            Modifier.sessionSwipeNavigation(
+                                currentIndex = uiState.currentBridgeIndex,
+                                sessionCount = uiState.bridges.size,
+                                selectionActive = terminalSelectionActive,
+                                onSwipeToSession = { index -> selectBridgePreservingKeyboard(index) },
+                                onInteraction = { handleTerminalInteraction(isInteraction = false) },
                             )
-
-                            LaunchedEffect(pagerState.currentPage) {
-                                if (pagerState.currentPage != uiState.currentBridgeIndex) {
-                                    selectBridgePreservingKeyboard(pagerState.currentPage)
-                                }
-                            }
-
-                            LaunchedEffect(uiState.currentBridgeIndex, uiState.bridges.size) {
-                                if (pagerState.currentPage != uiState.currentBridgeIndex) {
-                                    pagerState.scrollToPage(uiState.currentBridgeIndex)
-                                }
-                            }
-
-                            HorizontalPager(
-                                state = pagerState,
-                                modifier = Modifier.fillMaxSize(),
-                                userScrollEnabled = false,
-                                key = { page -> uiState.bridges[page].host.id },
-                            ) { page ->
-                                val pageBridge = uiState.bridges[page]
-                                ConsoleTerminalPage(
-                                    bridge = pageBridge,
-                                    isActive = page == uiState.currentBridgeIndex,
-                                    keyboardAlwaysVisible = keyboardAlwaysVisible,
-                                    showSoftwareKeyboard = showSoftwareKeyboard,
-                                    forceSize = forceSize,
-                                    termFocusRequester = termFocusRequester,
-                                    showExtraKeyboard = showExtraKeyboard,
-                                    hasPlayedKeyboardAnimation = hasPlayedKeyboardAnimation,
-                                    imeVisible = imeVisible,
-                                    handleTerminalInteraction = { handleTerminalInteraction(isTerminalTap = true) },
-                                    onShowSoftwareKeyboardChange = { showSoftwareKeyboard = it },
-                                    onImeVisibilityChange = { imeVisible = it },
-                                    onTextInputRequest = { showTextInputDialog = true },
-                                    onDisconnectRequest = {
-                                        pageBridge.dispatchDisconnect(DisconnectReason.USER_REQUESTED)
-                                    },
-                                    onKeyboardScrollInProgressChange = { inProgress ->
-                                        keyboardScrollInProgress = inProgress
-                                        handleTerminalInteraction()
-                                    },
-                                    onSelectionControllerChange = { selectionController = it },
-                                    onOpenUrl = ::openUrl,
-                                    onPasteRequest = ::pasteClipboardContents,
-                                    onInterceptKey = handleShortcut,
-                                    onReconnect = { viewModel.reconnect(pageBridge) },
-                                    snackbarHostState = snackbarHostState,
-                                    modifier = Modifier.fillMaxSize(),
-                                    terminalModifier = Modifier.sessionSwipeNavigation(
-                                        currentIndex = uiState.currentBridgeIndex,
-                                        sessionCount = uiState.bridges.size,
-                                        selectionActive = terminalSelectionActive,
-                                        onSwipeToSession = { index -> selectBridgePreservingKeyboard(index) },
-                                        onInteraction = { handleTerminalInteraction(isInteraction = false) },
-                                    ),
-                                )
-                            }
                         } else {
-                            val bridge = uiState.bridges[uiState.currentBridgeIndex]
+                            Modifier
+                        }
+
+                        key(bridge.host.id) {
                             ConsoleTerminalPage(
                                 bridge = bridge,
                                 isActive = true,
@@ -1017,6 +967,7 @@ fun ConsoleScreen(
                                 onReconnect = { viewModel.reconnect(bridge) },
                                 snackbarHostState = snackbarHostState,
                                 modifier = Modifier.fillMaxSize(),
+                                terminalModifier = terminalModifier,
                             )
                         }
                     }

--- a/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
@@ -116,6 +116,7 @@ import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.withLink
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.content.edit
@@ -251,14 +252,39 @@ internal fun sessionSwipeTarget(
     return targetIndex.takeIf { it != currentIndex }
 }
 
+@VisibleForTesting
+internal fun isSessionSwipeStartExcluded(
+    startY: Float,
+    viewportHeight: Int,
+    excludedBottomHeightPx: Float,
+): Boolean {
+    if (viewportHeight <= 0 || excludedBottomHeightPx <= 0f) {
+        return false
+    }
+
+    return startY >= (viewportHeight - excludedBottomHeightPx).coerceAtLeast(0f)
+}
+
 private fun Modifier.sessionSwipeNavigation(
     currentIndex: Int,
     sessionCount: Int,
     onSwipeToSession: (Int) -> Unit,
     onInteraction: () -> Unit,
-): Modifier = pointerInput(currentIndex, sessionCount) {
+    excludedBottomHeight: Dp = 0.dp,
+): Modifier = pointerInput(currentIndex, sessionCount, excludedBottomHeight) {
+    val excludedBottomHeightPx = excludedBottomHeight.toPx()
+
     awaitEachGesture {
         val down = awaitFirstDown(requireUnconsumed = false, pass = PointerEventPass.Initial)
+        if (isSessionSwipeStartExcluded(
+                startY = down.position.y,
+                viewportHeight = size.height,
+                excludedBottomHeightPx = excludedBottomHeightPx,
+            )
+        ) {
+            return@awaitEachGesture
+        }
+
         val pointerId = down.id
         var dragX = 0f
         var dragY = 0f
@@ -868,6 +894,11 @@ fun ConsoleScreen(
                                         sessionCount = uiState.bridges.size,
                                         onSwipeToSession = { index -> viewModel.selectBridge(index) },
                                         onInteraction = { handleTerminalInteraction(isTerminalTap = true) },
+                                        excludedBottomHeight = if (showExtraKeyboard) {
+                                            TERMINAL_KEYBOARD_HEIGHT_DP.dp
+                                        } else {
+                                            0.dp
+                                        },
                                     ),
                                 userScrollEnabled = false,
                                 key = { page -> uiState.bridges[page].host.id },

--- a/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
@@ -47,6 +47,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.union
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.ContentPaste
@@ -124,6 +126,7 @@ import org.connectbot.data.entity.Host
 import org.connectbot.service.AuthBanner
 import org.connectbot.service.DisconnectReason
 import org.connectbot.service.PromptRequest
+import org.connectbot.service.TerminalBridge
 import org.connectbot.terminal.ProgressState
 import org.connectbot.terminal.SelectionController
 import org.connectbot.terminal.Terminal
@@ -214,6 +217,165 @@ internal fun handleConsoleShortcut(
     }
 }
 
+@Composable
+private fun ConsoleTerminalPage(
+    bridge: TerminalBridge,
+    isActive: Boolean,
+    keyboardAlwaysVisible: Boolean,
+    showSoftwareKeyboard: Boolean,
+    forceSize: Pair<Int, Int>?,
+    termFocusRequester: FocusRequester,
+    showExtraKeyboard: Boolean,
+    hasPlayedKeyboardAnimation: Boolean,
+    imeVisible: Boolean,
+    handleTerminalInteraction: () -> Unit,
+    onShowSoftwareKeyboardChange: (Boolean) -> Unit,
+    onImeVisibilityChanged: (Boolean) -> Unit,
+    onTextInputRequested: () -> Unit,
+    onDisconnectRequested: () -> Unit,
+    onKeyboardScrollInProgressChange: (Boolean) -> Unit,
+    onSelectionControllerAvailable: (SelectionController) -> Unit,
+    onOpenUrl: (String) -> Unit,
+    onPasteRequest: () -> Unit,
+    onInterceptKey: (KeyEvent) -> Boolean,
+    onReconnect: () -> Unit,
+    snackbarHostState: SnackbarHostState,
+    modifier: Modifier = Modifier,
+) {
+    Box(modifier = modifier) {
+        val fontResult = rememberTerminalTypefaceResultFromStoredValue(bridge.fontFamily)
+        val coroutineScope = rememberCoroutineScope()
+        val fontSize by bridge.fontSizeFlow.collectAsState()
+        val delKeyMode by bridge.delKeyModeFlow.collectAsState()
+
+        LaunchedEffect(fontResult.loadFailed, fontResult.isLoading) {
+            if (fontResult.loadFailed && !fontResult.isLoading) {
+                coroutineScope.launch {
+                    snackbarHostState.showSnackbar(
+                        message = "Failed to load font '${fontResult.requestedFontName}'. Using system default.",
+                    )
+                }
+            }
+        }
+
+        Terminal(
+            terminalEmulator = bridge.terminalEmulator,
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(
+                    bottom = if (keyboardAlwaysVisible) TERMINAL_KEYBOARD_HEIGHT_DP.dp else 0.dp,
+                )
+                .testTag("terminal"),
+            typeface = fontResult.typeface,
+            initialFontSize = fontSize.sp,
+            keyboardEnabled = true,
+            showSoftKeyboard = showSoftwareKeyboard && isActive,
+            focusRequester = termFocusRequester,
+            forcedSize = forceSize,
+            modifierManager = bridge.keyHandler,
+            onSelectionControllerAvailable = { controller ->
+                if (isActive) {
+                    onSelectionControllerAvailable(controller)
+                }
+            },
+            onTerminalTap = { handleTerminalInteraction() },
+            onImeVisibilityChanged = { visible ->
+                if (isActive) {
+                    onImeVisibilityChanged(visible)
+                }
+            },
+            onHyperlinkClick = onOpenUrl,
+            delKeyMode = delKeyMode,
+            onPasteRequest = onPasteRequest,
+            onInterceptKey = onInterceptKey,
+        )
+
+        SideEffect {
+            bridge.onTextInputRequested = onTextInputRequested
+        }
+
+        if (isActive) {
+            AnimatedVisibility(
+                visible = showExtraKeyboard,
+                enter = fadeIn(animationSpec = tween(durationMillis = 100)),
+                exit = fadeOut(animationSpec = tween(durationMillis = 100)),
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .testTag("terminal_keyboard"),
+            ) {
+                TerminalKeyboard(
+                    bridge = bridge,
+                    onInteraction = { handleTerminalInteraction() },
+                    onHideIme = {
+                        onShowSoftwareKeyboardChange(false)
+                    },
+                    onShowIme = {
+                        onShowSoftwareKeyboardChange(true)
+                    },
+                    onOpenTextInput = onTextInputRequested,
+                    onScrollInProgressChange = onKeyboardScrollInProgressChange,
+                    imeVisible = imeVisible,
+                    playAnimation = !hasPlayedKeyboardAnimation,
+                )
+            }
+
+            val promptState by bridge.promptManager.promptState.collectAsState()
+
+            InlinePrompt(
+                promptRequest = promptState,
+                onResponse = { response ->
+                    bridge.promptManager.respond(response)
+                },
+                onCancel = {
+                    bridge.promptManager.cancelPrompt()
+                },
+                onDismiss = {
+                    termFocusRequester.requestFocus()
+                },
+                modifier = Modifier.align(Alignment.BottomCenter),
+            )
+
+            AnimatedVisibility(
+                visible = bridge.isDisconnected && !bridge.isConnecting && promptState == null,
+                enter = slideInVertically(initialOffsetY = { it }),
+                exit = slideOutVertically(targetOffsetY = { it }),
+                modifier = Modifier.align(Alignment.BottomCenter),
+            ) {
+                val terminalColors = MaterialTheme.colorScheme.terminal
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(terminalColors.overlayBackground)
+                        .padding(16.dp),
+                ) {
+                    Text(
+                        text = stringResource(R.string.alert_disconnect_msg),
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = terminalColors.overlayText,
+                        modifier = Modifier.padding(bottom = 16.dp),
+                    )
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.End,
+                    ) {
+                        TextButton(onClick = onDisconnectRequested) {
+                            Text(
+                                stringResource(R.string.console_menu_close),
+                                color = terminalColors.overlayText,
+                            )
+                        }
+                        Button(
+                            onClick = onReconnect,
+                            modifier = Modifier.padding(start = 8.dp),
+                        ) {
+                            Text(stringResource(R.string.console_menu_reconnect))
+                        }
+                    }
+                }
+            }
+    }
+}
+
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
 fun ConsoleScreen(
@@ -239,6 +401,9 @@ fun ConsoleScreen(
     // Read preferences
     val prefs = remember { PreferenceManager.getDefaultSharedPreferences(context) }
     val keyboardAlwaysVisible = remember { prefs.getBoolean(PreferenceConstants.KEY_ALWAYS_VISIBLE, false) }
+    val swipeSessionsEnabled = remember {
+        prefs.getBoolean(PreferenceConstants.SWIPE_SESSIONS, false)
+    }
     var fullscreen by remember { mutableStateOf(prefs.getBoolean(PreferenceConstants.FULLSCREEN, false)) }
     var titleBarHide by remember { mutableStateOf(prefs.getBoolean(PreferenceConstants.TITLEBARHIDE, false)) }
     val volumeKeysChangeFontSize = remember { prefs.getBoolean(PreferenceConstants.VOLUME_FONT, true) }
@@ -433,10 +598,10 @@ fun ConsoleScreen(
         .getOrNull(uiState.currentBridgeIndex)
         ?.takeUnless { uiState.isLoading }
     val hasMultipleSessions = uiState.bridges.size > 1 && !uiState.isLoading
+    val swipeBetweenSessions = swipeSessionsEnabled && hasMultipleSessions
     // These values are computed from bridge state and will recompute when uiState.revision changes
     val sessionOpen = currentBridge?.isSessionOpen == true
     val disconnected = currentBridge?.isDisconnected == true
-    val connecting = currentBridge?.isConnecting == true
     val canForwardPorts = currentBridge?.canFowardPorts() == true
     val snackbarHostState = remember { SnackbarHostState() }
 
@@ -581,158 +746,96 @@ fun ConsoleScreen(
                 }
 
                 uiState.bridges.isNotEmpty() -> {
-                    val bridge = uiState.bridges[uiState.currentBridgeIndex]
-
                     Box(
                         modifier = Modifier
                             .fillMaxWidth()
                             .weight(1f),
                     ) {
-                        // Get font from profile (stored in bridge)
-                        val fontResult = rememberTerminalTypefaceResultFromStoredValue(bridge.fontFamily)
-                        val coroutineScope = rememberCoroutineScope()
-                        // Observe font size changes for reactive updates
-                        val fontSize by bridge.fontSizeFlow.collectAsState()
-                        // Observe DEL key mode changes
-                        val delKeyMode by bridge.delKeyModeFlow.collectAsState()
+                        if (swipeBetweenSessions) {
+                            val pagerState = rememberPagerState(
+                                initialPage = uiState.currentBridgeIndex,
+                                pageCount = { uiState.bridges.size },
+                            )
 
-                        // Show snackbar if font loading failed
-                        LaunchedEffect(fontResult.loadFailed, fontResult.isLoading) {
-                            if (fontResult.loadFailed && !fontResult.isLoading) {
-                                coroutineScope.launch {
-                                    snackbarHostState.showSnackbar(
-                                        message = "Failed to load font '${fontResult.requestedFontName}'. Using system default.",
-                                    )
+                            LaunchedEffect(pagerState.currentPage) {
+                                if (pagerState.currentPage != uiState.currentBridgeIndex) {
+                                    viewModel.selectBridge(pagerState.currentPage)
                                 }
                             }
-                        }
 
-                        Terminal(
-                            terminalEmulator = bridge.terminalEmulator,
-                            modifier = Modifier
-                                .fillMaxSize()
-                                .padding(
-                                    bottom = if (keyboardAlwaysVisible) TERMINAL_KEYBOARD_HEIGHT_DP.dp else 0.dp,
-                                )
-                                .testTag("terminal"),
-                            typeface = fontResult.typeface,
-                            initialFontSize = fontSize.sp,
-                            keyboardEnabled = true,
-                            showSoftKeyboard = showSoftwareKeyboard,
-                            focusRequester = termFocusRequester,
-                            forcedSize = forceSize,
-                            modifierManager = bridge.keyHandler,
-                            onSelectionControllerAvailable = { selectionController = it },
-                            onTerminalTap = { handleTerminalInteraction(isTerminalTap = true) },
-                            onImeVisibilityChanged = { visible ->
-                                imeVisible = visible
-                            },
-                            onHyperlinkClick = { url ->
-                                openUrl(url)
-                            },
-                            delKeyMode = delKeyMode,
-                            onPasteRequest = {
-                                pasteClipboardContents()
-                            },
-                            onInterceptKey = handleShortcut,
-                        )
-
-                        // Set up text input request callback from bridge (for camera button)
-                        SideEffect {
-                            bridge.onTextInputRequested = {
-                                showTextInputDialog = true
+                            LaunchedEffect(uiState.currentBridgeIndex, uiState.bridges.size) {
+                                if (pagerState.currentPage != uiState.currentBridgeIndex) {
+                                    pagerState.scrollToPage(uiState.currentBridgeIndex)
+                                }
                             }
-                        }
 
-                        // Terminal keyboard overlay (doesn't resize terminal)
-                        // Must be BEFORE prompts so prompts appear on top
-                        // Fade in/out animation matches ConsoleActivity (100ms duration)
-                        AnimatedVisibility(
-                            visible = showExtraKeyboard,
-                            enter = fadeIn(animationSpec = tween(durationMillis = 100)),
-                            exit = fadeOut(animationSpec = tween(durationMillis = 100)),
-                            modifier = Modifier
-                                .align(Alignment.BottomCenter)
-                                .testTag("terminal_keyboard"),
-                        ) {
-                            TerminalKeyboard(
+                            HorizontalPager(
+                                state = pagerState,
+                                modifier = Modifier.fillMaxSize(),
+                                key = { page -> uiState.bridges[page].host.id },
+                            ) { page ->
+                                val pageBridge = uiState.bridges[page]
+                                ConsoleTerminalPage(
+                                    bridge = pageBridge,
+                                    isActive = page == uiState.currentBridgeIndex,
+                                    keyboardAlwaysVisible = keyboardAlwaysVisible,
+                                    showSoftwareKeyboard = showSoftwareKeyboard,
+                                    forceSize = forceSize,
+                                    termFocusRequester = termFocusRequester,
+                                    showExtraKeyboard = showExtraKeyboard,
+                                    hasPlayedKeyboardAnimation = hasPlayedKeyboardAnimation,
+                                    imeVisible = imeVisible,
+                                    handleTerminalInteraction = { handleTerminalInteraction(isTerminalTap = true) },
+                                    onShowSoftwareKeyboardChange = { showSoftwareKeyboard = it },
+                                    onImeVisibilityChanged = { imeVisible = it },
+                                    onTextInputRequested = { showTextInputDialog = true },
+                                    onDisconnectRequested = {
+                                        pageBridge.dispatchDisconnect(DisconnectReason.USER_REQUESTED)
+                                    },
+                                    onKeyboardScrollInProgressChange = { inProgress ->
+                                        keyboardScrollInProgress = inProgress
+                                        handleTerminalInteraction()
+                                    },
+                                    onSelectionControllerAvailable = { selectionController = it },
+                                    onOpenUrl = ::openUrl,
+                                    onPasteRequest = ::pasteClipboardContents,
+                                    onInterceptKey = handleShortcut,
+                                    onReconnect = { viewModel.reconnect(pageBridge) },
+                                    snackbarHostState = snackbarHostState,
+                                    modifier = Modifier.fillMaxSize(),
+                                )
+                            }
+                        } else {
+                            val bridge = uiState.bridges[uiState.currentBridgeIndex]
+                            ConsoleTerminalPage(
                                 bridge = bridge,
-                                onInteraction = { handleTerminalInteraction() },
-                                onHideIme = {
-                                    showSoftwareKeyboard = false
+                                isActive = true,
+                                keyboardAlwaysVisible = keyboardAlwaysVisible,
+                                showSoftwareKeyboard = showSoftwareKeyboard,
+                                forceSize = forceSize,
+                                termFocusRequester = termFocusRequester,
+                                showExtraKeyboard = showExtraKeyboard,
+                                hasPlayedKeyboardAnimation = hasPlayedKeyboardAnimation,
+                                imeVisible = imeVisible,
+                                handleTerminalInteraction = { handleTerminalInteraction(isTerminalTap = true) },
+                                onShowSoftwareKeyboardChange = { showSoftwareKeyboard = it },
+                                onImeVisibilityChanged = { imeVisible = it },
+                                onTextInputRequested = { showTextInputDialog = true },
+                                onDisconnectRequested = {
+                                    bridge.dispatchDisconnect(DisconnectReason.USER_REQUESTED)
                                 },
-                                onShowIme = {
-                                    showSoftwareKeyboard = true
-                                },
-                                onOpenTextInput = {
-                                    showTextInputDialog = true
-                                },
-                                onScrollInProgressChange = { inProgress ->
+                                onKeyboardScrollInProgressChange = { inProgress ->
                                     keyboardScrollInProgress = inProgress
                                     handleTerminalInteraction()
                                 },
-                                imeVisible = imeVisible,
-                                playAnimation = !hasPlayedKeyboardAnimation,
+                                onSelectionControllerAvailable = { selectionController = it },
+                                onOpenUrl = ::openUrl,
+                                onPasteRequest = ::pasteClipboardContents,
+                                onInterceptKey = handleShortcut,
+                                onReconnect = { viewModel.reconnect(bridge) },
+                                snackbarHostState = snackbarHostState,
+                                modifier = Modifier.fillMaxSize(),
                             )
-                        }
-
-                        // Show inline prompts from the current bridge (non-modal at bottom)
-                        // Must be AFTER keyboard so prompts appear on top (z-order)
-                        val promptState by bridge.promptManager.promptState.collectAsState()
-
-                        InlinePrompt(
-                            promptRequest = promptState,
-                            onResponse = { response ->
-                                bridge.promptManager.respond(response)
-                            },
-                            onCancel = {
-                                bridge.promptManager.cancelPrompt()
-                            },
-                            onDismiss = {
-                                termFocusRequester.requestFocus()
-                            },
-                            modifier = Modifier
-                                .align(Alignment.BottomCenter),
-                        )
-
-                        // Show reconnect/close overlay when session is disconnected
-                        AnimatedVisibility(
-                            visible = disconnected && !connecting && promptState == null,
-                            enter = slideInVertically(initialOffsetY = { it }),
-                            exit = slideOutVertically(targetOffsetY = { it }),
-                            modifier = Modifier.align(Alignment.BottomCenter),
-                        ) {
-                            val terminalColors = MaterialTheme.colorScheme.terminal
-                            Column(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .background(terminalColors.overlayBackground)
-                                    .padding(16.dp),
-                            ) {
-                                Text(
-                                    text = stringResource(R.string.alert_disconnect_msg),
-                                    style = MaterialTheme.typography.bodyLarge,
-                                    color = terminalColors.overlayText,
-                                    modifier = Modifier.padding(bottom = 16.dp),
-                                )
-                                Row(
-                                    modifier = Modifier.fillMaxWidth(),
-                                    horizontalArrangement = Arrangement.End,
-                                ) {
-                                    TextButton(onClick = { bridge.dispatchDisconnect(DisconnectReason.USER_REQUESTED) }) {
-                                        Text(
-                                            stringResource(R.string.console_menu_close),
-                                            color = terminalColors.overlayText,
-                                        )
-                                    }
-                                    Button(
-                                        onClick = { viewModel.reconnect(bridge) },
-                                        modifier = Modifier.padding(start = 8.dp),
-                                    ) {
-                                        Text(stringResource(R.string.console_menu_reconnect))
-                                    }
-                                }
-                            }
                         }
                     }
                 }
@@ -1096,7 +1199,7 @@ private fun HostDisconnectDialog(
 
 @Composable
 private fun SessionPickerDialog(
-    bridges: List<org.connectbot.service.TerminalBridge>,
+    bridges: List<TerminalBridge>,
     currentBridgeIndex: Int,
     onDismiss: () -> Unit,
     onSelectBridge: (Int) -> Unit,

--- a/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
@@ -29,6 +29,8 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -100,6 +102,9 @@ import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.keepScreenOn
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.input.pointer.positionChange
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
@@ -144,6 +149,8 @@ import org.connectbot.util.PreferenceConstants
 import org.connectbot.util.UrlUtils
 import org.connectbot.util.rememberTerminalTypefaceResultFromStoredValue
 import timber.log.Timber
+import kotlin.math.abs
+import kotlin.math.max
 
 /**
  * Check if a hardware keyboard is currently attached to the device.
@@ -214,6 +221,89 @@ internal fun handleConsoleShortcut(
         }
 
         else -> false
+    }
+}
+
+@VisibleForTesting
+internal fun sessionSwipeTarget(
+    currentIndex: Int,
+    sessionCount: Int,
+    dragX: Float,
+    dragY: Float,
+    viewportWidth: Int,
+    touchSlop: Float,
+): Int? {
+    if (sessionCount < 2 || viewportWidth <= 0) {
+        return null
+    }
+
+    val minimumSwipeDistance = max(touchSlop * 3f, viewportWidth * 0.18f)
+    if (abs(dragX) < minimumSwipeDistance || abs(dragX) < abs(dragY) * 1.5f) {
+        return null
+    }
+
+    val targetIndex = if (dragX < 0f) {
+        (currentIndex + 1).coerceAtMost(sessionCount - 1)
+    } else {
+        (currentIndex - 1).coerceAtLeast(0)
+    }
+
+    return targetIndex.takeIf { it != currentIndex }
+}
+
+private fun Modifier.sessionSwipeNavigation(
+    currentIndex: Int,
+    sessionCount: Int,
+    onSwipeToSession: (Int) -> Unit,
+    onInteraction: () -> Unit,
+): Modifier = pointerInput(currentIndex, sessionCount) {
+    awaitEachGesture {
+        val down = awaitFirstDown(requireUnconsumed = false, pass = PointerEventPass.Initial)
+        val pointerId = down.id
+        var dragX = 0f
+        var dragY = 0f
+        var horizontalSwipeLocked = false
+        var verticalGestureLocked = false
+
+        while (true) {
+            val event = awaitPointerEvent(PointerEventPass.Initial)
+            val change = event.changes.firstOrNull { it.id == pointerId } ?: break
+            if (!change.pressed) {
+                break
+            }
+
+            val delta = change.positionChange()
+            dragX += delta.x
+            dragY += delta.y
+
+            if (!horizontalSwipeLocked && !verticalGestureLocked) {
+                val absX = abs(dragX)
+                val absY = abs(dragY)
+                if (absX > viewConfiguration.touchSlop && absX > absY * 1.5f) {
+                    horizontalSwipeLocked = true
+                } else if (absY > viewConfiguration.touchSlop && absY > absX) {
+                    verticalGestureLocked = true
+                }
+            }
+
+            if (horizontalSwipeLocked) {
+                change.consume()
+            }
+        }
+
+        if (horizontalSwipeLocked) {
+            sessionSwipeTarget(
+                currentIndex = currentIndex,
+                sessionCount = sessionCount,
+                dragX = dragX,
+                dragY = dragY,
+                viewportWidth = size.width,
+                touchSlop = viewConfiguration.touchSlop,
+            )?.let { target ->
+                onInteraction()
+                onSwipeToSession(target)
+            }
+        }
     }
 }
 
@@ -771,7 +861,15 @@ fun ConsoleScreen(
 
                             HorizontalPager(
                                 state = pagerState,
-                                modifier = Modifier.fillMaxSize(),
+                                modifier = Modifier
+                                    .fillMaxSize()
+                                    .sessionSwipeNavigation(
+                                        currentIndex = uiState.currentBridgeIndex,
+                                        sessionCount = uiState.bridges.size,
+                                        onSwipeToSession = { index -> viewModel.selectBridge(index) },
+                                        onInteraction = { handleTerminalInteraction(isTerminalTap = true) },
+                                    ),
+                                userScrollEnabled = false,
                                 key = { page -> uiState.bridges[page].host.id },
                             ) { page ->
                                 val pageBridge = uiState.bridges[page]

--- a/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
@@ -116,7 +116,6 @@ import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.withLink
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.content.edit
@@ -252,39 +251,14 @@ internal fun sessionSwipeTarget(
     return targetIndex.takeIf { it != currentIndex }
 }
 
-@VisibleForTesting
-internal fun isSessionSwipeStartExcluded(
-    startY: Float,
-    viewportHeight: Int,
-    excludedBottomHeightPx: Float,
-): Boolean {
-    if (viewportHeight <= 0 || excludedBottomHeightPx <= 0f) {
-        return false
-    }
-
-    return startY >= (viewportHeight - excludedBottomHeightPx).coerceAtLeast(0f)
-}
-
 private fun Modifier.sessionSwipeNavigation(
     currentIndex: Int,
     sessionCount: Int,
     onSwipeToSession: (Int) -> Unit,
     onInteraction: () -> Unit,
-    excludedBottomHeight: Dp = 0.dp,
-): Modifier = pointerInput(currentIndex, sessionCount, excludedBottomHeight) {
-    val excludedBottomHeightPx = excludedBottomHeight.toPx()
-
+): Modifier = pointerInput(currentIndex, sessionCount) {
     awaitEachGesture {
         val down = awaitFirstDown(requireUnconsumed = false, pass = PointerEventPass.Initial)
-        if (isSessionSwipeStartExcluded(
-                startY = down.position.y,
-                viewportHeight = size.height,
-                excludedBottomHeightPx = excludedBottomHeightPx,
-            )
-        ) {
-            return@awaitEachGesture
-        }
-
         val pointerId = down.id
         var dragX = 0f
         var dragY = 0f
@@ -357,6 +331,7 @@ private fun ConsoleTerminalPage(
     onReconnect: () -> Unit,
     snackbarHostState: SnackbarHostState,
     modifier: Modifier = Modifier,
+    terminalModifier: Modifier = Modifier,
 ) {
     Box(modifier = modifier) {
         val fontResult = rememberTerminalTypefaceResultFromStoredValue(bridge.fontFamily)
@@ -381,6 +356,7 @@ private fun ConsoleTerminalPage(
                 .padding(
                     bottom = if (keyboardAlwaysVisible) TERMINAL_KEYBOARD_HEIGHT_DP.dp else 0.dp,
                 )
+                .then(terminalModifier)
                 .testTag("terminal"),
             typeface = fontResult.typeface,
             initialFontSize = fontSize.sp,
@@ -887,19 +863,7 @@ fun ConsoleScreen(
 
                             HorizontalPager(
                                 state = pagerState,
-                                modifier = Modifier
-                                    .fillMaxSize()
-                                    .sessionSwipeNavigation(
-                                        currentIndex = uiState.currentBridgeIndex,
-                                        sessionCount = uiState.bridges.size,
-                                        onSwipeToSession = { index -> viewModel.selectBridge(index) },
-                                        onInteraction = { handleTerminalInteraction(isTerminalTap = true) },
-                                        excludedBottomHeight = if (showExtraKeyboard) {
-                                            TERMINAL_KEYBOARD_HEIGHT_DP.dp
-                                        } else {
-                                            0.dp
-                                        },
-                                    ),
+                                modifier = Modifier.fillMaxSize(),
                                 userScrollEnabled = false,
                                 key = { page -> uiState.bridges[page].host.id },
                             ) { page ->
@@ -932,6 +896,12 @@ fun ConsoleScreen(
                                     onReconnect = { viewModel.reconnect(pageBridge) },
                                     snackbarHostState = snackbarHostState,
                                     modifier = Modifier.fillMaxSize(),
+                                    terminalModifier = Modifier.sessionSwipeNavigation(
+                                        currentIndex = uiState.currentBridgeIndex,
+                                        sessionCount = uiState.bridges.size,
+                                        onSwipeToSession = { index -> viewModel.selectBridge(index) },
+                                        onInteraction = { handleTerminalInteraction(isTerminalTap = true) },
+                                    ),
                                 )
                             }
                         } else {

--- a/app/src/main/java/org/connectbot/ui/screens/console/ConsoleViewModel.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/console/ConsoleViewModel.kt
@@ -22,6 +22,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -60,6 +61,12 @@ class ConsoleViewModel @Inject constructor(
 ) : ViewModel() {
     private val hostId: Long = savedStateHandle.get<Long>("hostId") ?: -1L
     private var terminalManager: TerminalManager? = null
+    private var pendingInitialHostId: Long? = hostId.takeIf { it != -1L }
+    private var selectedHostId: Long? = null
+
+    private val bellJobs = mutableMapOf<Long, Job>()
+    private val progressJobs = mutableMapOf<Long, Job>()
+    private val networkStatusJobs = mutableMapOf<Long, Job>()
 
     private val _uiState = MutableStateFlow(ConsoleUiState())
     val uiState: StateFlow<ConsoleUiState> = _uiState.asStateFlow()
@@ -76,24 +83,22 @@ class ConsoleViewModel @Inject constructor(
     fun setTerminalManager(manager: TerminalManager) {
         if (terminalManager != manager) {
             terminalManager = manager
-            // Observe bridges flow from TerminalManager
+
             viewModelScope.launch {
                 manager.bridgesFlow.collect { bridges ->
                     updateBridges(bridges)
-                    subscribeToActiveBridgeBells(bridges)
-                    subscribeToActiveBridgeProgress(bridges)
-                    subscribeToNetworkStatusMessages(bridges)
+                    syncBridgeBellSubscriptions(bridges)
+                    syncBridgeProgressSubscriptions(bridges)
+                    syncBridgeNetworkStatusSubscriptions(bridges)
                 }
             }
 
-            // Observe host status changes (connect/disconnect events) to refresh UI
             viewModelScope.launch {
                 manager.hostStatusChangedFlow.collect {
                     _uiState.update { it.copy(revision = it.revision + 1) }
                 }
             }
 
-            // First, try to find or create the bridge for this host
             if (hostId != -1L) {
                 viewModelScope.launch {
                     ensureBridgeExists()
@@ -102,68 +107,125 @@ class ConsoleViewModel @Inject constructor(
         }
     }
 
-    private fun subscribeToActiveBridgeBells(bridges: List<TerminalBridge>) {
-        viewModelScope.launch {
-            bridges.forEach { bridge ->
-                launch {
-                    bridge.bellEvents.collect {
-                        val currentIndex = _uiState.value.currentBridgeIndex
-                        val currentBridge = _uiState.value.bridges.getOrNull(currentIndex)
+    private fun syncBridgeBellSubscriptions(bridges: List<TerminalBridge>) {
+        syncBridgeJobs(bridges, bellJobs) { bridge ->
+            viewModelScope.launch {
+                bridge.bellEvents.collect {
+                    val currentBridge = _uiState.value.bridges.getOrNull(_uiState.value.currentBridgeIndex)
 
-                        if (currentBridge == bridge) {
-                            // The bridge is visible, play the beep
-                            terminalManager?.playBeep()
-                        } else {
-                            // The bridge is not visible, send a notification
-                            currentBridge?.host?.let {
-                                terminalManager?.sendActivityNotification(it)
-                            }
-                        }
+                    if (currentBridge == bridge) {
+                        terminalManager?.playBeep()
+                    } else {
+                        terminalManager?.sendActivityNotification(bridge.host)
                     }
                 }
             }
         }
     }
 
-    private fun subscribeToActiveBridgeProgress(bridges: List<TerminalBridge>) {
-        viewModelScope.launch {
-            bridges.forEach { bridge ->
-                launch {
-                    bridge.progressState.collect { progressInfo ->
-                        val currentIndex = _uiState.value.currentBridgeIndex
-                        val currentBridge = _uiState.value.bridges.getOrNull(currentIndex)
-
-                        if (currentBridge == bridge) {
-                            // Update progress state for the visible bridge
-                            _uiState.update {
-                                if (progressInfo == null || progressInfo.state == ProgressState.HIDDEN) {
-                                    it.copy(progressState = null, progressValue = 0)
-                                } else {
-                                    it.copy(
-                                        progressState = progressInfo.state,
-                                        progressValue = progressInfo.progress,
-                                    )
-                                }
-                            }
-                        }
+    private fun syncBridgeProgressSubscriptions(bridges: List<TerminalBridge>) {
+        syncBridgeJobs(bridges, progressJobs) { bridge ->
+            viewModelScope.launch {
+                bridge.progressState.collect { progressInfo ->
+                    val currentBridge = _uiState.value.bridges.getOrNull(_uiState.value.currentBridgeIndex)
+                    if (currentBridge == bridge) {
+                        updateProgressState(progressInfo)
                     }
                 }
             }
         }
     }
 
-    private fun subscribeToNetworkStatusMessages(bridges: List<TerminalBridge>) {
-        viewModelScope.launch {
-            bridges.forEach { bridge ->
-                launch {
-                    bridge.networkStatusMessages.collect { message ->
-                        val currentBridge = _uiState.value.bridges.getOrNull(_uiState.value.currentBridgeIndex)
-                        if (currentBridge == bridge) {
-                            _networkStatusMessages.emit(message)
-                        }
+    private fun syncBridgeNetworkStatusSubscriptions(bridges: List<TerminalBridge>) {
+        syncBridgeJobs(bridges, networkStatusJobs) { bridge ->
+            viewModelScope.launch {
+                bridge.networkStatusMessages.collect { message ->
+                    val currentBridge = _uiState.value.bridges.getOrNull(_uiState.value.currentBridgeIndex)
+                    if (currentBridge == bridge) {
+                        _networkStatusMessages.emit(message)
                     }
                 }
             }
+        }
+    }
+
+    private fun syncBridgeJobs(
+        bridges: List<TerminalBridge>,
+        jobs: MutableMap<Long, Job>,
+        createJob: (TerminalBridge) -> Job
+    ) {
+        val activeHostIds = bridges.map { it.host.id }.toSet()
+
+        val removedIds = jobs.keys.filter { it !in activeHostIds }
+        removedIds.forEach { hostId ->
+            jobs.remove(hostId)?.cancel()
+        }
+
+        bridges.forEach { bridge ->
+            jobs.getOrPut(bridge.host.id) {
+                createJob(bridge)
+            }
+        }
+    }
+
+    private fun updateProgressState(progressInfo: TerminalBridge.ProgressInfo?) {
+        _uiState.update {
+            if (progressInfo == null || progressInfo.state == ProgressState.HIDDEN) {
+                it.copy(progressState = null, progressValue = 0)
+            } else {
+                it.copy(
+                    progressState = progressInfo.state,
+                    progressValue = progressInfo.progress
+                )
+            }
+        }
+    }
+
+    private fun updateCurrentBridgeProgress(
+        bridges: List<TerminalBridge> = _uiState.value.bridges,
+        currentIndex: Int = _uiState.value.currentBridgeIndex
+    ) {
+        val progressInfo = bridges.getOrNull(currentIndex)?.progressState?.value
+        updateProgressState(progressInfo)
+    }
+
+    private fun findBridgeIndex(bridges: List<TerminalBridge>, bridgeHostId: Long?): Int {
+        if (bridgeHostId == null) {
+            return -1
+        }
+
+        return bridges.indexOfFirst { bridge ->
+            bridge.host.id == bridgeHostId
+        }
+    }
+
+    private fun stepBridgeSelection(offset: Int) {
+        val bridges = _uiState.value.bridges
+        if (bridges.isEmpty()) {
+            return
+        }
+
+        val newIndex = (_uiState.value.currentBridgeIndex + offset).coerceIn(0, bridges.lastIndex)
+        if (newIndex != _uiState.value.currentBridgeIndex) {
+            selectBridge(newIndex)
+        }
+    }
+
+    fun selectNextBridge() {
+        stepBridgeSelection(1)
+    }
+
+    fun selectPreviousBridge() {
+        stepBridgeSelection(-1)
+    }
+
+    private fun handleInitialSelectionError(message: String) {
+        pendingInitialHostId = null
+        _uiState.update {
+            it.copy(
+                isLoading = false,
+                error = message
+            )
         }
     }
 
@@ -171,85 +233,65 @@ class ConsoleViewModel @Inject constructor(
         withContext(dispatchers.io) {
             try {
                 val allBridges = terminalManager?.bridgesFlow?.value ?: emptyList()
-
-                // Check if we already have a bridge for this host
                 val existingBridge = allBridges.find { bridge ->
                     bridge.host.id == hostId
                 }
 
-                // If no bridge exists, create one using the service method
                 if (existingBridge == null) {
                     if (hostId < 0L) {
-                        // Temporary host - should already exist from MainActivity/URI handling
-                        _uiState.update {
-                            it.copy(
-                                isLoading = false,
-                                error = "Temporary connection not found",
-                            )
-                        }
+                        handleInitialSelectionError("Temporary connection not found")
                     } else {
-                        // Permanent host - create from database
                         val bridge = terminalManager?.openConnectionForHostId(hostId)
                         if (bridge == null) {
-                            _uiState.update {
-                                it.copy(
-                                    isLoading = false,
-                                    error = "Failed to open connection: host not found",
-                                )
-                            }
+                            handleInitialSelectionError("Failed to open connection: host not found")
                         }
                     }
                 }
             } catch (e: Exception) {
-                _uiState.update {
-                    it.copy(
-                        isLoading = false,
-                        error = e.message ?: "Failed to create connection",
-                    )
-                }
+                handleInitialSelectionError(e.message ?: "Failed to create connection")
             }
         }
     }
 
     private fun updateBridges(allBridges: List<TerminalBridge>) {
-        // If hostId is provided, try to find the bridge for this specific host
-        val filteredBridges = if (hostId != -1L) {
-            allBridges.filter { bridge ->
-                bridge.host.id == hostId
-            }
-        } else {
-            allBridges
+        val currentState = _uiState.value
+        val selectedIndex = findBridgeIndex(allBridges, selectedHostId)
+        val requestedIndex = findBridgeIndex(allBridges, pendingInitialHostId)
+        val requestedBridgeAvailable = requestedIndex != -1
+
+        val newIndex = when {
+            requestedBridgeAvailable -> requestedIndex
+            selectedIndex != -1 -> selectedIndex
+            currentState.currentBridgeIndex >= allBridges.size -> (allBridges.size - 1).coerceAtLeast(0)
+            else -> currentState.currentBridgeIndex
         }
+
+        if (requestedBridgeAvailable) {
+            pendingInitialHostId = null
+            selectedHostId = allBridges.getOrNull(newIndex)?.host?.id
+        } else if (pendingInitialHostId == null) {
+            selectedHostId = allBridges.getOrNull(newIndex)?.host?.id
+        }
+
+        val waitingForRequestedHost = pendingInitialHostId != null
 
         _uiState.update {
-            val newBridges = filteredBridges.ifEmpty { allBridges }
-            val newIndex = if (it.currentBridgeIndex >= newBridges.size) {
-                // Adjust index if it's now out of range
-                (newBridges.size - 1).coerceAtLeast(0)
-            } else {
-                it.currentBridgeIndex
-            }
-
-            // Stop loading when we have bridges, or when we're showing all bridges (hostId == -1)
-            // If waiting for a specific host, keep loading until that bridge appears
-            val shouldStopLoading = if (hostId != -1L) {
-                filteredBridges.isNotEmpty()
-            } else {
-                true // Always stop loading when showing all bridges
-            }
-
             it.copy(
-                bridges = newBridges,
+                bridges = allBridges,
                 currentBridgeIndex = newIndex,
-                isLoading = if (shouldStopLoading) false else it.isLoading,
-                error = null,
+                isLoading = waitingForRequestedHost,
+                error = null
             )
         }
+
+        updateCurrentBridgeProgress(allBridges, newIndex)
     }
 
     fun selectBridge(index: Int) {
         if (index in _uiState.value.bridges.indices) {
+            selectedHostId = _uiState.value.bridges[index].host.id
             _uiState.update { it.copy(currentBridgeIndex = index) }
+            updateCurrentBridgeProgress()
         }
     }
 

--- a/app/src/main/java/org/connectbot/ui/screens/console/ConsoleViewModel.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/console/ConsoleViewModel.kt
@@ -1,6 +1,6 @@
 /*
  * ConnectBot: simple, powerful, open-source SSH client for Android
- * Copyright 2025 Kenny Root
+ * Copyright 2025-2026 Kenny Root
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/org/connectbot/ui/screens/console/ConsoleViewModel.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/console/ConsoleViewModel.kt
@@ -152,7 +152,7 @@ class ConsoleViewModel @Inject constructor(
     private fun syncBridgeJobs(
         bridges: List<TerminalBridge>,
         jobs: MutableMap<Long, Job>,
-        createJob: (TerminalBridge) -> Job
+        createJob: (TerminalBridge) -> Job,
     ) {
         val activeHostIds = bridges.map { it.host.id }.toSet()
 
@@ -175,7 +175,7 @@ class ConsoleViewModel @Inject constructor(
             } else {
                 it.copy(
                     progressState = progressInfo.state,
-                    progressValue = progressInfo.progress
+                    progressValue = progressInfo.progress,
                 )
             }
         }
@@ -183,7 +183,7 @@ class ConsoleViewModel @Inject constructor(
 
     private fun updateCurrentBridgeProgress(
         bridges: List<TerminalBridge> = _uiState.value.bridges,
-        currentIndex: Int = _uiState.value.currentBridgeIndex
+        currentIndex: Int = _uiState.value.currentBridgeIndex,
     ) {
         val progressInfo = bridges.getOrNull(currentIndex)?.progressState?.value
         updateProgressState(progressInfo)
@@ -224,7 +224,7 @@ class ConsoleViewModel @Inject constructor(
         _uiState.update {
             it.copy(
                 isLoading = false,
-                error = message
+                error = message,
             )
         }
     }
@@ -280,7 +280,7 @@ class ConsoleViewModel @Inject constructor(
                 bridges = allBridges,
                 currentBridgeIndex = newIndex,
                 isLoading = waitingForRequestedHost,
-                error = null
+                error = null,
             )
         }
 

--- a/app/src/main/java/org/connectbot/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/settings/SettingsScreen.kt
@@ -189,6 +189,7 @@ fun SettingsScreen(
         onFullscreenChange = viewModel::updateFullscreen,
         onTitleBarHideChange = viewModel::updateTitleBarHide,
         onPgUpDnGestureChange = viewModel::updatePgUpDnGesture,
+        onSwipeSessionsChange = viewModel::updateSwipeSessions,
         onVolumeFontChange = viewModel::updateVolumeFont,
         onKeepAliveChange = viewModel::updateKeepAlive,
         onAlwaysVisibleChange = viewModel::updateAlwaysVisible,
@@ -233,6 +234,7 @@ fun SettingsScreenContent(
     onFullscreenChange: (Boolean) -> Unit,
     onTitleBarHideChange: (Boolean) -> Unit,
     onPgUpDnGestureChange: (Boolean) -> Unit,
+    onSwipeSessionsChange: (Boolean) -> Unit,
     onVolumeFontChange: (Boolean) -> Unit,
     onKeepAliveChange: (Boolean) -> Unit,
     onAlwaysVisibleChange: (Boolean) -> Unit,
@@ -526,6 +528,15 @@ fun SettingsScreenContent(
                     summary = stringResource(R.string.pref_pg_updn_gesture_summary),
                     checked = uiState.pgupdngesture,
                     onCheckedChange = onPgUpDnGestureChange,
+                )
+            }
+
+            item {
+                SwitchPreference(
+                    title = stringResource(R.string.pref_swipe_sessions_title),
+                    summary = stringResource(R.string.pref_swipe_sessions_summary),
+                    checked = uiState.swipeSessions,
+                    onCheckedChange = onSwipeSessionsChange
                 )
             }
 
@@ -1542,6 +1553,7 @@ private fun SettingsScreenPreview() {
                 titlebarhide = false,
                 fullscreen = true,
                 pgupdngesture = true,
+                swipeSessions = false,
                 volumefont = true,
                 keepalive = true,
                 alwaysvisible = true,
@@ -1587,6 +1599,7 @@ private fun SettingsScreenPreview() {
             onFullscreenChange = {},
             onTitleBarHideChange = {},
             onPgUpDnGestureChange = {},
+            onSwipeSessionsChange = {},
             onVolumeFontChange = {},
             onKeepAliveChange = {},
             onAlwaysVisibleChange = {},

--- a/app/src/main/java/org/connectbot/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/settings/SettingsScreen.kt
@@ -536,7 +536,7 @@ fun SettingsScreenContent(
                     title = stringResource(R.string.pref_swipe_sessions_title),
                     summary = stringResource(R.string.pref_swipe_sessions_summary),
                     checked = uiState.swipeSessions,
-                    onCheckedChange = onSwipeSessionsChange
+                    onCheckedChange = onSwipeSessionsChange,
                 )
             }
 

--- a/app/src/main/java/org/connectbot/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/settings/SettingsScreen.kt
@@ -1,6 +1,6 @@
 /*
  * ConnectBot: simple, powerful, open-source SSH client for Android
- * Copyright 2025 Kenny Root
+ * Copyright 2025-2026 Kenny Root
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/org/connectbot/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/settings/SettingsViewModel.kt
@@ -62,6 +62,7 @@ data class SettingsUiState(
     val titlebarhide: Boolean = false,
     val fullscreen: Boolean = false,
     val pgupdngesture: Boolean = false,
+    val swipeSessions: Boolean = false,
     val volumefont: Boolean = true,
     val keepalive: Boolean = true,
     val alwaysvisible: Boolean = false,
@@ -199,6 +200,7 @@ class SettingsViewModel @Inject constructor(
             titlebarhide = prefs.getBoolean("titlebarhide", false),
             fullscreen = prefs.getBoolean("fullscreen", false),
             pgupdngesture = prefs.getBoolean("pgupdngesture", false),
+            swipeSessions = prefs.getBoolean(PreferenceConstants.SWIPE_SESSIONS, false),
             volumefont = prefs.getBoolean("volumefont", true),
             keepalive = prefs.getBoolean("keepalive", true),
             alwaysvisible = prefs.getBoolean("alwaysvisible", false),
@@ -313,6 +315,10 @@ class SettingsViewModel @Inject constructor(
 
     fun updatePgUpDnGesture(value: Boolean) {
         updateBooleanPref(PreferenceConstants.PG_UPDN_GESTURE, value) { copy(pgupdngesture = value) }
+    }
+
+    fun updateSwipeSessions(value: Boolean) {
+        updateBooleanPref(PreferenceConstants.SWIPE_SESSIONS, value) { copy(swipeSessions = value) }
     }
 
     fun updateVolumeFont(value: Boolean) {

--- a/app/src/main/java/org/connectbot/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/settings/SettingsViewModel.kt
@@ -1,6 +1,6 @@
 /*
  * ConnectBot: simple, powerful, open-source SSH client for Android
- * Copyright 2025 Kenny Root
+ * Copyright 2025-2026 Kenny Root
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/org/connectbot/util/PreferenceConstants.kt
+++ b/app/src/main/java/org/connectbot/util/PreferenceConstants.kt
@@ -38,6 +38,7 @@ object PreferenceConstants {
     const val FULLSCREEN: String = "fullscreen"
     const val TITLEBARHIDE: String = "titlebarhide"
     const val PG_UPDN_GESTURE: String = "pgupdngesture"
+    const val SWIPE_SESSIONS: String = "swipeSessions"
 
     const val KEYMODE: String = "keymode"
     const val KEY_ALWAYS_VISIBLE: String = "alwaysvisible"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -587,6 +587,10 @@
 
 	<!-- Button to reconnect to a disconnected host. -->
 	<string name="console_menu_reconnect">Reconnect</string>
+	<!-- Button to switch to the previous active terminal session. -->
+	<string name="console_previous_session">Previous session</string>
+	<!-- Button to switch to the next active terminal session. -->
+	<string name="console_next_session">Next session</string>
 	<!-- Button to close the disconnected terminal window. -->
 	<string name="console_menu_close">"Close"</string>
 	<!-- Button to paste from the clipboard to the terminal. -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -300,6 +300,10 @@
 	<string name="pref_pg_updn_gesture_title">"Page up/down gesture"</string>
 	<!-- Summary for the full screen preference -->
 	<string name="pref_pg_updn_gesture_summary">"Swipe the left third of the screen to send pg up/dn to the terminal"</string>
+	<!-- Name for the optional swipe-to-switch-sessions preference -->
+	<string name="pref_swipe_sessions_title">Swipe between sessions</string>
+	<!-- Summary for the optional swipe-to-switch-sessions preference -->
+	<string name="pref_swipe_sessions_summary">Enable horizontal swiping to switch terminal sessions. Off by default for accessibility.</string>
 
 	<!-- Name for the full screen preference -->
 	<string name="pref_fullscreen_title">"Full screen"</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -587,6 +587,8 @@
 
 	<!-- Button to reconnect to a disconnected host. -->
 	<string name="console_menu_reconnect">Reconnect</string>
+	<!-- Content description and dialog title for switching between active terminal sessions. -->
+	<string name="console_switch_session">Switch session</string>
 	<!-- Button to switch to the previous active terminal session. -->
 	<string name="console_previous_session">Previous session</string>
 	<!-- Button to switch to the next active terminal session. -->

--- a/app/src/test/kotlin/org/connectbot/SettingsScreenTest.kt
+++ b/app/src/test/kotlin/org/connectbot/SettingsScreenTest.kt
@@ -292,6 +292,7 @@ class SettingsScreenTest {
                     onVolumeFontChange = {},
                     onKeepAliveChange = {},
                     onAlwaysVisibleChange = {},
+                    onSwipeSessionsChange = {},
                     onShiftFkeysChange = {},
                     onCtrlFkeysChange = {},
                     onStickyModifiersChange = {},

--- a/app/src/test/kotlin/org/connectbot/ui/screens/console/ConsoleViewModelTest.kt
+++ b/app/src/test/kotlin/org/connectbot/ui/screens/console/ConsoleViewModelTest.kt
@@ -45,6 +45,7 @@ import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
 /**
@@ -130,6 +131,49 @@ class ConsoleViewModelTest {
     }
 
     @Test
+    fun loadBridges_WithRequestedHost_ShowsAllBridgesAndSelectsRequestedHost() = runTest {
+        val mockBridge1 = createMockBridge(1L, "host1")
+        val mockBridge2 = createMockBridge(2L, "host2")
+        bridgesFlow.value = listOf(mockBridge1, mockBridge2)
+        whenever(savedStateHandle.get<Long>("hostId")).thenReturn(2L)
+
+        val viewModel = ConsoleViewModel(savedStateHandle, dispatchers)
+        viewModel.setTerminalManager(terminalManager)
+
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertFalse("Should stop loading once the requested bridge is present", state.isLoading)
+        assertEquals("Should keep all active bridges visible", 2, state.bridges.size)
+        assertEquals("Requested host should be the selected bridge", 1, state.currentBridgeIndex)
+        assertEquals("Requested bridge should be active", 2L, state.bridges[state.currentBridgeIndex].host.id)
+    }
+
+    @Test
+    fun loadBridges_WhenRequestedHostIsOpening_KeepsLoadingUntilItAppears() = runTest {
+        val mockBridge1 = createMockBridge(1L, "host1")
+        val mockBridge2 = createMockBridge(2L, "host2")
+        bridgesFlow.value = listOf(mockBridge1)
+        whenever(savedStateHandle.get<Long>("hostId")).thenReturn(2L)
+        whenever(terminalManager.openConnectionForHostId(2L)).thenReturn(mockBridge2)
+
+        val viewModel = ConsoleViewModel(savedStateHandle, dispatchers)
+        viewModel.setTerminalManager(terminalManager)
+
+        advanceUntilIdle()
+
+        assertTrue("Should keep showing loading until the requested bridge is active", viewModel.uiState.value.isLoading)
+        verify(terminalManager).openConnectionForHostId(2L)
+
+        bridgesFlow.value = listOf(mockBridge1, mockBridge2)
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertFalse("Should stop loading once the requested bridge appears", state.isLoading)
+        assertEquals("Requested bridge should become active when it appears", 2L, state.bridges[state.currentBridgeIndex].host.id)
+    }
+
+    @Test
     fun loadBridges_WithMultipleBridges_LoadsAll() = runTest {
         val mockBridge1 = createMockBridge(1L, "host1")
         val mockBridge2 = createMockBridge(2L, "host2")
@@ -166,6 +210,41 @@ class ConsoleViewModelTest {
 
         val state = viewModel.uiState.value
         assertEquals("Current bridge index should be 1", 1, state.currentBridgeIndex)
+    }
+
+    @Test
+    fun selectNextBridge_UpdatesCurrentBridge() = runTest {
+        val mockBridge1 = createMockBridge(1L, "host1")
+        val mockBridge2 = createMockBridge(2L, "host2")
+        bridgesFlow.value = listOf(mockBridge1, mockBridge2)
+        whenever(savedStateHandle.get<Long>("hostId")).thenReturn(-1L)
+
+        val viewModel = ConsoleViewModel(savedStateHandle, dispatchers)
+        viewModel.setTerminalManager(terminalManager)
+
+        advanceUntilIdle()
+
+        viewModel.selectNextBridge()
+
+        assertEquals("Current bridge index should advance by one", 1, viewModel.uiState.value.currentBridgeIndex)
+    }
+
+    @Test
+    fun selectPreviousBridge_UpdatesCurrentBridge() = runTest {
+        val mockBridge1 = createMockBridge(1L, "host1")
+        val mockBridge2 = createMockBridge(2L, "host2")
+        bridgesFlow.value = listOf(mockBridge1, mockBridge2)
+        whenever(savedStateHandle.get<Long>("hostId")).thenReturn(-1L)
+
+        val viewModel = ConsoleViewModel(savedStateHandle, dispatchers)
+        viewModel.setTerminalManager(terminalManager)
+
+        advanceUntilIdle()
+        viewModel.selectBridge(1)
+
+        viewModel.selectPreviousBridge()
+
+        assertEquals("Current bridge index should move back by one", 0, viewModel.uiState.value.currentBridgeIndex)
     }
 
     @Test
@@ -297,6 +376,29 @@ class ConsoleViewModelTest {
         val state = viewModel.uiState.value
         assertEquals("Should have 2 bridges", 2, state.bridges.size)
         assertTrue("Current index should be adjusted to valid range", state.currentBridgeIndex < state.bridges.size)
+    }
+
+    @Test
+    fun onDisconnected_PreservesSelectedHost_WhenAnotherBridgeIsRemoved() = runTest {
+        val mockBridge1 = createMockBridge(1L, "host1")
+        val mockBridge2 = createMockBridge(2L, "host2")
+        val mockBridge3 = createMockBridge(3L, "host3")
+
+        bridgesFlow.value = listOf(mockBridge1, mockBridge2, mockBridge3)
+        whenever(savedStateHandle.get<Long>("hostId")).thenReturn(-1L)
+
+        val viewModel = ConsoleViewModel(savedStateHandle, dispatchers)
+        viewModel.setTerminalManager(terminalManager)
+
+        advanceUntilIdle()
+        viewModel.selectBridge(2)
+
+        bridgesFlow.value = listOf(mockBridge2, mockBridge3)
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertEquals("Should still have 2 bridges", 2, state.bridges.size)
+        assertEquals("Selected host should remain the same after another bridge is removed", 3L, state.bridges[state.currentBridgeIndex].host.id)
     }
 
     @Test
@@ -506,6 +608,27 @@ class ConsoleViewModelTest {
         assertFalse("Should not show warning when connPersist is true and permission granted", viewModel.shouldShowNotificationWarning())
     }
 
+    @Test
+    fun progressState_SwitchingBridgesShowsExistingProgressImmediately() = runTest {
+        val progressFlow1 =
+            MutableStateFlow<TerminalBridge.ProgressInfo?>(TerminalBridge.ProgressInfo(ProgressState.DEFAULT, 10))
+        val progressFlow2 =
+            MutableStateFlow<TerminalBridge.ProgressInfo?>(TerminalBridge.ProgressInfo(ProgressState.WARNING, 90))
+        val mockBridge1 = createMockBridge(1L, "host1", progressFlow1)
+        val mockBridge2 = createMockBridge(2L, "host2", progressFlow2)
+        bridgesFlow.value = listOf(mockBridge1, mockBridge2)
+        whenever(savedStateHandle.get<Long>("hostId")).thenReturn(-1L)
+
+        val viewModel = ConsoleViewModel(savedStateHandle, dispatchers, prefs, notificationPermissionHelper)
+        viewModel.setTerminalManager(terminalManager)
+
+        advanceUntilIdle()
+        viewModel.selectBridge(1)
+
+        assertEquals("Switching bridges should show the selected bridge's current progress state", ProgressState.WARNING, viewModel.uiState.value.progressState)
+        assertEquals("Switching bridges should show the selected bridge's current progress value", 90, viewModel.uiState.value.progressValue)
+    }
+
     private fun createMockBridge(
         id: Long,
         hostname: String,
@@ -520,7 +643,7 @@ class ConsoleViewModelTest {
             port = 22,
             username = "test",
         )
-        bridge.host = host
+        whenever(bridge.host).thenReturn(host)
         whenever(bridge.isSessionOpen).thenReturn(true)
         whenever(bridge.isDisconnected).thenReturn(false)
         whenever(bridge.bellEvents).thenReturn(MutableSharedFlow())

--- a/app/src/test/kotlin/org/connectbot/ui/screens/console/ConsoleViewModelTest.kt
+++ b/app/src/test/kotlin/org/connectbot/ui/screens/console/ConsoleViewModelTest.kt
@@ -1,6 +1,6 @@
 /*
  * ConnectBot: simple, powerful, open-source SSH client for Android
- * Copyright 2025 Kenny Root
+ * Copyright 2025-2026 Kenny Root
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/test/kotlin/org/connectbot/ui/screens/console/ConsoleViewModelTest.kt
+++ b/app/src/test/kotlin/org/connectbot/ui/screens/console/ConsoleViewModelTest.kt
@@ -137,7 +137,7 @@ class ConsoleViewModelTest {
         bridgesFlow.value = listOf(mockBridge1, mockBridge2)
         whenever(savedStateHandle.get<Long>("hostId")).thenReturn(2L)
 
-        val viewModel = ConsoleViewModel(savedStateHandle, dispatchers)
+        val viewModel = ConsoleViewModel(savedStateHandle, dispatchers, prefs, notificationPermissionHelper)
         viewModel.setTerminalManager(terminalManager)
 
         advanceUntilIdle()
@@ -157,7 +157,7 @@ class ConsoleViewModelTest {
         whenever(savedStateHandle.get<Long>("hostId")).thenReturn(2L)
         whenever(terminalManager.openConnectionForHostId(2L)).thenReturn(mockBridge2)
 
-        val viewModel = ConsoleViewModel(savedStateHandle, dispatchers)
+        val viewModel = ConsoleViewModel(savedStateHandle, dispatchers, prefs, notificationPermissionHelper)
         viewModel.setTerminalManager(terminalManager)
 
         advanceUntilIdle()
@@ -219,7 +219,7 @@ class ConsoleViewModelTest {
         bridgesFlow.value = listOf(mockBridge1, mockBridge2)
         whenever(savedStateHandle.get<Long>("hostId")).thenReturn(-1L)
 
-        val viewModel = ConsoleViewModel(savedStateHandle, dispatchers)
+        val viewModel = ConsoleViewModel(savedStateHandle, dispatchers, prefs, notificationPermissionHelper)
         viewModel.setTerminalManager(terminalManager)
 
         advanceUntilIdle()
@@ -236,7 +236,7 @@ class ConsoleViewModelTest {
         bridgesFlow.value = listOf(mockBridge1, mockBridge2)
         whenever(savedStateHandle.get<Long>("hostId")).thenReturn(-1L)
 
-        val viewModel = ConsoleViewModel(savedStateHandle, dispatchers)
+        val viewModel = ConsoleViewModel(savedStateHandle, dispatchers, prefs, notificationPermissionHelper)
         viewModel.setTerminalManager(terminalManager)
 
         advanceUntilIdle()
@@ -387,7 +387,7 @@ class ConsoleViewModelTest {
         bridgesFlow.value = listOf(mockBridge1, mockBridge2, mockBridge3)
         whenever(savedStateHandle.get<Long>("hostId")).thenReturn(-1L)
 
-        val viewModel = ConsoleViewModel(savedStateHandle, dispatchers)
+        val viewModel = ConsoleViewModel(savedStateHandle, dispatchers, prefs, notificationPermissionHelper)
         viewModel.setTerminalManager(terminalManager)
 
         advanceUntilIdle()

--- a/app/src/test/kotlin/org/connectbot/ui/screens/console/SessionSwipeNavigationTest.kt
+++ b/app/src/test/kotlin/org/connectbot/ui/screens/console/SessionSwipeNavigationTest.kt
@@ -18,7 +18,9 @@
 package org.connectbot.ui.screens.console
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class SessionSwipeNavigationTest {
@@ -98,6 +100,44 @@ class SessionSwipeNavigationTest {
                 dragY = 180f,
                 viewportWidth = 1000,
                 touchSlop = 20f,
+            ),
+        )
+    }
+
+    @Test
+    fun isSessionSwipeStartExcluded_excludesBottomArea() {
+        assertFalse(
+            isSessionSwipeStartExcluded(
+                startY = 969f,
+                viewportHeight = 1000,
+                excludedBottomHeightPx = 30f,
+            ),
+        )
+
+        assertTrue(
+            isSessionSwipeStartExcluded(
+                startY = 970f,
+                viewportHeight = 1000,
+                excludedBottomHeightPx = 30f,
+            ),
+        )
+    }
+
+    @Test
+    fun isSessionSwipeStartExcluded_ignoresInvalidExclusion() {
+        assertFalse(
+            isSessionSwipeStartExcluded(
+                startY = 999f,
+                viewportHeight = 1000,
+                excludedBottomHeightPx = 0f,
+            ),
+        )
+
+        assertFalse(
+            isSessionSwipeStartExcluded(
+                startY = 999f,
+                viewportHeight = 0,
+                excludedBottomHeightPx = 30f,
             ),
         )
     }

--- a/app/src/test/kotlin/org/connectbot/ui/screens/console/SessionSwipeNavigationTest.kt
+++ b/app/src/test/kotlin/org/connectbot/ui/screens/console/SessionSwipeNavigationTest.kt
@@ -1,0 +1,103 @@
+/*
+ * ConnectBot: simple, powerful, open-source SSH client for Android
+ * Copyright 2026 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.connectbot.ui.screens.console
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class SessionSwipeNavigationTest {
+    @Test
+    fun sessionSwipeTarget_leftSwipe_selectsNextSession() {
+        assertEquals(
+            1,
+            sessionSwipeTarget(
+                currentIndex = 0,
+                sessionCount = 3,
+                dragX = -220f,
+                dragY = 20f,
+                viewportWidth = 1000,
+                touchSlop = 20f,
+            ),
+        )
+    }
+
+    @Test
+    fun sessionSwipeTarget_rightSwipe_selectsPreviousSession() {
+        assertEquals(
+            1,
+            sessionSwipeTarget(
+                currentIndex = 2,
+                sessionCount = 3,
+                dragX = 220f,
+                dragY = 20f,
+                viewportWidth = 1000,
+                touchSlop = 20f,
+            ),
+        )
+    }
+
+    @Test
+    fun sessionSwipeTarget_doesNotMovePastBounds() {
+        assertNull(
+            sessionSwipeTarget(
+                currentIndex = 0,
+                sessionCount = 3,
+                dragX = 220f,
+                dragY = 20f,
+                viewportWidth = 1000,
+                touchSlop = 20f,
+            ),
+        )
+
+        assertNull(
+            sessionSwipeTarget(
+                currentIndex = 2,
+                sessionCount = 3,
+                dragX = -220f,
+                dragY = 20f,
+                viewportWidth = 1000,
+                touchSlop = 20f,
+            ),
+        )
+    }
+
+    @Test
+    fun sessionSwipeTarget_ignoresSmallOrVerticalDrags() {
+        assertNull(
+            sessionSwipeTarget(
+                currentIndex = 1,
+                sessionCount = 3,
+                dragX = -100f,
+                dragY = 0f,
+                viewportWidth = 1000,
+                touchSlop = 20f,
+            ),
+        )
+
+        assertNull(
+            sessionSwipeTarget(
+                currentIndex = 1,
+                sessionCount = 3,
+                dragX = -220f,
+                dragY = 180f,
+                viewportWidth = 1000,
+                touchSlop = 20f,
+            ),
+        )
+    }
+}

--- a/app/src/test/kotlin/org/connectbot/ui/screens/console/SessionSwipeNavigationTest.kt
+++ b/app/src/test/kotlin/org/connectbot/ui/screens/console/SessionSwipeNavigationTest.kt
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.connectbot.ui.screens.console
 
 import org.junit.Assert.assertEquals

--- a/app/src/test/kotlin/org/connectbot/ui/screens/console/SessionSwipeNavigationTest.kt
+++ b/app/src/test/kotlin/org/connectbot/ui/screens/console/SessionSwipeNavigationTest.kt
@@ -18,9 +18,7 @@
 package org.connectbot.ui.screens.console
 
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class SessionSwipeNavigationTest {
@@ -100,44 +98,6 @@ class SessionSwipeNavigationTest {
                 dragY = 180f,
                 viewportWidth = 1000,
                 touchSlop = 20f,
-            ),
-        )
-    }
-
-    @Test
-    fun isSessionSwipeStartExcluded_excludesBottomArea() {
-        assertFalse(
-            isSessionSwipeStartExcluded(
-                startY = 969f,
-                viewportHeight = 1000,
-                excludedBottomHeightPx = 30f,
-            ),
-        )
-
-        assertTrue(
-            isSessionSwipeStartExcluded(
-                startY = 970f,
-                viewportHeight = 1000,
-                excludedBottomHeightPx = 30f,
-            ),
-        )
-    }
-
-    @Test
-    fun isSessionSwipeStartExcluded_ignoresInvalidExclusion() {
-        assertFalse(
-            isSessionSwipeStartExcluded(
-                startY = 999f,
-                viewportHeight = 1000,
-                excludedBottomHeightPx = 0f,
-            ),
-        )
-
-        assertFalse(
-            isSessionSwipeStartExcluded(
-                startY = 999f,
-                viewportHeight = 0,
-                excludedBottomHeightPx = 30f,
             ),
         )
     }

--- a/app/src/test/kotlin/org/connectbot/ui/screens/console/SessionSwipeNavigationTest.kt
+++ b/app/src/test/kotlin/org/connectbot/ui/screens/console/SessionSwipeNavigationTest.kt
@@ -105,6 +105,21 @@ class SessionSwipeNavigationTest {
     }
 
     @Test
+    fun sessionSwipeTarget_ignoresDragsWhileSelectionActive() {
+        assertNull(
+            sessionSwipeTarget(
+                currentIndex = 1,
+                sessionCount = 3,
+                dragX = -220f,
+                dragY = 20f,
+                viewportWidth = 1000,
+                touchSlop = 20f,
+                selectionActive = true,
+            ),
+        )
+    }
+
+    @Test
     fun shouldShowSoftwareKeyboardForSessionOpen_showsOnlyForSameBridgeOpening() {
         assertTrue(
             shouldShowSoftwareKeyboardForSessionOpen(

--- a/app/src/test/kotlin/org/connectbot/ui/screens/console/SessionSwipeNavigationTest.kt
+++ b/app/src/test/kotlin/org/connectbot/ui/screens/console/SessionSwipeNavigationTest.kt
@@ -18,7 +18,9 @@
 package org.connectbot.ui.screens.console
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class SessionSwipeNavigationTest {
@@ -98,6 +100,72 @@ class SessionSwipeNavigationTest {
                 dragY = 180f,
                 viewportWidth = 1000,
                 touchSlop = 20f,
+            ),
+        )
+    }
+
+    @Test
+    fun shouldShowSoftwareKeyboardForSessionOpen_showsOnlyForSameBridgeOpening() {
+        assertTrue(
+            shouldShowSoftwareKeyboardForSessionOpen(
+                previousBridgeId = 1L,
+                previousSessionOpen = false,
+                currentBridgeId = 1L,
+                sessionOpen = true,
+                hasHardwareKeyboard = false,
+            ),
+        )
+
+        assertFalse(
+            shouldShowSoftwareKeyboardForSessionOpen(
+                previousBridgeId = 1L,
+                previousSessionOpen = true,
+                currentBridgeId = 2L,
+                sessionOpen = true,
+                hasHardwareKeyboard = false,
+            ),
+        )
+    }
+
+    @Test
+    fun shouldShowSoftwareKeyboardForSessionOpen_ignoresHardwareKeyboard() {
+        assertFalse(
+            shouldShowSoftwareKeyboardForSessionOpen(
+                previousBridgeId = 1L,
+                previousSessionOpen = false,
+                currentBridgeId = 1L,
+                sessionOpen = true,
+                hasHardwareKeyboard = true,
+            ),
+        )
+    }
+
+    @Test
+    fun shouldPreserveSoftwareKeyboardForBridgeChange_preservesOnlyVisibleSoftKeyboard() {
+        assertTrue(
+            shouldPreserveSoftwareKeyboardForBridgeChange(
+                previousBridgeId = 1L,
+                currentBridgeId = 2L,
+                showSoftwareKeyboard = true,
+                hasHardwareKeyboard = false,
+            ),
+        )
+
+        assertFalse(
+            shouldPreserveSoftwareKeyboardForBridgeChange(
+                previousBridgeId = 1L,
+                currentBridgeId = 2L,
+                showSoftwareKeyboard = false,
+                hasHardwareKeyboard = false,
+            ),
+        )
+
+        assertFalse(
+            shouldPreserveSoftwareKeyboardForBridgeChange(
+                previousBridgeId = 1L,
+                currentBridgeId = 2L,
+                showSoftwareKeyboard = true,
+                hasHardwareKeyboard = true,
             ),
         )
     }


### PR DESCRIPTION
Fix #2040 terminal session switching

  - Restore switching between active terminal sessions from the console chrome.
  - Add previous/next session menu actions and a session picker dialog.
  - Add an optional swipe-to-switch-sessions preference, disabled by default for accessibility.
  - Preserve selected session state as terminal bridges are added or removed.