### PR TITLE
Fix virtual keyboard overlap

### DIFF
--- a/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
@@ -23,7 +23,6 @@ import android.content.ClipboardManager
 import android.content.Context
 import androidx.annotation.VisibleForTesting
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -86,7 +85,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.input.key.Key
@@ -127,7 +125,6 @@ import org.connectbot.ui.LocalTerminalManager
 import org.connectbot.ui.components.FloatingTextInputDialog
 import org.connectbot.ui.components.InlinePrompt
 import org.connectbot.ui.components.ResizeDialog
-import org.connectbot.ui.components.TERMINAL_KEYBOARD_HEIGHT_DP
 import org.connectbot.ui.components.TerminalKeyboard
 import org.connectbot.ui.components.UrlScanDialog
 import org.connectbot.ui.theme.terminal
@@ -605,7 +602,6 @@ fun ConsoleScreen(
                             modifier = Modifier
                                 .weight(1f)
                                 .fillMaxWidth()
-                                .animateContentSize()
                                 .testTag("terminal"),
                             typeface = fontResult.typeface,
                             initialFontSize = fontSize.sp,

--- a/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
@@ -23,6 +23,7 @@ import android.content.ClipboardManager
 import android.content.Context
 import androidx.annotation.VisibleForTesting
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -572,9 +573,8 @@ fun ConsoleScreen(
 
                     val bridge = uiState.bridges[uiState.currentBridgeIndex]
 
-                    // Terminal view fills entire space with insets padding
-                    // to avoid content being cut off by screen curves/notches
-                    Box(
+                    // Terminal view with keyboard stacked below (not overlapping)
+                    Column(
                         modifier = Modifier
                             .fillMaxSize()
                             .padding(
@@ -603,10 +603,9 @@ fun ConsoleScreen(
                         Terminal(
                             terminalEmulator = bridge.terminalEmulator,
                             modifier = Modifier
-                                .fillMaxSize()
-                                .padding(
-                                    bottom = if (keyboardAlwaysVisible) TERMINAL_KEYBOARD_HEIGHT_DP.dp else 0.dp,
-                                )
+                                .weight(1f)
+                                .fillMaxWidth()
+                                .animateContentSize()
                                 .testTag("terminal"),
                             typeface = fontResult.typeface,
                             initialFontSize = fontSize.sp,
@@ -636,40 +635,7 @@ fun ConsoleScreen(
                             }
                         }
 
-                        // Terminal keyboard overlay (doesn't resize terminal)
-                        // Must be BEFORE prompts so prompts appear on top
-                        // Fade in/out animation matches ConsoleActivity (100ms duration)
-                        AnimatedVisibility(
-                            visible = showExtraKeyboard,
-                            enter = fadeIn(animationSpec = tween(durationMillis = 100)),
-                            exit = fadeOut(animationSpec = tween(durationMillis = 100)),
-                            modifier = Modifier
-                                .align(Alignment.BottomCenter)
-                                .testTag("terminal_keyboard"),
-                        ) {
-                            TerminalKeyboard(
-                                bridge = bridge,
-                                onInteraction = { handleTerminalInteraction() },
-                                onHideIme = {
-                                    showSoftwareKeyboard = false
-                                },
-                                onShowIme = {
-                                    showSoftwareKeyboard = true
-                                },
-                                onOpenTextInput = {
-                                    showTextInputDialog = true
-                                },
-                                onScrollInProgressChange = { inProgress ->
-                                    keyboardScrollInProgress = inProgress
-                                    handleTerminalInteraction()
-                                },
-                                imeVisible = imeVisible,
-                                playAnimation = !hasPlayedKeyboardAnimation,
-                            )
-                        }
-
-                        // Show inline prompts from the current bridge (non-modal at bottom)
-                        // Must be AFTER keyboard so prompts appear on top (z-order)
+                        // Show inline prompts from the current bridge (above keyboard)
                         val promptState by bridge.promptManager.promptState.collectAsState()
 
                         InlinePrompt(
@@ -683,8 +649,6 @@ fun ConsoleScreen(
                             onDismiss = {
                                 termFocusRequester.requestFocus()
                             },
-                            modifier = Modifier
-                                .align(Alignment.BottomCenter),
                         )
 
                         // Show reconnect/close overlay when session is disconnected
@@ -692,7 +656,6 @@ fun ConsoleScreen(
                             visible = disconnected && !connecting && promptState == null,
                             enter = slideInVertically(initialOffsetY = { it }),
                             exit = slideOutVertically(targetOffsetY = { it }),
-                            modifier = Modifier.align(Alignment.BottomCenter),
                         ) {
                             val terminalColors = MaterialTheme.colorScheme.terminal
                             Column(
@@ -725,6 +688,34 @@ fun ConsoleScreen(
                                     }
                                 }
                             }
+                        }
+
+                        // Terminal keyboard at the bottom (stacked below terminal, not overlay)
+                        AnimatedVisibility(
+                            visible = showExtraKeyboard,
+                            enter = fadeIn(animationSpec = tween(durationMillis = 100)),
+                            exit = fadeOut(animationSpec = tween(durationMillis = 100)),
+                            modifier = Modifier.testTag("terminal_keyboard"),
+                        ) {
+                            TerminalKeyboard(
+                                bridge = bridge,
+                                onInteraction = { handleTerminalInteraction() },
+                                onHideIme = {
+                                    showSoftwareKeyboard = false
+                                },
+                                onShowIme = {
+                                    showSoftwareKeyboard = true
+                                },
+                                onOpenTextInput = {
+                                    showTextInputDialog = true
+                                },
+                                onScrollInProgressChange = { inProgress ->
+                                    keyboardScrollInProgress = inProgress
+                                    handleTerminalInteraction()
+                                },
+                                imeVisible = imeVisible,
+                                playAnimation = !hasPlayedKeyboardAnimation,
+                            )
                         }
                     }
                 }

--- a/docs/MODULE_VIRTUAL_KEYBOARD.md
+++ b/docs/MODULE_VIRTUAL_KEYBOARD.md
@@ -1,0 +1,472 @@
+# 虚拟按键模块文档
+
+> 本文档详细说明 ConnectBot 虚拟按键（Virtual Keyboard）的实现，包括 UI 结构、功能逻辑和修改指南。
+
+---
+
+## 1. 模块概述
+
+虚拟按键是 ConnectBot 终端界面底部的一行特殊按键，提供 Esc、Ctrl、方向键、F1-F12 等终端常用键，弥补移动设备物理键盘缺失的问题。
+
+### 功能特性
+
+- **Ctrl 修饰键**：支持三态切换（OFF → 临时 → 锁定 → OFF）
+- **方向键**：支持长按自动重复
+- **触觉反馈**：方向键可选的震动反馈（Bumpy Arrows）
+- **水平滚动**：按键过多时可左右滑动
+- **自动隐藏**：闲置一段时间后自动隐藏（由父组件控制）
+
+---
+
+## 2. 核心文件
+
+| 文件路径 | 职责 |
+|----------|------|
+| `app/src/main/java/org/connectbot/ui/components/TerminalKeyboard.kt` | UI 组件定义 |
+| `app/src/main/java/org/connectbot/service/TerminalKeyListener.kt` | 按键逻辑和修饰键状态管理 |
+| `app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt` | 集成虚拟键盘到终端界面 |
+| `app/src/main/java/org/connectbot/ui/screens/settings/SettingsScreen.kt` | 键盘相关设置 UI |
+| `app/src/main/java/org/connectbot/ui/screens/settings/SettingsViewModel.kt` | 设置逻辑处理 |
+| `app/src/main/java/org/connectbot/util/PreferenceConstants.kt` | 偏好设置常量定义 |
+
+---
+
+## 3. 架构分层
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                         ConsoleScreen                               │
+│  ┌───────────────────────────────────────────────────────────────┐  │
+│  │                    TerminalKeyboard (Compose)                  │  │
+│  │                                                               │  │
+│  │  ┌────────┐ ┌─────┐ ┌─────┐ ┌───┐ ┌───┐ ┌───┐ ┌───┐ ┌────┐ │  │
+│  │  │  Ctrl  │ │ Esc │ │ Tab │ │ ↑ │ │ ↓ │ │ ← │ │ → │ │ F1 │ │  │
+│  │  └───┬────┘ └──┬──┘ └──┬──┘ └─┬─┘ └─┬─┘ └─┬─┘ └─┬─┘ └──┬─┘ │  │
+│  │      │         │       │      │     │     │     │      │    │  │
+│  │      └─────────┴───────┴──────┴─────┴─────┴─────┴──────┘    │  │
+│  │                              │                               │  │
+│  │                   TerminalKeyListener                        │  │
+│  │                (按键状态 + 修饰键管理)                         │  │
+│  │                              │                               │  │
+│  │                   ┌──────────┴──────────┐                    │  │
+│  │                   │   TerminalBridge    │                    │  │
+│  │                   │  (连接到终端模拟器)   │                    │  │
+│  └───────────────────┴─────────────────────┴────────────────────┘  │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+### 数据流
+
+```
+用户点击按键
+    ↓
+TerminalKeyboard (UI 回调)
+    ↓
+TerminalKeyListener (处理逻辑)
+    ↓
+TerminalBridge.keyHandler → TerminalEmulator (发送到终端)
+```
+
+---
+
+## 4. UI 实现详解
+
+### 4.1 组件结构
+
+`TerminalKeyboard.kt` 包含以下 Compose 组件：
+
+| 组件名 | 用途 |
+|--------|------|
+| `TerminalKeyboard` | 有状态的顶层组件，连接 TerminalBridge |
+| `TerminalKeyboardContent` | 无状态的 UI 组件，支持 Preview |
+| `KeyButton` | 普通按键（单次点击） |
+| `ModifierKeyButton` | 修饰键按键（Ctrl，支持状态切换） |
+| `RepeatableKeyButton` | 可重复按键（方向键，长按自动重复） |
+
+### 4.2 按键布局
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│ [Ctrl] [Esc] [Tab] [↑] [↓] [←] [→] [Home] [End] [PgUp] [PgDn] [F1-F12] │ [✎] [⌨] │
+└─────────────────────────────────────────────────────────────────────────┘
+  ←─────────────────── 可水平滚动区域 ───────────────────→    ←── 固定 ──→
+```
+
+### 4.3 关键常量
+
+```kotlin
+// TerminalKeyboard.kt
+const val TERMINAL_KEYBOARD_HEIGHT_DP = 30      // 按键高度 (dp)
+private const val TERMINAL_KEYBOARD_WIDTH_DP = 45       // 按键宽度 (dp)
+private const val TERMINAL_KEYBOARD_CONTENT_SIZE_DP = 20 // 图标/文字大小 (dp)
+private const val UI_OPACITY = 0.5f                      // 界面透明度
+```
+
+### 4.4 按键类型详解
+
+#### 普通按键 (KeyButton)
+
+用于：Esc、Tab、Home、End、PgUp、PgDn、F1-F12
+
+```kotlin
+@Composable
+private fun KeyButton(
+    contentDescription: String?,
+    modifier: Modifier = Modifier,
+    text: String? = null,           // 文字显示
+    icon: ImageVector? = null,      // 图标显示
+    onClick: (() -> Unit)? = null,  // 点击回调
+    backgroundColor: Color = ...,
+    tint: Color = ...,
+)
+```
+
+**样式特点：**
+- 矩形形状 (`RectangleShape`)
+- 1dp 边框 (`BorderStroke`)
+- 半透明背景
+
+#### 修饰键按键 (ModifierKeyButton)
+
+用于：Ctrl
+
+```kotlin
+@Composable
+private fun ModifierKeyButton(
+    text: String,
+    contentDescription: String?,
+    modifierLevel: ModifierLevel,  // 当前修饰键状态
+    onClick: () -> Unit,
+)
+```
+
+**状态颜色映射：**
+
+| 状态 | 背景色 | 文字色 |
+|------|--------|--------|
+| `OFF` | `surface` (半透明) | `onSurface` |
+| `TRANSIENT` | `primaryContainer` (70% 不透明) | `onPrimaryContainer` |
+| `LOCKED` | `primary` (80% 不透明) | `onPrimary` |
+
+#### 可重复按键 (RepeatableKeyButton)
+
+用于：方向键（↑ ↓ ← →）
+
+```kotlin
+@Composable
+private fun RepeatableKeyButton(
+    icon: ImageVector,
+    contentDescription: String?,
+    onPress: () -> Unit,
+)
+```
+
+**重复逻辑：**
+1. 按下后等待 `ViewConfiguration.getTapTimeout()` 毫秒（允许滚动手势抢占）
+2. 发送第一次按键
+3. 等待 500ms - tapTimeout
+4. 开始重复，每 50ms 发送一次
+5. 松开时停止
+
+### 4.5 固定区域按钮
+
+右侧有两个固定按钮（不随滚动移动）：
+
+| 按钮 | 图标 | 功能 |
+|------|------|------|
+| 文本输入 | `Icons.Default.Edit` | 打开文本输入对话框 |
+| 键盘切换 | `Icons.Default.Keyboard` / `KeyboardHide` | 显示/隐藏系统输入法 |
+
+---
+
+## 5. 功能实现详解
+
+### 5.1 TerminalKeyListener
+
+位置：`app/src/main/java/org/connectbot/service/TerminalKeyListener.kt`
+
+#### 修饰键状态管理
+
+**状态机：**
+
+```
+OFF ──点击──→ TRANSIENT ──点击──→ LOCKED ──点击──→ OFF
+                 │
+                 └──发送按键后──→ OFF (clearTransients)
+```
+
+**状态说明：**
+
+| 状态 | 含义 |
+|------|------|
+| `OFF` | 修饰键未激活 |
+| `TRANSIENT` | 临时激活，发送一个按键后自动取消 |
+| `LOCKED` | 锁定激活，持续有效直到手动关闭 |
+
+**内部位掩码：**
+
+```kotlin
+private const val OUR_CTRL_ON = 0x01    // Ctrl 临时激活
+private const val OUR_CTRL_LOCK = 0x02  // Ctrl 锁定
+private const val OUR_ALT_ON = 0x04     // Alt 临时激活
+private const val OUR_ALT_LOCK = 0x08   // Alt 锁定
+private const val OUR_SHIFT_ON = 0x10   // Shift 临时激活
+private const val OUR_SHIFT_LOCK = 0x20 // Shift 锁定
+```
+
+#### 核心方法
+
+| 方法 | 功能 |
+|------|------|
+| `metaPress(code, forceSticky)` | 切换修饰键状态 |
+| `sendEscape()` | 发送 Esc 键 |
+| `sendTab()` | 发送 Tab 键 |
+| `sendPressedKey(key)` | 发送普通按键（带当前修饰键） |
+| `clearTransients()` | 清除所有临时状态 |
+| `isCtrlActive()` | 检查 Ctrl 是否激活 |
+| `isAltActive()` | 检查 Alt 是否激活 |
+| `isShiftActive()` | 检查 Shift 是否激活 |
+
+### 5.2 按键发送流程
+
+```
+用户点击按键
+    ↓
+TerminalKeyboard.onKeyPress(key) 或 onCtrlPress() 等
+    ↓
+TerminalKeyListener.sendPressedKey(key)
+    ↓
+keyDispatcher.dispatchKey(modifiers, key)
+    ↓
+TerminalEmulator.dispatchKey(modifiers, key)
+    ↓
+发送转义序列到远程终端
+```
+
+### 5.3 VTermKey 常量
+
+按键常量定义在 `termlib` 库的 `org.connectbot.terminal.VTermKey` 类中。常用常量：
+
+| 常量 | 用途 |
+|------|------|
+| `VTermKey.ESCAPE` | Esc 键 |
+| `VTermKey.TAB` | Tab 键 |
+| `VTermKey.UP` / `DOWN` / `LEFT` / `RIGHT` | 方向键 |
+| `VTermKey.HOME` / `END` | Home/End 键 |
+| `VTermKey.PAGEUP` / `PAGEDOWN` | 翻页键 |
+| `VTermKey.FUNCTION_1` ~ `VTermKey.FUNCTION_12` | F1-F12 |
+
+---
+
+## 6. 配置与设置
+
+### 6.1 相关偏好设置
+
+位置：`app/src/main/java/org/connectbot/util/PreferenceConstants.kt`
+
+| 常量 | 键名 | 类型 | 默认值 | 说明 |
+|------|------|------|--------|------|
+| `STICKY_MODIFIERS` | `"stickymodifiers"` | String | `"no"` | 粘性修饰键模式 |
+| `BUMPY_ARROWS` | `"bumpyarrows"` | Boolean | `true` | 方向键触觉反馈 |
+
+### 6.2 粘性修饰键模式
+
+| 值 | 行为 |
+|----|------|
+| `"no"` | 禁用粘性，硬件键盘不进入临时状态 |
+| `"alt"` | 仅 Alt 键支持粘性 |
+| `"yes"` | Ctrl、Alt、Shift 都支持粘性 |
+
+**注意：** 软键盘（屏幕上的虚拟按键）始终使用 `forceSticky = true`，确保至少进入临时状态。
+
+### 6.3 设置界面
+
+位置：`app/src/main/java/org/connectbot/ui/screens/settings/SettingsScreen.kt`
+
+设置项位于 "Keyboard" 分类下：
+- **Sticky Modifiers**：粘性修饰键模式选择
+- **Bumpy Arrows**：方向键触觉反馈开关
+
+---
+
+## 7. 集成到 ConsoleScreen
+
+位置：`app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt`
+
+### 7.1 显示逻辑
+
+```kotlin
+// 状态变量
+var showExtraKeyboard by remember { mutableStateOf(true) }
+
+// 显示条件
+AnimatedVisibility(
+    visible = showExtraKeyboard,
+    enter = fadeIn(animationSpec = tween(durationMillis = 100)),
+    exit = fadeOut(animationSpec = tween(durationMillis = 100)),
+) {
+    TerminalKeyboard(
+        bridge = bridge,
+        onInteraction = { handleTerminalInteraction() },
+        onHideIme = { showSoftwareKeyboard = false },
+        onShowIme = { showSoftwareKeyboard = true },
+        onOpenTextInput = { showTextInputDialog = true },
+        // ...
+    )
+}
+```
+
+### 7.2 自动隐藏机制
+
+虚拟键盘的自动隐藏由 ConsoleScreen 控制，不是 TerminalKeyboard 自身的逻辑。当用户闲置一段时间后，`showExtraKeyboard` 会被设为 `false`。
+
+---
+
+## 8. 修改指南
+
+### 8.1 添加新按键
+
+**步骤：**
+
+1. 打开 `app/src/main/java/org/connectbot/ui/components/TerminalKeyboard.kt`
+2. 在 `TerminalKeyboardContent` 函数的 `Row` 中找到合适位置
+3. 添加新的 `KeyButton`
+
+**示例：添加 Insert 键**
+
+```kotlin
+// 在 Row 中添加（约第 232 行的 Row 内）
+KeyButton(
+    text = stringResource(R.string.button_key_insert),  // 需要在 strings.xml 添加
+    contentDescription = null,
+    onClick = { onKeyPress(VTermKey.INSERT) },  // 需确认 termlib 是否支持
+)
+```
+
+**需要修改的文件：**
+
+| 文件 | 修改内容 |
+|------|----------|
+| `TerminalKeyboard.kt` | 添加按键 UI |
+| `app/src/main/res/values/strings.xml` | 添加按键文字字符串 |
+| `app/src/main/res/values-xx/strings.xml` | 添加翻译（可选） |
+
+### 8.2 修改按键样式
+
+**修改尺寸：**
+
+```kotlin
+// TerminalKeyboard.kt 顶部常量
+const val TERMINAL_KEYBOARD_HEIGHT_DP = 35  // 增大高度
+private const val TERMINAL_KEYBOARD_WIDTH_DP = 50   // 增大宽度
+```
+
+**修改颜色：**
+
+在 `KeyButton` 函数中修改 `backgroundColor` 参数的默认值：
+
+```kotlin
+backgroundColor: Color = MaterialTheme.colorScheme.surfaceVariant,  // 使用不同颜色
+```
+
+**修改透明度：**
+
+```kotlin
+private const val UI_OPACITY = 0.7f  // 从 0.5 改为 0.7，更不透明
+```
+
+### 8.3 修改方向键重复速度
+
+在 `RepeatableKeyButton` 的 `pointerInput` 块中：
+
+```kotlin
+// TerminalKeyboard.kt 约第 577 行
+delay(50) // 重复间隔，改为更大的值会更慢
+```
+
+### 8.4 添加新的修饰键
+
+如果需要添加 Alt 或 Shift 按钮：
+
+```kotlin
+// 在 Row 中添加
+ModifierKeyButton(
+    text = stringResource(R.string.button_key_alt),
+    contentDescription = "Alt key",
+    modifierLevel = modifierState.altState,
+    onClick = { keyHandler.metaPress(TerminalKeyListener.ALT_ON, true) },
+)
+```
+
+**注意：** `TerminalKeyListener` 已经支持 Alt 和 Shift，只需要在 UI 中添加按钮。
+
+### 8.5 修改按键排列顺序
+
+直接调整 `TerminalKeyboardContent` 中 `Row` 内各按键的顺序即可。
+
+---
+
+## 9. 测试
+
+### 9.1 预览
+
+`TerminalKeyboard.kt` 包含多个 Preview 函数：
+
+| Preview 名称 | 测试场景 |
+|--------------|----------|
+| `TerminalKeyboardPreview` | 默认状态 |
+| `TerminalKeyboardCtrlPressedPreview` | Ctrl 临时激活 |
+| `TerminalKeyboardCtrlLockedPreview` | Ctrl 锁定 |
+| `TerminalKeyboardImeVisiblePreview` | 系统输入法可见 |
+
+### 9.2 单元测试
+
+位置：`app/src/test/kotlin/org/connectbot/ui/components/`
+
+相关测试文件：
+- `TerminalKeyboardContentTest.kt` - 键盘 UI 测试
+
+### 9.3 运行测试
+
+```bash
+# 运行键盘相关的单元测试
+./gradlew test --tests "org.connectbot.ui.components.*"
+
+# 运行所有测试
+./gradlew test
+```
+
+---
+
+## 10. 常见问题
+
+### Q: 为什么虚拟按键没有响应？
+
+检查以下几点：
+1. `TerminalBridge` 是否正确初始化
+2. `keyHandler` 是否正确绑定
+3. 按键回调是否正确传递到 `TerminalKeyListener`
+
+### Q: 如何添加一个新的 VTermKey？
+
+VTermKey 常量定义在 `termlib` 库中（外部依赖）。如果需要新的按键：
+1. 检查 `termlib` 是否已定义该常量
+2. 如果没有，需要先修改 `termlib` 库
+3. 然后在 ConnectBot 中使用新的常量
+
+### Q: 如何让虚拟键盘始终显示？
+
+在 `ConsoleScreen.kt` 中，`showExtraKeyboard` 的初始值和控制逻辑决定了显示状态。设置相关的偏好项 `conn_persist` 可能影响行为。
+
+---
+
+## 附录：关键代码位置索引
+
+| 功能 | 文件 | 大约行号 |
+|------|------|----------|
+| 按键布局定义 | `TerminalKeyboard.kt` | 228-398 |
+| Ctrl 按键逻辑 | `TerminalKeyListener.kt` | 107-123 |
+| 方向键重复逻辑 | `TerminalKeyboard.kt` | 558-596 |
+| 键盘显示控制 | `ConsoleScreen.kt` | 640-669 |
+| 粘性修饰键设置 | `SettingsScreen.kt` | 583-596 |
+| 触觉反馈设置 | `SettingsScreen.kt` | 647-650 |

--- a/docs/PROJECT_OVERVIEW.md
+++ b/docs/PROJECT_OVERVIEW.md
@@ -1,0 +1,361 @@
+# ConnectBot 项目概览
+
+> 本文档面向开发者和 AI Coding Agent，提供项目级别的全局视图，帮助快速定位"做什么事该去哪找代码"。
+
+---
+
+## 1. 项目概述
+
+ConnectBot 是一个开源的 Android SSH/Telnet 客户端，让用户通过加密安全连接访问远程服务器，同时支持本地终端会话。
+
+---
+
+## 2. 技术栈
+
+| 类别 | 技术 |
+|------|------|
+| 语言 | Kotlin（主要）、Java（遗留代码）、C++（本地层） |
+| 平台 | Android（minSdk 24，targetSdk 36） |
+| UI 框架 | Jetpack Compose + Material3 |
+| 架构模式 | MVVM（ViewModel + Repository） |
+| 依赖注入 | Hilt（Dagger） |
+| 数据库 | Room（SQLite） |
+| 导航 | Navigation Compose |
+| 构建系统 | Gradle（Kotlin DSL）+ KSP |
+| SSH 库 | sshlib（ConnectBot 维护的 Trilead SSH-2 分支） |
+| 终端库 | termlib（ConnectBot 维护的终端模拟器） |
+| 加密提供者 | Conscrypt（oss 版本）/ Google Play Services（google 版本） |
+| 测试框架 | JUnit、Mockito、Robolectric、Espresso、Compose Test |
+| 代码质量 | Spotless（ktlint + Google Java Format）、SonarQube、Kover |
+
+---
+
+## 3. 目录结构及职责说明
+
+```
+connectbot/
+├── app/                              # 主应用模块
+│   ├── build.gradle.kts              # 应用级构建配置（flavor、签名、依赖）
+│   ├── CMakeLists.txt                # 本地 C++ 代码构建配置
+│   ├── lint.xml                      # Android Lint 规则配置
+│   ├── proguard.cfg                  # ProGuard 混淆规则
+│   ├── schemas/                      # Room 数据库 schema 导出（用于迁移测试）
+│   │   └── org.connectbot.data.ConnectBotDatabase/
+│   └── src/
+│       ├── main/
+│       │   ├── AndroidManifest.xml   # 应用清单（权限、组件声明）
+│       │   ├── cpp/                  # C++ 本地代码（JNI，用于本地 shell 执行）
+│       │   ├── java/org/connectbot/  # Kotlin/Java 源码根目录
+│       │   │   ├── ConnectBotApplication.kt  # Application 入口
+│       │   │   ├── data/             # 数据层（Room 数据库、Repository）
+│       │   │   ├── di/               # Hilt 依赖注入模块
+│       │   │   ├── logging/          # 日志初始化（Timber）
+│       │   │   ├── service/          # 后台服务（TerminalManager、TerminalBridge）
+│       │   │   ├── transport/        # 协议传输层（SSH、Telnet、Local）
+│       │   │   ├── ui/               # UI 层（Compose 界面、ViewModel）
+│       │   │   └── util/             # 工具类（加密、字体、常量）
+│       │   └── res/                  # Android 资源（drawable、values、layout 等）
+│       ├── test/                     # 本地单元测试（Robolectric）
+│       ├── androidTest/              # 设备/模拟器集成测试
+│       └── sharedTest/kotlin/        # 测试共享代码
+├── gradle/
+│   └── libs.versions.toml            # 版本目录（统一依赖版本管理）
+├── translations/                     # 翻译工具（Python 脚本 + 测试）
+├── spotless/                         # Spotless 格式化配置
+├── icons/                            # 应用图标资源
+├── .github/workflows/                # GitHub Actions CI 配置
+├── build.gradle.kts                  # 根构建脚本（Spotless、仓库配置）
+├── settings.gradle.kts               # 项目设置（模块包含）
+├── gradle.properties                 # Gradle 属性（JVM 参数、AndroidX 配置）
+├── AGENTS.md                         # AI Agent 开发指南
+├── CONTRIBUTING.md                   # 贡献者指南
+├── CHANGELOG.md                      # 变更日志
+└── README.md                         # 项目说明
+```
+
+### 关键目录详解
+
+- **`app/src/main/java/org/connectbot/ui/`**：所有 Compose UI 代码
+  - `screens/`：各功能页面（hostlist、console、settings 等），每个子目录包含 Screen 和 ViewModel
+  - `components/`：可复用的 UI 组件（对话框、键盘等）
+  - `navigation/`：Navigation Compose 路由定义
+  - `theme/`：Material3 主题配置
+- **`app/src/main/java/org/connectbot/data/`**：数据层
+  - `entity/`：Room 实体类（Host、Pubkey、PortForward、KnownHost、ColorScheme、Profile）
+  - `dao/`：Room DAO 接口
+  - `migration/`：数据库迁移脚本
+  - 根目录：Repository 类和数据库定义
+- **`app/src/main/java/org/connectbot/transport/`**：传输协议实现
+  - `Transport.kt`：密封类，定义协议类型（SSH、Telnet、Local）
+  - `AbsTransport.kt`：传输抽象基类
+  - `SSH.kt`、`Telnet.kt`、`Local.kt`：具体协议实现
+- **`app/src/main/java/org/connectbot/service/`**：后台服务
+  - `TerminalManager.kt`：终端会话管理服务（Android Service）
+  - `TerminalBridge.kt`：连接桥接（管理单个终端会话的生命周期）
+
+---
+
+## 4. 架构概览
+
+### 分层架构
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                        UI Layer                              │
+│  ┌─────────────┐  ┌─────────────┐  ┌─────────────────────┐ │
+│  │   Screens   │  │ Components  │  │    Navigation       │ │
+│  │ (Compose)   │  │ (Compose)   │  │ (NavGraph)          │ │
+│  └──────┬──────┘  └──────┬──────┘  └──────────┬──────────┘ │
+│         │                │                     │             │
+│         └────────────────┼─────────────────────┘             │
+│                          │                                   │
+│                   ┌──────▼──────┐                            │
+│                   │  ViewModels │                            │
+│                   └──────┬──────┘                            │
+├──────────────────────────┼───────────────────────────────────┤
+│                   Service Layer                              │
+│  ┌───────────────────────▼───────────────────────────────┐  │
+│  │              TerminalManager (Service)                 │  │
+│  │  ┌─────────────┐  ┌─────────────┐  ┌───────────────┐ │  │
+│  │  │  Terminal    │  │   Relay     │  │  Connection   │ │  │
+│  │  │  Bridge      │  │             │  │  Notifier     │ │  │
+│  │  └──────┬──────┘  └─────────────┘  └───────────────┘ │  │
+│  └─────────┼─────────────────────────────────────────────┘  │
+├────────────┼─────────────────────────────────────────────────┤
+│            │          Transport Layer                        │
+│  ┌─────────▼─────────────────────────────────────────────┐  │
+│  │              Transport (Sealed Class)                  │  │
+│  │  ┌─────────┐  ┌──────────┐  ┌─────────┐              │  │
+│  │  │   SSH   │  │  Telnet  │  │  Local  │              │  │
+│  │  └────┬────┘  └────┬─────┘  └────┬────┘              │  │
+│  │       │            │             │                     │  │
+│  │       └────────────┼─────────────┘                     │  │
+│  │                    │                                   │  │
+│  │            ┌───────▼───────┐                           │  │
+│  │            │ AbsTransport  │                           │  │
+│  │            └───────────────┘                           │  │
+│  └───────────────────────────────────────────────────────┘  │
+├──────────────────────────────────────────────────────────────┤
+│                      Data Layer                              │
+│  ┌───────────────┐  ┌───────────────┐  ┌─────────────────┐ │
+│  │  Repositories │  │     DAOs      │  │    Entities     │ │
+│  │  (Host, Pub,  │  │ (Room)        │  │ (Room)          │ │
+│  │   Color...)   │  │               │  │                 │ │
+│  └───────┬───────┘  └───────┬───────┘  └────────┬────────┘ │
+│          │                  │                    │          │
+│          └──────────────────┼────────────────────┘          │
+│                             │                               │
+│                    ┌────────▼────────┐                      │
+│                    │ ConnectBot DB   │                      │
+│                    │ (Room/SQLite)   │                      │
+│                    └─────────────────┘                      │
+├──────────────────────────────────────────────────────────────┤
+│                     DI Layer (Hilt)                          │
+│  ┌─────────┐ ┌──────────┐ ┌──────────┐ ┌─────────────────┐ │
+│  │AppModule│ │DB Module │ │Dispatcher│ │Biometric Module │ │
+│  └─────────┘ └──────────┘ └──────────┘ └─────────────────┘ │
+└──────────────────────────────────────────────────────────────┘
+```
+
+### 核心业务流程
+
+**建立 SSH 连接的流程：**
+
+1. 用户在 `HostListScreen` 选择或创建主机配置
+2. `HostListViewModel` 调用 `HostRepository` 保存/读取主机数据
+3. 导航到 `ConsoleScreen`，触发 `TerminalManager` 创建新会话
+4. `TerminalManager` 通过 `TransportFactory` 创建 `SSH` 传输实例
+5. `TerminalBridge` 使用 `SSH` 传输建立连接，初始化终端模拟器
+6. `ConsoleScreen` 通过 `ConsoleViewModel` 订阅终端状态并渲染输出
+
+---
+
+## 5. 核心模块概要
+
+| 模块 | 职责 | 对应目录 |
+|------|------|----------|
+| **UI 层** | 所有用户界面，采用 Jetpack Compose 实现，包含各功能页面和可复用组件 | `app/src/main/java/org/connectbot/ui/` |
+| **Service 层** | 后台终端管理服务，维护连接生命周期，处理终端 I/O 和通知 | `app/src/main/java/org/connectbot/service/` |
+| **Transport 层** | 协议传输抽象，支持 SSH、Telnet、Local 三种连接方式 | `app/src/main/java/org/connectbot/transport/` |
+| **Data 层** | Room 数据库、DAO、Repository，管理主机、密钥、配色方案等持久化数据 | `app/src/main/java/org/connectbot/data/` |
+| **DI 层** | Hilt 依赖注入配置，提供数据库、调度器、生物识别等模块 | `app/src/main/java/org/connectbot/di/` |
+| **Util 层** | 工具类集合，包括加密、字体管理、偏好常量等 | `app/src/main/java/org/connectbot/util/` |
+| **翻译系统** | 自动化翻译工具链，管理多语言资源 | `translations/` |
+
+---
+
+## 6. 启动流程与入口点
+
+### 应用入口
+
+- **Application 类**：`app/src/main/java/org/connectbot/ConnectBotApplication.kt`
+  - 使用 `@HiltAndroidApp` 注解，触发 Hilt 依赖注入初始化
+  - 在 `onCreate()` 中初始化 Timber 日志系统
+
+- **主 Activity**：`app/src/main/java/org/connectbot/ui/MainActivity.kt`
+  - 使用 `@AndroidEntryPoint` 注解，支持 Hilt 注入
+  - 配置 `setContent` 使用 Compose UI
+  - 绑定 `TerminalManager` 服务
+  - 处理 Intent（SSH/Telnet URI scheme）
+
+### 启动初始化顺序
+
+1. `ConnectBotApplication.onCreate()` → Hilt 初始化 + Timber 日志
+2. `MainActivity.onCreate()` → Compose 内容设置 + 服务绑定
+3. Navigation Compose 初始化 → 加载 `NavGraph`
+4. 首次启动：显示 EULA → 主机列表
+5. 后续启动：直接显示主机列表
+
+### 关键配置文件
+
+- `AndroidManifest.xml`：声明权限、Activity、Service、URI scheme
+- `build.gradle.kts`（app）：产品风味（oss/google）、签名、依赖
+- `gradle/libs.versions.toml`：统一版本管理
+
+---
+
+## 7. 外部依赖与服务
+
+### 核心依赖库
+
+| 依赖 | 用途 | 版本管理位置 |
+|------|------|--------------|
+| `org.connectbot:sshlib` | SSH 协议实现 | `gradle/libs.versions.toml` |
+| `org.connectbot:termlib` | 终端模拟器 | `gradle/libs.versions.toml` |
+| `org.conscrypt:conscrypt-android` | TLS/加密提供者（oss 版本） | `gradle/libs.versions.toml` |
+| `com.google.android.gms:play-services-basement` | Google Play Services（google 版本） | `gradle/libs.versions.toml` |
+
+### Android 系统服务
+
+- **网络**：`ACCESS_NETWORK_STATE`、`INTERNET` 权限
+- **前台服务**：`FOREGROUND_SERVICE` + `FOREGROUND_SERVICE_REMOTE_MESSAGING`
+- **通知**：`POST_NOTIFICATIONS`（Android 13+）
+- **生物识别**：`androidx.biometric` 用于密钥保护
+
+### 数据库
+
+- **Room/SQLite**：本地数据库 `connectbot.db`
+  - 表：hosts、pubkeys、port_forwards、known_hosts、color_schemes、color_palette、profiles
+  - Schema 导出：`app/schemas/`
+  - 迁移脚本：`app/src/main/java/org/connectbot/data/migration/`
+
+### 第三方服务
+
+- **Google Play Services**（仅 google 版本）：用于加密提供者更新和可下载字体
+- **Google Play Feature Delivery**（仅 google 版本）：动态功能模块
+
+---
+
+## 8. 配置与环境变量
+
+### Gradle 配置
+
+| 配置项 | 位置 | 说明 |
+|--------|------|------|
+| `org.gradle.caching=true` | `gradle.properties` | 启用构建缓存 |
+| `org.gradle.parallel=true` | `gradle.properties` | 并行构建 |
+| `org.gradle.jvmargs=-Xmx4g` | `gradle.properties` | JVM 内存配置 |
+| `android.useAndroidX=true` | `gradle.properties` | 使用 AndroidX |
+| `TRANSLATIONS_ONLY` | 环境变量 | 仅构建翻译模块时设置 |
+
+### 应用配置
+
+| 配置项 | 位置 | 说明 |
+|--------|------|------|
+| `applicationId` | `app/build.gradle.kts` | `org.connectbot` |
+| `minSdk` | `gradle/libs.versions.toml` | 24（Android 7.0） |
+| `targetSdk` | `gradle/libs.versions.toml` | 36 |
+| `compileSdk` | `gradle/libs.versions.toml` | 37 |
+| `keystorePassword` | 系统属性 | 签名密钥密码（CI 环境） |
+
+### 产品风味
+
+| 风味 | 说明 |
+|------|------|
+| `oss` | 开源版本，使用 Conscrypt 加密提供者，无 Google Play Services |
+| `google` | Google Play 版本，使用 Play Services 进行加密提供者更新 |
+
+---
+
+## 9. 开发指南（极简）
+
+### 环境要求
+
+- Android Studio（最新稳定版）
+- JDK 17
+- Android SDK（API 37）
+- Docker（用于 OpenSSH 集成测试）
+
+### 常用命令
+
+```bash
+# 构建所有变体
+./gradlew assemble
+
+# 构建 oss 调试版本
+./gradlew :app:assembleOssDebug
+
+# 运行本地单元测试
+./gradlew test
+
+# 运行设备/模拟器测试
+./gradlew connectedAndroidTest
+
+# 运行特定风味的设备测试
+./gradlew connectedOssDebugAndroidTest
+./gradlew connectedGoogleDebugAndroidTest
+
+# 代码检查
+./gradlew lint
+
+# 格式化代码
+./gradlew spotlessApply
+
+# 验证格式
+./gradlew spotlessCheck
+
+# 完整验证（提交前推荐）
+./gradlew check test
+```
+
+### 开发工作流
+
+1. 从 `main` 分支创建特性分支
+2. 进行开发，遵循现有代码风格
+3. 运行 `./gradlew spotlessApply` 格式化代码
+4. 运行 `./gradlew lint` 检查 lint 问题
+5. 运行 `./gradlew check test` 验证所有检查通过
+6. 提交 PR，描述变更并关联 issue
+
+### 测试策略
+
+- **本地测试**（`app/src/test/`）：使用 Robolectric 运行，适合 ViewModel、业务逻辑
+- **集成测试**（`app/src/androidTest/`）：需要设备/模拟器，用于 UI 交互、Hilt 注入测试
+- **共享测试**（`app/src/sharedTest/`）：可在本地和设备测试间共享的代码
+
+### 注意事项
+
+- 不要阻塞主线程，使用协程处理耗时操作
+- 在 ViewModel 中使用注入的 `CoroutineDispatchers` 而非硬编码 `Dispatchers.IO`
+- 数据库迁移需更新 `app/schemas/` 下的 JSON 文件
+- UI 字符串使用 `stringResource()` 从资源读取，便于翻译
+
+---
+
+## 附录：关键文件快速索引
+
+| 文件 | 用途 |
+|------|------|
+| `app/src/main/AndroidManifest.xml` | 权限、组件声明 |
+| `app/build.gradle.kts` | 应用构建配置 |
+| `gradle/libs.versions.toml` | 依赖版本管理 |
+| `app/src/main/java/org/connectbot/ConnectBotApplication.kt` | Application 入口 |
+| `app/src/main/java/org/connectbot/ui/MainActivity.kt` | 主 Activity |
+| `app/src/main/java/org/connectbot/ui/navigation/NavGraph.kt` | 导航图定义 |
+| `app/src/main/java/org/connectbot/ui/navigation/NavDestinations.kt` | 路由常量 |
+| `app/src/main/java/org/connectbot/data/ConnectBotDatabase.kt` | Room 数据库定义 |
+| `app/src/main/java/org/connectbot/di/DatabaseModule.kt` | 数据库依赖注入 |
+| `app/src/main/java/org/connectbot/service/TerminalManager.kt` | 终端管理服务 |
+| `app/src/main/java/org/connectbot/transport/Transport.kt` | 传输协议定义 |
+| `AGENTS.md` | AI Agent 开发指南 |
+| `CONTRIBUTING.md` | 贡献者指南 |


### PR DESCRIPTION
  Fix virtual keyboard overlapping terminal content by changing terminal area layout from Box (overlay) to Column (stacked).
  As is shown in the two images.

<img width="1260" height="2800" alt="11" src="https://github.com/user-attachments/assets/bc4c3643-e3fb-4a4b-a4bb-b213cafd905f" />
<img width="1260" height="2800" alt="22" src="https://github.com/user-attachments/assets/b05a3220-d58b-4f95-b97a-b7972d9fcb12" />

