### PR TITLE
chore(HostEditorScreen): make edits to nickname clearer

### DIFF
--- a/app/src/main/java/org/connectbot/ui/screens/hosteditor/HostEditorScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/hosteditor/HostEditorScreen.kt
@@ -144,7 +144,9 @@ fun HostEditorScreenContent(
     modifier: Modifier = Modifier,
 ) {
     var showProtocolMenu by remember { mutableStateOf(false) }
-    var expandedMode by remember { mutableStateOf(hostId != -1L) }
+    var expandedMode by remember(uiState.isLoading) {
+        mutableStateOf(hostId != -1L && !uiState.isNicknameMatching)
+    }
     val protocols = listOf("ssh", "telnet", "local")
 
     Scaffold(
@@ -236,8 +238,8 @@ fun HostEditorScreenContent(
                     singleLine = true,
                 )
 
-                // Show collapse button only if this is a new host (not editing existing)
-                if (hostId == -1L) {
+                // Show collapse button if this is a new host or the nickname is matching
+                if (hostId == -1L || uiState.isNicknameMatching) {
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()

--- a/app/src/main/java/org/connectbot/ui/screens/hosteditor/HostEditorViewModel.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/hosteditor/HostEditorViewModel.kt
@@ -33,6 +33,7 @@ import org.connectbot.data.PubkeyRepository
 import org.connectbot.data.entity.Host
 import org.connectbot.data.entity.Profile
 import org.connectbot.data.entity.Pubkey
+import org.connectbot.transport.Transport
 import org.connectbot.util.SecurePasswordStorage
 import javax.inject.Inject
 
@@ -62,7 +63,18 @@ data class HostEditorUiState(
     val hasExistingPassword: Boolean = false,
     val isLoading: Boolean = false,
     val error: String? = null,
-)
+) {
+    val isNicknameMatching: Boolean
+        get() {
+            if (nickname.isBlank()) return true
+            if (protocol == "local") return false
+            val defaultPort = (Transport.fromProtocol(protocol)?.defaultPort ?: 0).toString()
+            val effectivePort = port.ifBlank { defaultPort }
+            val repWithPort = if (username.isNotEmpty() && protocol == "ssh") "$username@$hostname:$effectivePort" else "$hostname:$effectivePort"
+            val repWithoutPort = if (username.isNotEmpty() && protocol == "ssh") "$username@$hostname" else hostname
+            return nickname == repWithPort || (effectivePort == defaultPort && nickname == repWithoutPort)
+        }
+}
 
 @HiltViewModel
 class HostEditorViewModel @Inject constructor(
@@ -124,6 +136,37 @@ class HostEditorViewModel @Inject constructor(
         }
     }
 
+    private fun getDefaultPort(protocol: String): String = (Transport.fromProtocol(protocol)?.defaultPort ?: 0).toString()
+
+    private fun getHostRepresentation(username: String, hostname: String, port: String, protocol: String): String {
+        if (protocol == "local") return ""
+        val defaultPort = getDefaultPort(protocol)
+        return buildString {
+            if (username.isNotEmpty() && protocol == "ssh") {
+                append(username)
+                append('@')
+            }
+            append(hostname)
+            if (port.isNotEmpty() && port != defaultPort) {
+                append(':')
+                append(port)
+            }
+        }
+    }
+
+    private fun updateNicknameIfMatching(
+        oldState: HostEditorUiState,
+        newState: HostEditorUiState,
+    ): HostEditorUiState {
+        if (newState.protocol == "local") return newState
+        val newRep = getHostRepresentation(newState.username, newState.hostname, newState.port, newState.protocol)
+        return if (oldState.isNicknameMatching) {
+            newState.copy(nickname = newRep, quickConnect = newRep)
+        } else {
+            newState.copy(quickConnect = newRep)
+        }
+    }
+
     private fun loadHost() {
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true) }
@@ -131,6 +174,23 @@ class HostEditorViewModel @Inject constructor(
                 val host = repository.findHostById(hostId)
                 if (host != null) {
                     val hasPassword = securePasswordStorage.hasPassword(hostId)
+                    val tempState = HostEditorUiState(
+                        nickname = host.nickname,
+                        protocol = host.protocol,
+                        username = host.username,
+                        hostname = host.hostname,
+                        port = host.port.toString(),
+                    )
+                    val quickConnect = if (tempState.isNicknameMatching) {
+                        host.nickname
+                    } else {
+                        getHostRepresentation(
+                            host.username,
+                            host.hostname,
+                            host.port.toString(),
+                            host.protocol,
+                        )
+                    }
                     _uiState.update {
                         it.copy(
                             nickname = host.nickname,
@@ -138,6 +198,7 @@ class HostEditorViewModel @Inject constructor(
                             username = host.username,
                             hostname = host.hostname,
                             port = host.port.toString(),
+                            quickConnect = quickConnect,
                             color = host.color ?: "gray",
                             pubkeyId = host.pubkeyId,
                             profileId = host.profileId,
@@ -166,43 +227,89 @@ class HostEditorViewModel @Inject constructor(
         }
     }
 
+    private fun parseQuickConnect(value: String): Triple<String, String, String>? {
+        val regex = Regex("^(?:([^@]+)@)?((?:[0-9a-zA-Z._-]+)|(?:\\[[a-fA-F:0-9]+(?:%[-_.a-zA-Z0-9]+)?\\]))(?::(\\d+))?$")
+        val match = regex.find(value) ?: return null
+        val (username, hostname, port) = match.destructured
+        val isValid = hostname.isNotBlank() && (
+            (hostname.startsWith("[") && hostname.endsWith("]")) ||
+                hostname.all { it.isLetterOrDigit() || it == '.' || it == '-' || it == '_' }
+            )
+        return if (isValid) {
+            Triple(username.ifBlank { "" }, hostname, port)
+        } else {
+            null
+        }
+    }
+
     fun updateNickname(value: String) {
         _uiState.update { it.copy(nickname = value) }
+
+        if (_uiState.value.protocol == "local") {
+            _uiState.update { it.copy(quickConnect = value) }
+            return
+        }
+
+        val parsed = parseQuickConnect(value)
+        if (parsed != null) {
+            val (username, hostname, port) = parsed
+            _uiState.update { state ->
+                val parsedPort = port.ifBlank { getDefaultPort(state.protocol) }
+                val newRep = getHostRepresentation(username, hostname, parsedPort, state.protocol)
+                state.copy(
+                    username = username,
+                    hostname = hostname,
+                    port = parsedPort,
+                    quickConnect = newRep,
+                )
+            }
+        }
     }
 
     fun updateProtocol(value: String) {
-        _uiState.update { it.copy(protocol = value) }
+        _uiState.update { old ->
+            val updated = old.copy(protocol = value)
+            updateNicknameIfMatching(old, updated)
+        }
     }
 
     fun updateUsername(value: String) {
-        _uiState.update { it.copy(username = value) }
+        _uiState.update { old ->
+            val updated = old.copy(username = value)
+            updateNicknameIfMatching(old, updated)
+        }
     }
 
     fun updateHostname(value: String) {
-        _uiState.update { it.copy(hostname = value) }
+        _uiState.update { old ->
+            val updated = old.copy(hostname = value)
+            updateNicknameIfMatching(old, updated)
+        }
     }
 
     fun updatePort(value: String) {
         // Only allow numeric input
         if (value.isEmpty() || value.all { it.isDigit() }) {
-            _uiState.update { it.copy(port = value) }
+            _uiState.update { old ->
+                val updated = old.copy(port = value)
+                updateNicknameIfMatching(old, updated)
+            }
         }
     }
 
     fun updateQuickConnect(value: String) {
-        _uiState.update { it.copy(quickConnect = value) }
+        _uiState.update { it.copy(quickConnect = value, nickname = value) }
 
-        // Parse quick connect string: [user@]hostname[:port]
-        val regex = Regex("^(?:([^@]+)@)?([^:]+)(?::(\\d+))?$")
-        val match = regex.find(value)
+        if (_uiState.value.protocol == "local") return
 
-        if (match != null) {
-            val (username, hostname, port) = match.destructured
-            _uiState.update {
-                it.copy(
-                    username = username.ifBlank { "" },
+        val parsed = parseQuickConnect(value)
+        if (parsed != null) {
+            val (username, hostname, port) = parsed
+            _uiState.update { state ->
+                state.copy(
+                    username = username,
                     hostname = hostname,
-                    port = port.ifBlank { "22" },
+                    port = port.ifBlank { getDefaultPort(state.protocol) },
                 )
             }
         }
@@ -286,7 +393,7 @@ class HostEditorViewModel @Inject constructor(
                     protocol = state.protocol,
                     username = state.username,
                     hostname = state.hostname,
-                    port = state.port.toIntOrNull() ?: 22,
+                    port = state.port.toIntOrNull() ?: getDefaultPort(state.protocol).toIntOrNull() ?: 22,
                     color = state.color.takeIf { it != "gray" },
                     pubkeyId = state.pubkeyId,
                     profileId = state.profileId,

--- a/app/src/test/kotlin/org/connectbot/ui/screens/hosteditor/HostEditorViewModelTest.kt
+++ b/app/src/test/kotlin/org/connectbot/ui/screens/hosteditor/HostEditorViewModelTest.kt
@@ -1,0 +1,463 @@
+/*
+ * ConnectBot: simple, powerful, open-source SSH client for Android
+ * Copyright 2026 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.connectbot.ui.screens.hosteditor
+
+import android.content.SharedPreferences
+import androidx.lifecycle.SavedStateHandle
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.connectbot.data.HostRepository
+import org.connectbot.data.ProfileRepository
+import org.connectbot.data.PubkeyRepository
+import org.connectbot.data.entity.Host
+import org.connectbot.util.SecurePasswordStorage
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.ArgumentCaptor
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class HostEditorViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    private lateinit var savedStateHandle: SavedStateHandle
+    private lateinit var repository: HostRepository
+    private lateinit var pubkeyRepository: PubkeyRepository
+    private lateinit var profileRepository: ProfileRepository
+    private lateinit var prefs: SharedPreferences
+    private lateinit var securePasswordStorage: SecurePasswordStorage
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+
+        savedStateHandle = SavedStateHandle()
+        repository = mock(HostRepository::class.java)
+        pubkeyRepository = mock(PubkeyRepository::class.java)
+        profileRepository = mock(ProfileRepository::class.java)
+        prefs = mock(SharedPreferences::class.java)
+        securePasswordStorage = mock(SecurePasswordStorage::class.java)
+
+        // Mock default behavior for observe calls
+        `when`(pubkeyRepository.observeAll()).thenReturn(flowOf(emptyList()))
+        `when`(repository.observeSshHosts()).thenReturn(flowOf(emptyList()))
+        `when`(profileRepository.observeAll()).thenReturn(flowOf(emptyList()))
+        `when`(prefs.getLong("defaultProfileId", 0L)).thenReturn(0L)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun createViewModel(hostId: Long = -1L): HostEditorViewModel {
+        savedStateHandle["hostId"] = hostId
+        return HostEditorViewModel(
+            savedStateHandle = savedStateHandle,
+            repository = repository,
+            pubkeyRepository = pubkeyRepository,
+            profileRepository = profileRepository,
+            prefs = prefs,
+            securePasswordStorage = securePasswordStorage,
+        )
+    }
+
+    @Test
+    fun testNewHost_initializesWithDefaultState() = runTest {
+        val viewModel = createViewModel(-1L)
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertEquals(-1L, state.hostId)
+        assertEquals("", state.nickname)
+        assertEquals("ssh", state.protocol)
+        assertEquals("", state.username)
+        assertEquals("", state.hostname)
+        assertEquals("22", state.port)
+        assertTrue(state.isNicknameMatching)
+    }
+
+    @Test
+    fun testLoadExistingHost_populatesFields() = runTest {
+        val hostId = 42L
+        val existingHost = Host(
+            id = hostId,
+            nickname = "test-nick",
+            protocol = "telnet",
+            username = "test-user",
+            hostname = "10.0.0.1",
+            port = 23,
+        )
+        `when`(repository.findHostById(hostId)).thenReturn(existingHost)
+        `when`(securePasswordStorage.hasPassword(hostId)).thenReturn(true)
+
+        val viewModel = createViewModel(hostId)
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertEquals(hostId, state.hostId)
+        assertEquals("test-nick", state.nickname)
+        assertEquals("telnet", state.protocol)
+        assertEquals("test-user", state.username)
+        assertEquals("10.0.0.1", state.hostname)
+        assertEquals("23", state.port)
+        assertEquals("10.0.0.1", state.quickConnect) // Verify quickConnect is populated
+        assertTrue(state.hasExistingPassword)
+        assertFalse(state.isNicknameMatching)
+    }
+
+    @Test
+    fun testLoadExistingHost_matchingNickname_isNicknameMatchingIsTrue() = runTest {
+        val hostId = 42L
+        val existingHost = Host(
+            id = hostId,
+            nickname = "test-user@10.0.0.1:22",
+            protocol = "ssh",
+            username = "test-user",
+            hostname = "10.0.0.1",
+            port = 22,
+        )
+        `when`(repository.findHostById(hostId)).thenReturn(existingHost)
+        `when`(securePasswordStorage.hasPassword(hostId)).thenReturn(false)
+
+        val viewModel = createViewModel(hostId)
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertTrue(state.isNicknameMatching)
+    }
+
+    @Test
+    fun testUpdateNickname_withValidQuickConnect_syncsFields() = runTest {
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        // Syncs hostname
+        viewModel.updateNickname("192.168.1.100")
+        advanceUntilIdle()
+        assertEquals("192.168.1.100", viewModel.uiState.value.hostname)
+        assertEquals("", viewModel.uiState.value.username)
+        assertEquals("22", viewModel.uiState.value.port)
+
+        // Syncs username, hostname, port
+        viewModel.updateNickname("john@myhost:2222")
+        advanceUntilIdle()
+        assertEquals("myhost", viewModel.uiState.value.hostname)
+        assertEquals("john", viewModel.uiState.value.username)
+        assertEquals("2222", viewModel.uiState.value.port)
+    }
+
+    @Test
+    fun testUpdateNickname_withFriendlyName_doesNotOverwriteFields() = runTest {
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        // Set explicit host settings first
+        viewModel.updateHostname("192.168.1.1")
+        viewModel.updateUsername("user")
+        viewModel.updatePort("22")
+        advanceUntilIdle()
+
+        // Change nickname to a friendly label containing spaces
+        viewModel.updateNickname("My Home Server")
+        advanceUntilIdle()
+
+        // Should keep old hostname, username, port
+        assertEquals("My Home Server", viewModel.uiState.value.nickname)
+        assertEquals("192.168.1.1", viewModel.uiState.value.hostname)
+        assertEquals("user", viewModel.uiState.value.username)
+        assertEquals("22", viewModel.uiState.value.port)
+    }
+
+    @Test
+    fun testUpdateHostFields_syncsNickname_whenNicknameWasMatching() = runTest {
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        // Start with nickname in sync with default host/port representation
+        viewModel.updateQuickConnect("user@192.168.1.1:22")
+        advanceUntilIdle()
+
+        // Change hostname directly
+        viewModel.updateHostname("192.168.1.2")
+        advanceUntilIdle()
+
+        // Nickname and quickConnect should automatically update
+        assertEquals("user@192.168.1.2", viewModel.uiState.value.nickname)
+        assertEquals("user@192.168.1.2", viewModel.uiState.value.quickConnect)
+
+        // Change port directly
+        viewModel.updatePort("2222")
+        advanceUntilIdle()
+
+        assertEquals("user@192.168.1.2:2222", viewModel.uiState.value.nickname)
+        assertEquals("user@192.168.1.2:2222", viewModel.uiState.value.quickConnect)
+    }
+
+    @Test
+    fun testUpdateHostFields_doesNotSyncNickname_whenNicknameWasCustom() = runTest {
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        // Start with nickname in sync
+        viewModel.updateQuickConnect("user@192.168.1.1")
+        advanceUntilIdle()
+
+        // Change nickname to a custom friendly name
+        viewModel.updateNickname("My Custom Server")
+        advanceUntilIdle()
+
+        // Change hostname directly
+        viewModel.updateHostname("192.168.1.2")
+        advanceUntilIdle()
+
+        // Nickname should NOT change, but quickConnect should change
+        assertEquals("My Custom Server", viewModel.uiState.value.nickname)
+        assertEquals("user@192.168.1.2", viewModel.uiState.value.quickConnect)
+    }
+
+    @Test
+    fun testSaveHost_persistsUpdatedValues() = runTest {
+        val hostId = 42L
+        val existingHost = Host(
+            id = hostId,
+            nickname = "test-user@10.0.0.1",
+            protocol = "ssh",
+            username = "test-user",
+            hostname = "10.0.0.1",
+            port = 22,
+        )
+        `when`(repository.findHostById(hostId)).thenReturn(existingHost)
+        `when`(securePasswordStorage.hasPassword(hostId)).thenReturn(false)
+        // Mock saveHost to return the saved host (needed for password handling)
+        `when`(repository.saveHost(any(Host::class.java) ?: Host())).thenAnswer { invocation ->
+            invocation.arguments[0] as Host
+        }
+
+        val viewModel = createViewModel(hostId)
+        advanceUntilIdle()
+
+        // Modify host values in Expanded Mode (default for editing)
+        viewModel.updateHostname("10.0.0.2")
+        viewModel.updatePort("2222")
+        viewModel.updateUsername("new-user")
+        advanceUntilIdle()
+
+        viewModel.saveHost(useExpandedMode = true)
+        advanceUntilIdle()
+
+        // Capture saved host and verify it was updated
+        val hostCaptor = ArgumentCaptor.forClass(Host::class.java)
+        verify(repository).saveHost(hostCaptor.capture() ?: Host())
+        val savedHost = hostCaptor.value
+
+        assertEquals(hostId, savedHost.id)
+        assertEquals("10.0.0.2", savedHost.hostname)
+        assertEquals(2222, savedHost.port)
+        assertEquals("new-user", savedHost.username)
+        assertEquals("new-user@10.0.0.2:2222", savedHost.nickname) // Sync updated nickname
+    }
+
+    @Test
+    fun testSaveHost_customNickname_doesNotSync() = runTest {
+        val hostId = 42L
+        val existingHost = Host(
+            id = hostId,
+            nickname = "My Custom Server",
+            protocol = "ssh",
+            username = "test-user",
+            hostname = "10.0.0.1",
+            port = 22,
+        )
+        `when`(repository.findHostById(hostId)).thenReturn(existingHost)
+        `when`(securePasswordStorage.hasPassword(hostId)).thenReturn(false)
+        `when`(repository.saveHost(any(Host::class.java) ?: Host())).thenAnswer { invocation ->
+            invocation.arguments[0] as Host
+        }
+
+        val viewModel = createViewModel(hostId)
+        advanceUntilIdle()
+
+        viewModel.updateHostname("10.0.0.2")
+        advanceUntilIdle()
+
+        viewModel.saveHost(useExpandedMode = true)
+        advanceUntilIdle()
+
+        val hostCaptor = ArgumentCaptor.forClass(Host::class.java)
+        verify(repository).saveHost(hostCaptor.capture() ?: Host())
+        val savedHost = hostCaptor.value
+
+        assertEquals("My Custom Server", savedHost.nickname) // Nickname untouched
+        assertEquals("10.0.0.2", savedHost.hostname)
+    }
+
+    @Test
+    fun testUpdateNickname_withIPv6_syncsFields() = runTest {
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.updateNickname("[2001:db8::1]")
+        advanceUntilIdle()
+        assertEquals("[2001:db8::1]", viewModel.uiState.value.hostname)
+        assertEquals("", viewModel.uiState.value.username)
+        assertEquals("22", viewModel.uiState.value.port)
+        assertEquals("[2001:db8::1]", viewModel.uiState.value.quickConnect)
+    }
+
+    @Test
+    fun testUpdateNickname_withIPv6AndPort_syncsFields() = runTest {
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.updateNickname("admin@[2001:db8::1]:8022")
+        advanceUntilIdle()
+        assertEquals("[2001:db8::1]", viewModel.uiState.value.hostname)
+        assertEquals("admin", viewModel.uiState.value.username)
+        assertEquals("8022", viewModel.uiState.value.port)
+        assertEquals("admin@[2001:db8::1]:8022", viewModel.uiState.value.quickConnect)
+    }
+
+    @Test
+    fun testUpdateQuickConnect_withIPv6_syncsFields() = runTest {
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.updateQuickConnect("[2001:db8::1]")
+        advanceUntilIdle()
+        assertEquals("[2001:db8::1]", viewModel.uiState.value.hostname)
+        assertEquals("", viewModel.uiState.value.username)
+        assertEquals("22", viewModel.uiState.value.port)
+        assertEquals("[2001:db8::1]", viewModel.uiState.value.nickname)
+    }
+
+    @Test
+    fun testUpdateQuickConnect_withIPv6AndPort_syncsFields() = runTest {
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.updateQuickConnect("admin@[2001:db8::1]:8022")
+        advanceUntilIdle()
+        assertEquals("[2001:db8::1]", viewModel.uiState.value.hostname)
+        assertEquals("admin", viewModel.uiState.value.username)
+        assertEquals("8022", viewModel.uiState.value.port)
+        assertEquals("admin@[2001:db8::1]:8022", viewModel.uiState.value.nickname)
+    }
+
+    @Test
+    fun testIsNicknameMatching_blankPort_isMatching() = runTest {
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        // Syncs hostname/port. Set port to blank.
+        viewModel.updateQuickConnect("john@myhost")
+        advanceUntilIdle()
+        viewModel.updatePort("")
+        advanceUntilIdle()
+
+        // Nickname should still be matching
+        assertTrue(viewModel.uiState.value.isNicknameMatching)
+    }
+
+    @Test
+    fun testSaveHost_blankPort_usesDefaultPort() = runTest {
+        val hostId = 42L
+        val existingHost = Host(
+            id = hostId,
+            nickname = "test-user@10.0.0.1",
+            protocol = "telnet",
+            username = "test-user",
+            hostname = "10.0.0.1",
+            port = 23,
+        )
+        `when`(repository.findHostById(hostId)).thenReturn(existingHost)
+        `when`(securePasswordStorage.hasPassword(hostId)).thenReturn(false)
+        `when`(repository.saveHost(any(Host::class.java) ?: Host())).thenAnswer { invocation ->
+            invocation.arguments[0] as Host
+        }
+
+        val viewModel = createViewModel(hostId)
+        advanceUntilIdle()
+
+        viewModel.updatePort("") // Clear the port
+        advanceUntilIdle()
+
+        viewModel.saveHost(useExpandedMode = true)
+        advanceUntilIdle()
+
+        val hostCaptor = ArgumentCaptor.forClass(Host::class.java)
+        verify(repository).saveHost(hostCaptor.capture() ?: Host())
+        val savedHost = hostCaptor.value
+
+        assertEquals(23, savedHost.port) // Falls back to telnet default port 23
+    }
+
+    @Test
+    fun testLocalProtocol_doesNotSyncNicknameOrQuickConnect() = runTest {
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.updateProtocol("local")
+        viewModel.updateNickname("my-local-shell")
+        advanceUntilIdle()
+
+        // Changing hostname or username shouldn't sync nickname or quickConnect
+        viewModel.updateHostname("somehost")
+        viewModel.updateUsername("someuser")
+        advanceUntilIdle()
+
+        assertEquals("my-local-shell", viewModel.uiState.value.nickname)
+        // Since isNicknameMatching is false for local, quickConnect shouldn't sync either
+        assertEquals("my-local-shell", viewModel.uiState.value.quickConnect)
+    }
+
+    @Test
+    fun testLoadExistingHost_matchingNickname_initializesQuickConnectToNickname() = runTest {
+        val hostId = 42L
+        val existingHost = Host(
+            id = hostId,
+            nickname = "test-user@10.0.0.1:22",
+            protocol = "ssh",
+            username = "test-user",
+            hostname = "10.0.0.1",
+            port = 22,
+        )
+        `when`(repository.findHostById(hostId)).thenReturn(existingHost)
+        `when`(securePasswordStorage.hasPassword(hostId)).thenReturn(false)
+
+        val viewModel = createViewModel(hostId)
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertEquals("test-user@10.0.0.1:22", state.quickConnect)
+    }
+}


### PR DESCRIPTION
When the "quick connect" matches the host, changing the nickname should update hostname, username, etc. However, when it does not match it should be clearer that it is just the nickname. The hostname and port should be expanded to make it clearer.

Fixes #2222