### PR TITLE
fix: RSA host key algorithm handling

### DIFF
--- a/app/src/main/java/org/connectbot/data/HostRepository.kt
+++ b/app/src/main/java/org/connectbot/data/HostRepository.kt
@@ -50,6 +50,9 @@ class HostRepository @Inject constructor(
     private val knownHostDao: KnownHostDao,
     private val securePasswordStorage: SecurePasswordStorage,
 ) {
+    private companion object {
+        val RSA_HOST_KEY_ALGORITHMS = listOf("rsa-sha2-512", "rsa-sha2-256", "ssh-rsa")
+    }
 
     // ============================================================================
     // Host Operations
@@ -223,7 +226,14 @@ class HostRepository @Inject constructor(
      */
     suspend fun getHostKeyAlgorithmsForHost(hostId: Long): List<String> {
         val knownHosts = knownHostDao.getByHostId(hostId)
-        return knownHosts.map { it.hostKeyAlgo }.distinct()
+        return knownHosts
+            .flatMap { expandHostKeyAlgorithms(it.hostKeyAlgo) }
+            .distinct()
+    }
+
+    private fun expandHostKeyAlgorithms(algorithm: String): List<String> = when (algorithm) {
+        "rsa-sha2-512", "rsa-sha2-256", "ssh-rsa" -> RSA_HOST_KEY_ALGORITHMS
+        else -> listOf(algorithm)
     }
 
     /**
@@ -273,13 +283,19 @@ class HostRepository @Inject constructor(
      *
      * @param hostId The host ID
      * @param serverHostKeyAlgorithm The key algorithm
-     * @param serverHostKey The public key bytes
+     * @param serverHostKey The public key bytes, or null to remove all keys for the algorithm
      */
     suspend fun removeKnownHost(
         hostId: Long,
         serverHostKeyAlgorithm: String,
-        serverHostKey: ByteArray,
+        serverHostKey: ByteArray?,
     ) {
+        if (serverHostKey == null) {
+            expandHostKeyAlgorithms(serverHostKeyAlgorithm)
+                .forEach { knownHostDao.deleteByHostIdAndAlgo(hostId, it) }
+            return
+        }
+
         // Find the exact key to remove
         val knownHost = knownHostDao.getByHostIdAlgoAndKey(
             hostId,
@@ -366,7 +382,7 @@ class HostRepository @Inject constructor(
     fun removeKnownHostBlocking(
         hostId: Long,
         serverHostKeyAlgorithm: String,
-        serverHostKey: ByteArray,
+        serverHostKey: ByteArray?,
     ) = runBlocking {
         removeKnownHost(hostId, serverHostKeyAlgorithm, serverHostKey)
     }

--- a/app/src/main/java/org/connectbot/data/dao/KnownHostDao.kt
+++ b/app/src/main/java/org/connectbot/data/dao/KnownHostDao.kt
@@ -1,6 +1,6 @@
 /*
  * ConnectBot: simple, powerful, open-source SSH client for Android
- * Copyright 2025 Kenny Root
+ * Copyright 2025-2026 Kenny Root
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,6 +71,12 @@ interface KnownHostDao {
      */
     @Delete
     suspend fun delete(knownHost: KnownHost)
+
+    /**
+     * Delete all known hosts for a host configuration and algorithm.
+     */
+    @Query("DELETE FROM known_hosts WHERE host_id = :hostId AND host_key_algo = :algo")
+    suspend fun deleteByHostIdAndAlgo(hostId: Long, algo: String)
 
     /**
      * Delete a known host by hostname and port.

--- a/app/src/main/java/org/connectbot/transport/SSH.kt
+++ b/app/src/main/java/org/connectbot/transport/SSH.kt
@@ -1,6 +1,6 @@
 /*
  * ConnectBot: simple, powerful, open-source SSH client for Android
- * Copyright 2007 Kenny Root
+ * Copyright 2007-2026 Kenny Root
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import android.content.Context
 import android.net.Uri
 import android.security.keystore.KeyPermanentlyInvalidatedException
 import android.security.keystore.UserNotAuthenticatedException
+import androidx.annotation.VisibleForTesting
 import androidx.core.net.toUri
 import com.trilead.ssh2.AuthAgentCallback
 import com.trilead.ssh2.ChannelCondition
@@ -126,7 +127,7 @@ class SSH :
 
     private fun decodePublicKey(algorithm: String, keyBlob: ByteArray): PublicKey? = try {
         when (algorithm) {
-            "ssh-rsa" -> RSASHA1Verify.get().decodePublicKey(keyBlob)
+            "ssh-rsa", "rsa-sha2-256", "rsa-sha2-512" -> RSASHA1Verify.get().decodePublicKey(keyBlob)
             "ssh-dss" -> DSASHA1Verify.get().decodePublicKey(keyBlob)
             "ssh-ed25519" -> Ed25519Verify.get().decodePublicKey(keyBlob)
             "ecdsa-sha2-nistp256" -> ECDSASHA2Verify.ECDSASHA2NISTP256Verify.get().decodePublicKey(keyBlob)
@@ -147,16 +148,12 @@ class SSH :
         else -> 0
     }
 
-    private fun getKeyType(openSshKeyType: String): String? = if (openSshKeyType == "ssh-rsa") {
-        "RSA"
-    } else if (openSshKeyType == "ssh-dss") {
-        "DSA"
-    } else if (openSshKeyType == "ssh-ed25519") {
-        "Ed25519"
-    } else if (openSshKeyType.startsWith("ecdsa-sha2-")) {
-        "EC"
-    } else {
-        null
+    @VisibleForTesting
+    internal fun getKeyType(openSshKeyType: String): String? = when (openSshKeyType) {
+        "ssh-rsa", "rsa-sha2-256", "rsa-sha2-512" -> "RSA"
+        "ssh-dss" -> "DSA"
+        "ssh-ed25519" -> "Ed25519"
+        else -> if (openSshKeyType.startsWith("ecdsa-sha2-")) "EC" else null
     }
 
     inner class HostKeyVerifier(private val verifyHost: Host? = host) : ExtendedServerHostKeyVerifier() {
@@ -303,7 +300,7 @@ class SSH :
             manager?.hostRepository?.getHostKeyAlgorithmsForHostBlocking(hostId)
         }
 
-        override fun removeServerHostKey(host: String, port: Int, algorithm: String, hostKey: ByteArray) {
+        override fun removeServerHostKey(host: String, port: Int, algorithm: String, hostKey: ByteArray?) {
             verifyHost?.id?.let { hostId ->
                 manager?.hostRepository?.removeKnownHostBlocking(hostId, algorithm, hostKey)
             }

--- a/app/src/test/kotlin/org/connectbot/data/HostRepositoryKnownHostTest.kt
+++ b/app/src/test/kotlin/org/connectbot/data/HostRepositoryKnownHostTest.kt
@@ -1,6 +1,6 @@
 /*
  * ConnectBot: simple, powerful, open-source SSH client for Android
- * Copyright 2025 Kenny Root
+ * Copyright 2025-2026 Kenny Root
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -98,5 +98,105 @@ class HostRepositoryKnownHostTest {
         // hosts table is still empty and no dangling known_hosts row exists.
         assertThat(database.hostDao().getAll()).isEmpty()
         assertThat(database.knownHostDao().getAll()).isEmpty()
+    }
+
+    @Test
+    fun getHostKeyAlgorithmsForHost_withRsaKey_includesSha2Variants() = runTest {
+        val host = Host(
+            nickname = "rsa",
+            protocol = "ssh",
+            username = "root",
+            hostname = "example.com",
+            port = 22,
+        )
+        val hostId = database.hostDao().insert(host)
+        val savedHost = host.copy(id = hostId)
+
+        repository.saveKnownHost(
+            host = savedHost,
+            hostname = "example.com",
+            port = 22,
+            serverHostKeyAlgorithm = "ssh-rsa",
+            serverHostKey = "server-rsa-key".toByteArray(),
+        )
+
+        assertThat(repository.getHostKeyAlgorithmsForHost(hostId))
+            .containsExactlyInAnyOrder("rsa-sha2-512", "rsa-sha2-256", "ssh-rsa")
+    }
+
+    @Test
+    fun getHostKeyAlgorithmsForHost_withNoKnownHosts_returnsEmptyList() = runTest {
+        assertThat(repository.getHostKeyAlgorithmsForHost(123L)).isEmpty()
+    }
+
+    @Test
+    fun getHostKeyAlgorithmsForHost_withMixedKeys_expandsOnlyRsaKey() = runTest {
+        val host = Host(
+            nickname = "mixed",
+            protocol = "ssh",
+            username = "root",
+            hostname = "example.com",
+            port = 22,
+        )
+        val hostId = database.hostDao().insert(host)
+        val savedHost = host.copy(id = hostId)
+
+        repository.saveKnownHost(
+            host = savedHost,
+            hostname = "example.com",
+            port = 22,
+            serverHostKeyAlgorithm = "rsa-sha2-256",
+            serverHostKey = "server-rsa-key".toByteArray(),
+        )
+        repository.saveKnownHost(
+            host = savedHost,
+            hostname = "example.com",
+            port = 22,
+            serverHostKeyAlgorithm = "ssh-ed25519",
+            serverHostKey = "server-ed25519-key".toByteArray(),
+        )
+
+        assertThat(repository.getHostKeyAlgorithmsForHost(hostId))
+            .containsExactly("rsa-sha2-512", "rsa-sha2-256", "ssh-rsa", "ssh-ed25519")
+    }
+
+    @Test
+    fun removeKnownHost_withNullRsaKey_removesAllRsaAlgorithmVariants() = runTest {
+        val host = Host(
+            nickname = "rsa",
+            protocol = "ssh",
+            username = "root",
+            hostname = "example.com",
+            port = 22,
+        )
+        val hostId = database.hostDao().insert(host)
+        val savedHost = host.copy(id = hostId)
+
+        repository.saveKnownHost(
+            host = savedHost,
+            hostname = "example.com",
+            port = 22,
+            serverHostKeyAlgorithm = "ssh-rsa",
+            serverHostKey = "server-rsa-key".toByteArray(),
+        )
+        repository.saveKnownHost(
+            host = savedHost,
+            hostname = "example.com",
+            port = 22,
+            serverHostKeyAlgorithm = "rsa-sha2-256",
+            serverHostKey = "server-rsa-sha2-key".toByteArray(),
+        )
+        repository.saveKnownHost(
+            host = savedHost,
+            hostname = "example.com",
+            port = 22,
+            serverHostKeyAlgorithm = "ssh-ed25519",
+            serverHostKey = "server-ed25519-key".toByteArray(),
+        )
+
+        repository.removeKnownHost(hostId, "rsa-sha2-512", null)
+
+        val remaining = database.knownHostDao().getByHostId(hostId)
+        assertThat(remaining.map { it.hostKeyAlgo }).containsExactly("ssh-ed25519")
     }
 }

--- a/app/src/test/kotlin/org/connectbot/transport/SSHTest.kt
+++ b/app/src/test/kotlin/org/connectbot/transport/SSHTest.kt
@@ -1,0 +1,48 @@
+/*
+ * ConnectBot: simple, powerful, open-source SSH client for Android
+ * Copyright 2026 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.connectbot.transport
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+@RunWith(Parameterized::class)
+class SSHTest(
+    private val algorithm: String,
+    private val expectedKeyType: String?,
+) {
+    @Test
+    fun getKeyType_returnsDisplayName() {
+        assertThat(SSH().getKeyType(algorithm)).isEqualTo(expectedKeyType)
+    }
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters(name = "{0} -> {1}")
+        fun data(): List<Array<Any?>> = listOf(
+            arrayOf("ssh-rsa", "RSA"),
+            arrayOf("rsa-sha2-256", "RSA"),
+            arrayOf("rsa-sha2-512", "RSA"),
+            arrayOf("ssh-dss", "DSA"),
+            arrayOf("ssh-ed25519", "Ed25519"),
+            arrayOf("ecdsa-sha2-nistp256", "EC"),
+            arrayOf("unknown", null),
+        )
+    }
+}


### PR DESCRIPTION
Existing RSA known-host rows can be stored as ssh-rsa, but sshlib filters its KEX host key offer to the algorithms returned by ConnectBot's verifier. Expand any known RSA host key to rsa-sha2-512, rsa-sha2-256, and ssh-rsa so servers that no longer offer ssh-rsa can still negotiate an RSA SHA-2 host key.

Also tolerate sshlib hostkeys updates that remove an algorithm without providing a key blob, and cover the RSA display mapping and repository behavior with tests.

Fixes issue with `rsa-sha2-*` upgrades mentioned in #844