### PR TITLE
fix: display Tailscale SSH auth URL during connect (#1150)

### DIFF
--- a/app/src/main/java/org/connectbot/service/Relay.kt
+++ b/app/src/main/java/org/connectbot/service/Relay.kt
@@ -1,6 +1,6 @@
 /*
  * ConnectBot: simple, powerful, open-source SSH client for Android
- * Copyright 2025 Kenny Root
+ * Copyright 2025-2026 Kenny Root
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -135,6 +135,7 @@ class Relay(
 
                     if (destBuffer.hasRemaining()) {
                         bridge.terminalEmulator.writeInput(destBuffer.array(), 0, destBuffer.limit())
+                        bridge.recordForUrlScan(destBuffer.array(), 0, destBuffer.limit())
                     }
                     destBuffer.clear()
                     charBuffer.compact()
@@ -150,6 +151,7 @@ class Relay(
                                         0,
                                         destBuffer.limit(),
                                     )
+                                    bridge.recordForUrlScan(destBuffer.array(), 0, destBuffer.limit())
                                 }
                                 destBuffer.clear()
 

--- a/app/src/main/java/org/connectbot/service/TerminalBridge.kt
+++ b/app/src/main/java/org/connectbot/service/TerminalBridge.kt
@@ -1,6 +1,6 @@
 /*
  * ConnectBot: simple, powerful, open-source SSH client for Android
- * Copyright 2025 Kenny Root
+ * Copyright 2025-2026 Kenny Root
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -181,6 +181,14 @@ class TerminalBridge {
     private val fontSizeChangedListeners: MutableList<FontSizeChangedListener>
 
     private val localOutput: MutableList<String>
+
+    // Rolling buffer of recent terminal output, used only by [scanForURLs]. Bytes are stored as
+    // Latin-1 chars (1:1) so URL ASCII bytes survive regardless of the terminal's encoding.
+    // Escape sequences are kept in-buffer — they don't form URL-like substrings, and stripping
+    // them would require an ANSI parser this scan-only path doesn't need.
+    private val urlScanBuffer = StringBuilder()
+    private val urlScanBufferLock = Any()
+    private val urlScanBufferLimit = 64 * 1024
 
     /**
      * Flag indicating if we should perform a full-screen redraw during our next
@@ -526,7 +534,27 @@ class TerminalBridge {
 
                 localOutput.add(s)
 
-                terminalEmulator.writeInput(s.encodeToByteArray())
+                val bytes = s.encodeToByteArray()
+                terminalEmulator.writeInput(bytes)
+                recordForUrlScan(bytes, 0, bytes.size)
+            }
+        }
+    }
+
+    /**
+     * Append a chunk of raw terminal-bound bytes to the URL-scan buffer, oldest content dropped
+     * when the buffer exceeds [urlScanBufferLimit]. Called from [outputLine] and from [Relay] so
+     * URL scanning works for both pre-auth banner text and live PTY output.
+     */
+    fun recordForUrlScan(data: ByteArray, offset: Int, length: Int) {
+        if (length <= 0) return
+        synchronized(urlScanBufferLock) {
+            for (i in offset until offset + length) {
+                urlScanBuffer.append((data[i].toInt() and 0xFF).toChar())
+            }
+            val excess = urlScanBuffer.length - urlScanBufferLimit
+            if (excess > 0) {
+                urlScanBuffer.delete(0, excess)
             }
         }
     }
@@ -964,24 +992,14 @@ class TerminalBridge {
         }
     }
 
-    /**
-     * @return
-     */
     fun scanForURLs(): List<String> {
-        // buffer!! is intentional - buffer is initialized in constructor and must be non-null
-        val urls = mutableListOf<String>()
-
-        // TODO(Terminal): replace URL scanner
-//        val visibleBuffer = CharArray(buffer!!.height * buffer!!.width)
-//        for (l in 0 until buffer!!.height)
-//            System.arraycopy(buffer!!.charArray[buffer!!.windowBase + l], 0,
-//                    visibleBuffer, l * buffer!!.width, buffer!!.width)
-//
-//        val urlMatcher = PatternHolder.urlPattern.matcher(String(visibleBuffer))
-//        while (urlMatcher.find())
-//            urls.add(urlMatcher.group())
-
-        return urls
+        val text = synchronized(urlScanBufferLock) { urlScanBuffer.toString() }
+        val urls = LinkedHashSet<String>()
+        val matcher = PatternHolder.urlPattern.matcher(text)
+        while (matcher.find()) {
+            urls.add(matcher.group())
+        }
+        return urls.toList()
     }
 
     /**

--- a/app/src/main/java/org/connectbot/transport/SSH.kt
+++ b/app/src/main/java/org/connectbot/transport/SSH.kt
@@ -43,6 +43,12 @@ import com.trilead.ssh2.signature.DSASHA1Verify
 import com.trilead.ssh2.signature.ECDSASHA2Verify
 import com.trilead.ssh2.signature.Ed25519Verify
 import com.trilead.ssh2.signature.RSASHA1Verify
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
 import org.connectbot.R
 import org.connectbot.data.entity.Host
 import org.connectbot.data.entity.KeyStorageType
@@ -330,7 +336,50 @@ class SSH :
 
         try {
             val currentHost = host ?: return
-            if (connection?.authenticateWithNone(currentHost.username) == true) {
+
+            // Start a polling coroutine to surface SSH_MSG_USERAUTH_BANNER while
+            // authenticateWithNone is blocking. Tailscale sends its web-login URL in a banner
+            // and waits for the user to finish that login before sending USERAUTH_SUCCESS, so
+            // the call below blocks indefinitely without ever returning the banner content.
+            //
+            // org.connectbot:sshlib 2.2.46 has no public banner accessor — the field is
+            // package-private on AuthenticationManager and `Connection.am` itself is private —
+            // so we reach in via reflection. Once sshlib gains a public Connection.getBanner()
+            // (upstream trilead-ssh2 already has List<String> getBanners()), this block can be
+            // replaced with `connection?.getBanner()` and the bannerField/amField lookups
+            // deleted. See https://github.com/connectbot/sshlib for the upstream library.
+            var bannerJob: Job? = null
+            if (bridge != null) {
+                bannerJob = CoroutineScope(Dispatchers.IO).launch {
+                    try {
+                        var lastBanner: String? = null
+                        while (isActive) {
+                            val conn = connection ?: break
+                            val amField = conn.javaClass.getDeclaredField("am")
+                            amField.isAccessible = true
+                            val am = amField.get(conn)
+                            if (am != null) {
+                                val bannerField = am.javaClass.getDeclaredField("banner")
+                                bannerField.isAccessible = true
+                                val bannerStr = bannerField.get(am) as? String
+                                if (bannerStr != null && bannerStr != lastBanner) {
+                                    lastBanner = bannerStr
+                                    // Remove any trailing newlines since outputLine adds its own
+                                    bridge?.outputLine(bannerStr.trimEnd('\r', '\n'))
+                                }
+                            }
+                            delay(200)
+                        }
+                    } catch (e: Exception) {
+                        Timber.d(e, "Reflection banner polling failed")
+                    }
+                }
+            }
+
+            val authNoneSuccess = connection?.authenticateWithNone(currentHost.username) == true
+            bannerJob?.cancel()
+
+            if (authNoneSuccess) {
                 finishConnection()
                 return
             }
@@ -1199,6 +1248,12 @@ class SSH :
         echo: BooleanArray,
     ): Array<String> {
         interactiveCanContinue = true
+        if (name.isNotEmpty()) {
+            bridge?.outputLine(name)
+        }
+        if (instruction.isNotEmpty()) {
+            bridge?.outputLine(instruction)
+        }
         val responses = Array(numPrompts) { i ->
             // request response from user for each prompt
             val isPassword = i < echo.size && !echo[i]


### PR DESCRIPTION
## Summary

Fixes #1150 — Tailscale-managed sshd asks the user to visit a web URL
to finish authentication, sending the URL via `SSH_MSG_USERAUTH_BANNER`
and only emitting `USERAUTH_SUCCESS` once the user has logged in on the
web. Two issues prevented this from working in ConnectBot:

- **The banner never reached the terminal.** trilead-ssh2's
  `authenticateWithNone` blocks waiting for the auth reply and stashes
  any banner it receives in a private field, so the URL was invisible
  and the connection looked frozen until Tailscale eventually gave up.
  Worked around by polling that field via reflection while
  `authenticateWithNone` is blocked, echoing each new value through
  `bridge.outputLine`. The polling job is cancelled as soon as
  `authenticateWithNone` returns.
- **URL Scan couldn't see the URL.** `TerminalBridge.scanForURLs()`
  had been stubbed (`TODO(Terminal): replace URL scanner`) during the
  termlib migration, so the menu always reported "No URLs found in
  terminal buffer". Replaced with a small rolling 64 KB Latin-1 buffer
  that captures bytes as they flow to `terminalEmulator.writeInput`
  (both from `outputLine` and from `Relay`), then runs the existing
  RFC 2396 regex over that buffer. This avoids touching termlib
  internals or relying on its `softWrapped` flag (which is unreliable
  for `outputLine`-written text).

Also surfaces the `name`/`instruction` fields of keyboard-interactive
auth so servers that explain context via those fields are no longer
silent before the prompt.

## Test plan

- [x] Connect to a Tailscale-managed sshd; verify the
      `# To authenticate, visit: https://login.tailscale.com/a/...`
      banner appears in the terminal during the auth wait.
- [x] Open the URL Scan menu while waiting; verify the full URL is
      listed (no truncation at the soft-wrap point).
- [x] Complete the web login; verify the SSH session opens normally.
- [x] Connect to a regular (non-Tailscale) sshd; verify no regression
      in normal auth flow or in URL Scan over PTY output.
- [x] `./gradlew spotlessCheck` passes.