### PR TITLE
chore: updating nickname does not sync when expanded

### DIFF
--- a/app/src/main/java/org/connectbot/ui/screens/hosteditor/HostEditorScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/hosteditor/HostEditorScreen.kt
@@ -92,7 +92,7 @@ fun HostEditorScreen(
         uiState = uiState,
         onNavigateBack = onNavigateBack,
         onQuickConnectChange = viewModel::updateQuickConnect,
-        onNicknameChange = viewModel::updateNickname,
+        onNicknameChange = { nickname, isExpanded -> viewModel.updateNickname(nickname, isExpanded) },
         onProtocolChange = viewModel::updateProtocol,
         onUsernameChange = viewModel::updateUsername,
         onHostnameChange = viewModel::updateHostname,
@@ -122,7 +122,7 @@ fun HostEditorScreenContent(
     uiState: HostEditorUiState,
     onNavigateBack: () -> Unit,
     onQuickConnectChange: (String) -> Unit,
-    onNicknameChange: (String) -> Unit,
+    onNicknameChange: (String, Boolean) -> Unit,
     onProtocolChange: (String) -> Unit,
     onUsernameChange: (String) -> Unit,
     onHostnameChange: (String) -> Unit,
@@ -232,32 +232,36 @@ fun HostEditorScreenContent(
                 // Expanded mode
                 OutlinedTextField(
                     value = uiState.nickname,
-                    onValueChange = onNicknameChange,
+                    onValueChange = { onNicknameChange(it, expandedMode) },
                     label = { Text(stringResource(R.string.hostpref_nickname_title)) },
                     modifier = Modifier.fillMaxWidth(),
                     singleLine = true,
                 )
 
-                // Show collapse button if this is a new host or the nickname is matching
-                if (hostId == -1L || uiState.isNicknameMatching) {
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .clickable { expandedMode = false }
-                            .padding(vertical = 8.dp),
-                    ) {
-                        Text(
-                            text = stringResource(R.string.host_editor_hide_advanced),
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.primary,
-                        )
-                        Spacer(Modifier.width(4.dp))
-                        Icon(
-                            Icons.Default.ExpandLess,
-                            contentDescription = stringResource(R.string.button_collapse),
-                            tint = MaterialTheme.colorScheme.primary,
-                        )
-                    }
+                val isCollapseEnabled = uiState.isNicknameMatching
+                val collapseColor = if (isCollapseEnabled) {
+                    MaterialTheme.colorScheme.primary
+                } else {
+                    MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
+                }
+
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable(enabled = isCollapseEnabled) { expandedMode = false }
+                        .padding(vertical = 8.dp),
+                ) {
+                    Text(
+                        text = stringResource(R.string.host_editor_hide_advanced),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = collapseColor,
+                    )
+                    Spacer(Modifier.width(4.dp))
+                    Icon(
+                        Icons.Default.ExpandLess,
+                        contentDescription = stringResource(R.string.button_collapse),
+                        tint = collapseColor,
+                    )
                 }
             }
 
@@ -1259,7 +1263,7 @@ private fun HostEditorScreenPreview() {
             ),
             onNavigateBack = {},
             onQuickConnectChange = {},
-            onNicknameChange = {},
+            onNicknameChange = { _, _ -> },
             onProtocolChange = {},
             onUsernameChange = {},
             onHostnameChange = {},

--- a/app/src/main/java/org/connectbot/ui/screens/hosteditor/HostEditorViewModel.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/hosteditor/HostEditorViewModel.kt
@@ -242,8 +242,12 @@ class HostEditorViewModel @Inject constructor(
         }
     }
 
-    fun updateNickname(value: String) {
+    fun updateNickname(value: String, isExpanded: Boolean = false) {
         _uiState.update { it.copy(nickname = value) }
+
+        if (isExpanded) {
+            return
+        }
 
         if (_uiState.value.protocol == "local") {
             _uiState.update { it.copy(quickConnect = value) }

--- a/app/src/test/kotlin/org/connectbot/ui/screens/hosteditor/HostEditorViewModelTest.kt
+++ b/app/src/test/kotlin/org/connectbot/ui/screens/hosteditor/HostEditorViewModelTest.kt
@@ -199,6 +199,28 @@ class HostEditorViewModelTest {
     }
 
     @Test
+    fun testUpdateNickname_whenExpanded_doesNotSyncFields() = runTest {
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        // Set explicit host settings first
+        viewModel.updateHostname("192.168.1.1")
+        viewModel.updateUsername("user")
+        viewModel.updatePort("22")
+        advanceUntilIdle()
+
+        // Change nickname with isExpanded = true
+        viewModel.updateNickname("john@myhost:2222", isExpanded = true)
+        advanceUntilIdle()
+
+        // Should keep old hostname, username, port, but update nickname
+        assertEquals("john@myhost:2222", viewModel.uiState.value.nickname)
+        assertEquals("192.168.1.1", viewModel.uiState.value.hostname)
+        assertEquals("user", viewModel.uiState.value.username)
+        assertEquals("22", viewModel.uiState.value.port)
+    }
+
+    @Test
     fun testUpdateHostFields_syncsNickname_whenNicknameWasMatching() = runTest {
         val viewModel = createViewModel()
         advanceUntilIdle()


### PR DESCRIPTION
In order to break the lock from quick-connect and nickname, do not update the user, host, and port when the advanced options is expanded.

Slight tweak for fixing #2222 