### PR TITLE
fix(url-scan): use termlib for URL scanning

### DIFF
--- a/app/src/main/java/org/connectbot/service/TerminalBridge.kt
+++ b/app/src/main/java/org/connectbot/service/TerminalBridge.kt
@@ -1,6 +1,6 @@
 /*
  * ConnectBot: simple, powerful, open-source SSH client for Android
- * Copyright 2025 Kenny Root
+ * Copyright 2025-2026 Kenny Root
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,6 +51,7 @@ import org.connectbot.terminal.DelKeyMode
 import org.connectbot.terminal.ProgressState
 import org.connectbot.terminal.TerminalEmulator
 import org.connectbot.terminal.TerminalEmulatorFactory
+import org.connectbot.terminal.UrlScanScope
 import org.connectbot.transport.AbsTransport
 import org.connectbot.transport.SSH
 import org.connectbot.transport.TransportFactory
@@ -60,7 +61,6 @@ import timber.log.Timber
 import java.io.IOException
 import java.nio.charset.Charset
 import java.util.concurrent.CopyOnWriteArrayList
-import java.util.regex.Pattern
 
 /**
  * Provides a bridge between a MUD terminal buffer and a possible TerminalView.
@@ -929,60 +929,7 @@ class TerminalBridge {
     val isConnecting: Boolean
         get() = connecting
 
-    private object PatternHolder {
-        val urlPattern: Pattern
-
-        init {
-            // based on http://www.ietf.org/rfc/rfc2396.txt
-            val scheme = "[A-Za-z][-+.0-9A-Za-z]*"
-            val unreserved = "[-._~0-9A-Za-z]"
-            val pctEncoded = "%[0-9A-Fa-f]{2}"
-            val subDelims = "[!${'$'}&'()*+,;:=]"
-            val userinfo = "(?:$unreserved|$pctEncoded|$subDelims|:)*"
-            val h16 = "[0-9A-Fa-f]{1,4}"
-            val decOctet = "(?:[0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])"
-            val ipv4address = "$decOctet\\.$decOctet\\.$decOctet\\.$decOctet"
-            val ls32 = "(?:$h16:$h16|$ipv4address)"
-            val ipv6address = "(?:(?:$h16){6}$ls32)"
-            val ipvfuture = "v[0-9A-Fa-f]+.(?:$unreserved|$subDelims|:)+"
-            val ipLiteral = "\\[(?:$ipv6address|$ipvfuture)\\]"
-            val regName = "(?:$unreserved|$pctEncoded|$subDelims)*"
-            val host = "(?:$ipLiteral|$ipv4address|$regName)"
-            val port = "[0-9]*"
-            val authority = "(?:$userinfo@)?$host(?::$port)?"
-            val pchar = "(?:$unreserved|$pctEncoded|$subDelims|@)"
-            val segment = "$pchar*"
-            val pathAbempty = "(?:/$segment)*"
-            val segmentNz = "$pchar+"
-            val pathAbsolute = "/(?:$segmentNz(?:/$segment)*)?"
-            val pathRootless = "$segmentNz(?:/$segment)*"
-            val hierPart = "(?://$authority$pathAbempty|$pathAbsolute|$pathRootless)"
-            val query = "(?:$pchar|/|\\?)*"
-            val fragment = "(?:$pchar|/|\\?)*"
-            val uriRegex = "$scheme:$hierPart(?:$query)?(?:#$fragment)?"
-            urlPattern = Pattern.compile(uriRegex)
-        }
-    }
-
-    /**
-     * @return
-     */
-    fun scanForURLs(): List<String> {
-        // buffer!! is intentional - buffer is initialized in constructor and must be non-null
-        val urls = mutableListOf<String>()
-
-        // TODO(Terminal): replace URL scanner
-//        val visibleBuffer = CharArray(buffer!!.height * buffer!!.width)
-//        for (l in 0 until buffer!!.height)
-//            System.arraycopy(buffer!!.charArray[buffer!!.windowBase + l], 0,
-//                    visibleBuffer, l * buffer!!.width, buffer!!.width)
-//
-//        val urlMatcher = PatternHolder.urlPattern.matcher(String(visibleBuffer))
-//        while (urlMatcher.find())
-//            urls.add(urlMatcher.group())
-
-        return urls
-    }
+    fun scanForURLs(): List<String> = terminalEmulator.getUrls(UrlScanScope.CurrentView).map { it.url }
 
     /**
      * @return


### PR DESCRIPTION
Now that termlib has URL scanning API, we can fix tihs missing function in ConnectBot's new UI.