### PR TITLE
feat: display banners and URLs during "none" auth

### DIFF
--- a/app/src/main/java/org/connectbot/service/TerminalBridge.kt
+++ b/app/src/main/java/org/connectbot/service/TerminalBridge.kt
@@ -41,6 +41,7 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import org.connectbot.R
 import org.connectbot.data.entity.Host
@@ -61,6 +62,15 @@ import timber.log.Timber
 import java.io.IOException
 import java.nio.charset.Charset
 import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicLong
+
+data class AuthBanner(
+    val id: Long,
+    val sourceName: String,
+    val message: String,
+    val urls: List<String>,
+    val languageTag: String?,
+)
 
 /**
  * Provides a bridge between a MUD terminal buffer and a possible TerminalView.
@@ -141,6 +151,10 @@ class TerminalBridge {
 
     private val _networkStatusMessages = MutableSharedFlow<String>(replay = 0, extraBufferCapacity = 10)
     val networkStatusMessages: SharedFlow<String> = _networkStatusMessages.asSharedFlow()
+
+    private val authBannerIds = AtomicLong()
+    private val _authBanners = MutableStateFlow<List<AuthBanner>>(emptyList())
+    val authBanners: StateFlow<List<AuthBanner>> = _authBanners.asStateFlow()
 
     // Progress state for OSC 9;4 progress reporting
     data class ProgressInfo(val state: ProgressState, val progress: Int)
@@ -931,6 +945,38 @@ class TerminalBridge {
 
     fun scanForURLs(): List<String> = terminalEmulator.getUrls(UrlScanScope.CurrentView).map { it.url }
 
+    fun enqueueAuthBanner(
+        sourceName: String,
+        message: String,
+        urls: List<String>,
+        languageTag: String?,
+    ) {
+        if (urls.isEmpty()) return
+
+        val banner = AuthBanner(
+            id = authBannerIds.incrementAndGet(),
+            sourceName = sourceName,
+            message = message,
+            urls = urls,
+            languageTag = languageTag,
+        )
+        _authBanners.update { list ->
+            if (list.any { it.sourceName == sourceName && it.message == message }) {
+                list
+            } else {
+                (list + banner).takeLast(MAX_AUTH_BANNERS)
+            }
+        }
+    }
+
+    fun dismissAuthBanner(id: Long) {
+        _authBanners.update { list -> list.filterNot { it.id == id } }
+    }
+
+    fun dismissAuthBannersFrom(sourceName: String) {
+        _authBanners.update { list -> list.filterNot { it.sourceName == sourceName } }
+    }
+
     /**
      * @return
      */
@@ -1083,6 +1129,7 @@ class TerminalBridge {
 
         private const val DEFAULT_FONT_SIZE_SP = 10
         private const val FONT_SIZE_STEP = 2
+        private const val MAX_AUTH_BANNERS = 10
     }
 }
 

--- a/app/src/main/java/org/connectbot/transport/SSH.kt
+++ b/app/src/main/java/org/connectbot/transport/SSH.kt
@@ -34,6 +34,7 @@ import com.trilead.ssh2.IpVersion
 import com.trilead.ssh2.KnownHosts
 import com.trilead.ssh2.LocalPortForwarder
 import com.trilead.ssh2.Session
+import com.trilead.ssh2.UserAuthBannerCallback
 import com.trilead.ssh2.crypto.PEMDecoder
 import com.trilead.ssh2.crypto.fingerprint.KeyFingerprint
 import com.trilead.ssh2.crypto.keys.Ed25519PrivateKey
@@ -57,6 +58,7 @@ import org.connectbot.service.requestHostKeyFingerprintPrompt
 import org.connectbot.service.requestStringPrompt
 import org.connectbot.util.HostConstants
 import org.connectbot.util.PubkeyUtils
+import org.connectbot.util.UrlUtils
 import timber.log.Timber
 import java.io.IOException
 import java.io.InputStream
@@ -111,6 +113,7 @@ class SSH :
     private var stderr: InputStream? = null
 
     private val portForwards = mutableListOf<PortForward>()
+    private val userAuthBannerCallbacks = mutableListOf<Pair<Connection, UserAuthBannerCallback>>()
 
     private var columns: Int = 0
     private var rows: Int = 0
@@ -124,6 +127,63 @@ class SSH :
     constructor() : super()
 
     constructor(host: Host?, bridge: TerminalBridge?, manager: TerminalManager?) : super(host, bridge, manager)
+
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    internal fun setConnectionForTesting(connection: Connection?) {
+        this.connection = connection
+    }
+
+    private fun registerUserAuthBanner(connection: Connection, sourceName: String) {
+        val callback = UserAuthBannerCallback { banner, languageTag ->
+            handleAuthBanner(sourceName, banner, languageTag)
+        }
+        connection.addUserAuthBanner(callback)
+        synchronized(userAuthBannerCallbacks) {
+            userAuthBannerCallbacks.add(connection to callback)
+        }
+    }
+
+    private fun unregisterUserAuthBanner(connection: Connection) {
+        synchronized(userAuthBannerCallbacks) {
+            val iterator = userAuthBannerCallbacks.iterator()
+            while (iterator.hasNext()) {
+                val (registeredConnection, callback) = iterator.next()
+                if (registeredConnection == connection) {
+                    runCatching {
+                        registeredConnection.removeUserAuthBanner(callback)
+                    }
+                    iterator.remove()
+                }
+            }
+        }
+    }
+
+    @VisibleForTesting
+    fun handleAuthBanner(sourceName: String, banner: String?, languageTag: String?) {
+        val trimmedBanner = banner?.trim()
+        if (trimmedBanner.isNullOrEmpty()) return
+
+        val header = manager?.res?.getString(R.string.terminal_auth_banner_header, sourceName)
+            ?: "[$sourceName] Authentication message:"
+        bridge?.outputLine(header)
+        bridge?.outputLine(trimmedBanner)
+
+        val urls = UrlUtils.extractUrls(trimmedBanner)
+        if (urls.isNotEmpty()) {
+            bridge?.enqueueAuthBanner(sourceName, trimmedBanner, urls, languageTag)
+        }
+    }
+
+    private fun Host.authBannerSourceName(): String {
+        if (nickname.isNotBlank()) return nickname
+
+        val userPrefix = username.takeIf { it.isNotBlank() }?.let { "$it@" } ?: ""
+        return if (port == DEFAULT_PORT) {
+            "$userPrefix$hostname"
+        } else {
+            "$userPrefix$hostname:$port"
+        }
+    }
 
     private fun decodePublicKey(algorithm: String, keyBlob: ByteArray): PublicKey? = try {
         when (algorithm) {
@@ -313,7 +373,8 @@ class SSH :
         }
     }
 
-    private fun authenticate() {
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    internal fun authenticate() {
         // Prompt for username if not configured
         if (host?.username.isNullOrEmpty()) {
             val username = bridge?.requestStringPrompt(
@@ -328,14 +389,17 @@ class SSH :
             host = host?.copy(username = username)
         }
 
+        val currentHost = host ?: return
+        val authBannerSourceName = currentHost.authBannerSourceName()
         try {
-            val currentHost = host ?: return
             if (connection?.authenticateWithNone(currentHost.username) == true) {
                 finishConnection()
                 return
             }
         } catch (e: Exception) {
             Timber.d("Host does not support 'none' authentication.")
+        } finally {
+            bridge?.dismissAuthBannersFrom(authBannerSourceName)
         }
 
         bridge?.outputLine(manager?.res?.getString(R.string.terminal_auth))
@@ -663,6 +727,7 @@ class SSH :
         bridge?.outputLine(manager?.res?.getString(R.string.terminal_connecting_via_jump, jumpHost.nickname))
 
         val jc = Connection(jumpHost.hostname, jumpHost.port)
+        registerUserAuthBanner(jc, jumpHost.authBannerSourceName())
 
         try {
             // Check if this jump host itself requires a jump host (chained ProxyJump)
@@ -670,11 +735,16 @@ class SSH :
             if (nestedJumpHostId != null && nestedJumpHostId > 0) {
                 val nestedJumpHost = manager?.hostRepository?.findHostByIdBlocking(nestedJumpHostId)
                 if (nestedJumpHost != null) {
-                    val nestedConnection = connectToJumpHost(nestedJumpHost) ?: return null
+                    val nestedConnection = connectToJumpHost(nestedJumpHost)
+                    if (nestedConnection == null) {
+                        unregisterUserAuthBanner(jc)
+                        return null
+                    }
                     // Use the nested jump host connection as proxy for this jump host
                     jc.setProxyData(JumpHostProxyData(nestedConnection))
                 } else {
                     bridge?.outputLine(manager?.res?.getString(R.string.terminal_jump_not_found))
+                    unregisterUserAuthBanner(jc)
                     return null
                 }
             }
@@ -694,6 +764,7 @@ class SSH :
             // Authenticate to jump host
             if (!authenticateJumpHost(jc, jumpHost)) {
                 bridge?.outputLine(manager?.res?.getString(R.string.terminal_jump_auth_failed, jumpHost.nickname))
+                unregisterUserAuthBanner(jc)
                 jc.close()
                 jumpConnections.remove(jc)
                 return null
@@ -705,6 +776,7 @@ class SSH :
             Timber.e(e, "Failed to connect to jump host: ${jumpHost.nickname}")
             bridge?.outputLine(manager?.res?.getString(R.string.terminal_jump_failed, jumpHost.nickname, e.message))
             try {
+                unregisterUserAuthBanner(jc)
                 jc.close()
                 jumpConnections.remove(jc)
             } catch (ignored: Exception) {
@@ -720,7 +792,9 @@ class SSH :
      * @param jumpHost The jump host configuration
      * @return true if authentication succeeded
      */
-    private fun authenticateJumpHost(jc: Connection, jumpHost: Host): Boolean {
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    internal fun authenticateJumpHost(jc: Connection, jumpHost: Host): Boolean {
+        val authBannerSourceName = jumpHost.authBannerSourceName()
         try {
             // Try 'none' authentication first
             if (jc.authenticateWithNone(jumpHost.username)) {
@@ -819,6 +893,8 @@ class SSH :
         } catch (e: Exception) {
             Timber.e(e, "Error during jump host authentication")
             return false
+        } finally {
+            bridge?.dismissAuthBannersFrom(authBannerSourceName)
         }
     }
 
@@ -845,6 +921,7 @@ class SSH :
 
         connection = Connection(currentHost.hostname, currentHost.port)
         connection?.addConnectionMonitor(this)
+        connection?.let { registerUserAuthBanner(it, currentHost.authBannerSourceName()) }
 
         // If we have a jump host connection, set up the proxy
         directJumpConnection?.let {
@@ -942,17 +1019,22 @@ class SSH :
         session?.close()
         session = null
 
+        connection?.let { unregisterUserAuthBanner(it) }
         connection?.close()
         connection = null
 
         // Close all jump host connections (in reverse order)
         jumpConnections.asReversed().forEach { jc ->
             try {
+                unregisterUserAuthBanner(jc)
                 jc.close()
             } catch (ignored: Exception) {
             }
         }
         jumpConnections.clear()
+        synchronized(userAuthBannerCallbacks) {
+            userAuthBannerCallbacks.clear()
+        }
     }
 
     private fun onDisconnect(reason: DisconnectReason = DisconnectReason.IO_ERROR) {

--- a/app/src/main/java/org/connectbot/ui/MigrationScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/MigrationScreen.kt
@@ -60,6 +60,7 @@ import org.connectbot.R
 import org.connectbot.data.migration.MigrationState
 import org.connectbot.data.migration.MigrationStatus
 import org.connectbot.ui.theme.ConnectBotTheme
+import org.connectbot.util.UrlUtils
 
 /**
  * Full-screen UI shown during database migration.
@@ -358,16 +359,18 @@ private fun MigrationFailedContent(
         Spacer(modifier = Modifier.height(16.dp))
 
         val annotatedString = buildAnnotatedString {
-            val url = "https://github.com/connectbot/connectbot/issues"
-            val fullText = stringResource(id = R.string.migration_failed_help)
-            val startIndex = fullText.indexOf($$"%1$s")
-            if (startIndex != -1) {
-                append(fullText.take(startIndex))
-                withLink(LinkAnnotation.Url(url)) { append(url) }
-                append(fullText.substring(startIndex + $$"%1$s".length))
-            } else {
-                append(fullText)
+            val url = UrlUtils.normalizeUrl("https://github.com/connectbot/connectbot/issues")
+            val fullText = stringResource(id = R.string.migration_failed_help, url)
+            var startIndex = 0
+            UrlUtils.extractUrls(fullText).forEach { linkUrl ->
+                val urlIndex = fullText.indexOf(linkUrl, startIndex)
+                if (urlIndex >= 0) {
+                    append(fullText.substring(startIndex, urlIndex))
+                    withLink(LinkAnnotation.Url(linkUrl)) { append(linkUrl) }
+                    startIndex = urlIndex + linkUrl.length
+                }
             }
+            append(fullText.substring(startIndex))
         }
         Text(
             text = annotatedString,

--- a/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
@@ -103,7 +103,10 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.text.withLink
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.content.edit
@@ -116,6 +119,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.connectbot.R
 import org.connectbot.data.entity.Host
+import org.connectbot.service.AuthBanner
 import org.connectbot.service.DisconnectReason
 import org.connectbot.service.PromptRequest
 import org.connectbot.terminal.ProgressState
@@ -229,12 +233,15 @@ fun ConsoleScreen(
     val currentBridgeForPrompt = uiState.bridges.getOrNull(uiState.currentBridgeIndex)
     val promptState by currentBridgeForPrompt?.promptManager?.promptState?.collectAsState()
         ?: remember { mutableStateOf(null) }
+    val authBanners by currentBridgeForPrompt?.authBanners?.collectAsState()
+        ?: remember { mutableStateOf(emptyList()) }
+    val currentAuthBanner = authBanners.firstOrNull()
     var wasBiometricPromptActive by remember { mutableStateOf(false) }
     val isBiometricPromptActive = promptState is PromptRequest.BiometricPrompt
 
     // Check if any modal (menu or dialog) is currently active
     val anyModalActive = showMenu || showUrlScanDialog || showResizeDialog ||
-        showDisconnectDialog || showTextInputDialog || isBiometricPromptActive
+        showDisconnectDialog || showTextInputDialog || isBiometricPromptActive || currentAuthBanner != null
 
     /**
      * Unified interaction handler for terminal and keyboard.
@@ -742,6 +749,15 @@ fun ConsoleScreen(
             )
         }
 
+        currentAuthBanner?.let { banner ->
+            AuthBannerDialog(
+                banner = banner,
+                onDismiss = {
+                    currentBridgeForPrompt?.dismissAuthBanner(banner.id)
+                },
+            )
+        }
+
         if (showResizeDialog && currentBridge != null) {
             ResizeDialog(
                 currentBridge = currentBridge,
@@ -1008,6 +1024,47 @@ fun ConsoleScreen(
             }
         }
     }
+}
+
+@Composable
+private fun AuthBannerDialog(
+    banner: AuthBanner,
+    onDismiss: () -> Unit,
+) {
+    val annotatedMessage = remember(banner.message, banner.urls) {
+        buildAnnotatedString {
+            var startIndex = 0
+            banner.urls.forEach { url ->
+                val urlIndex = banner.message.indexOf(url, startIndex)
+                if (urlIndex >= 0) {
+                    append(banner.message.substring(startIndex, urlIndex))
+                    withLink(LinkAnnotation.Url(url)) {
+                        append(url)
+                    }
+                    startIndex = urlIndex + url.length
+                }
+            }
+            append(banner.message.substring(startIndex))
+        }
+    }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = {
+            Text(stringResource(R.string.auth_banner_title, banner.sourceName))
+        },
+        text = {
+            Text(
+                text = annotatedMessage,
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.button_close))
+            }
+        },
+    )
 }
 
 @Composable

--- a/app/src/main/java/org/connectbot/util/UrlUtils.kt
+++ b/app/src/main/java/org/connectbot/util/UrlUtils.kt
@@ -1,6 +1,6 @@
 /*
  * ConnectBot: simple, powerful, open-source SSH client for Android
- * Copyright 2025 Kenny Root
+ * Copyright 2025-2026 Kenny Root
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,8 @@ import androidx.core.net.toUri
 
 object UrlUtils {
     private val schemeRegex = Regex("^[a-zA-Z][a-zA-Z0-9+.-]*:")
+    private val safeUrlRegex = Regex("""https?://[^\s<>"']+""", RegexOption.IGNORE_CASE)
+    private val trailingPunctuation = setOf('.', ',', ';', ':', '!', '?', ')', ']', '}', '>')
 
     /**
      * Normalizes a URL string by trimming and adding a default scheme if missing.
@@ -65,6 +67,11 @@ object UrlUtils {
 
         return "https://$trimmedUrl"
     }
+
+    fun extractUrls(text: String): List<String> = safeUrlRegex.findAll(text)
+        .map { match -> match.value.trimEnd { it in trailingPunctuation } }
+        .filter { it.isNotEmpty() }
+        .toList()
 
     private val supportedSchemes = setOf("http", "https", "mailto", "tel")
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -601,6 +601,8 @@
 	<string name="console_url_no_handler">No app available to open this URL</string>
 	<!-- Error shown in a snackbar when the URL type is not supported -->
 	<string name="console_url_not_supported">This URL type is not supported</string>
+	<!-- Dialog title for an SSH authentication banner sent by a server. Parameter is the host or jump host name. -->
+	<string name="auth_banner_title">Authentication message from %1$s</string>
 
 	<!-- Button label to answer "Yes" to a yes/no prompt -->
 	<string name="button_yes">"Yes"</string>
@@ -709,6 +711,8 @@
 
 	<!-- Message shown in terminal when starting authentication process -->
 	<string name="terminal_auth">"Trying to authenticate"</string>
+	<!-- Header shown before an SSH authentication banner in the terminal. Parameter is the host or jump host name. -->
+	<string name="terminal_auth_banner_header">"[%1$s] Authentication message:"</string>
 
 	<!-- Message shown in terminal when attempting password authentication method -->
 	<string name="terminal_auth_pass">"Attempting 'password' authentication"</string>

--- a/app/src/test/kotlin/org/connectbot/transport/SSHAuthBannerTest.kt
+++ b/app/src/test/kotlin/org/connectbot/transport/SSHAuthBannerTest.kt
@@ -1,0 +1,159 @@
+/*
+ * ConnectBot: simple, powerful, open-source SSH client for Android
+ * Copyright 2026 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.connectbot.transport
+
+import com.trilead.ssh2.Connection
+import org.connectbot.data.entity.Host
+import org.connectbot.service.TerminalBridge
+import org.connectbot.util.HostConstants
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.verifyNoInteractions
+import org.mockito.Mockito.`when`
+import java.io.IOException
+
+class SSHAuthBannerTest {
+    @Test
+    fun authenticate_whenNoneAuthSucceeds_dismissesAuthBanner() {
+        val bridge = mock(TerminalBridge::class.java)
+        val connection = mock(Connection::class.java)
+        `when`(connection.authenticateWithNone("alice")).thenReturn(true)
+        val ssh = sshWithConnection(bridge, connection)
+
+        ssh.authenticate()
+
+        verify(bridge).dismissAuthBannersFrom("target")
+    }
+
+    @Test
+    fun authenticate_whenNoneAuthFails_dismissesAuthBannerBeforeContinuing() {
+        val bridge = mock(TerminalBridge::class.java)
+        val connection = mock(Connection::class.java)
+        `when`(connection.authenticateWithNone("alice")).thenReturn(false)
+        val ssh = sshWithConnection(bridge, connection)
+
+        ssh.authenticate()
+
+        verify(bridge).dismissAuthBannersFrom("target")
+    }
+
+    @Test
+    fun authenticate_whenNoneAuthThrows_dismissesAuthBannerBeforeContinuing() {
+        val bridge = mock(TerminalBridge::class.java)
+        val connection = mock(Connection::class.java)
+        `when`(connection.authenticateWithNone("alice")).thenThrow(IOException("none failed"))
+        val ssh = sshWithConnection(bridge, connection)
+
+        ssh.authenticate()
+
+        verify(bridge).dismissAuthBannersFrom("target")
+    }
+
+    @Test
+    fun authenticateJumpHost_whenNoneAuthThrows_dismissesAuthBanner() {
+        val bridge = mock(TerminalBridge::class.java)
+        val connection = mock(Connection::class.java)
+        val jumpHost = Host(
+            nickname = "jump",
+            username = "alice",
+            hostname = "jump.example.com",
+        )
+        `when`(connection.authenticateWithNone("alice")).thenThrow(IOException("none failed"))
+        val ssh = SSH().apply {
+            setBridge(bridge)
+        }
+
+        ssh.authenticateJumpHost(connection, jumpHost)
+
+        verify(bridge).dismissAuthBannersFrom("jump")
+    }
+
+    @Test
+    fun handleAuthBanner_outputsSourceAndBanner() {
+        val bridge = mock(TerminalBridge::class.java)
+        val ssh = SSH().apply {
+            setBridge(bridge)
+        }
+
+        ssh.handleAuthBanner("target", "Visit https://login.tailscale.com/a/123456", "en")
+
+        verify(bridge).outputLine("[target] Authentication message:")
+        verify(bridge).outputLine("Visit https://login.tailscale.com/a/123456")
+    }
+
+    @Test
+    fun handleAuthBanner_blankBanner_isIgnored() {
+        val bridge = mock(TerminalBridge::class.java)
+        val ssh = SSH().apply {
+            setBridge(bridge)
+        }
+
+        ssh.handleAuthBanner("target", "   ", "en")
+
+        verifyNoInteractions(bridge)
+    }
+
+    @Test
+    fun handleAuthBanner_withUrl_enqueuesAuthBanner() {
+        val bridge = mock(TerminalBridge::class.java)
+        val ssh = SSH().apply {
+            setBridge(bridge)
+        }
+
+        ssh.handleAuthBanner("jump", "Visit https://login.tailscale.com/a/123456", "en")
+
+        verify(bridge).enqueueAuthBanner(
+            "jump",
+            "Visit https://login.tailscale.com/a/123456",
+            listOf("https://login.tailscale.com/a/123456"),
+            "en",
+        )
+    }
+
+    @Test
+    fun handleAuthBanner_withoutUrl_doesNotEnqueueAuthBanner() {
+        val bridge = mock(TerminalBridge::class.java)
+        val ssh = SSH().apply {
+            setBridge(bridge)
+        }
+
+        ssh.handleAuthBanner("target", "Authentication will continue.", null)
+
+        verify(bridge, never()).enqueueAuthBanner(
+            org.mockito.ArgumentMatchers.anyString(),
+            org.mockito.ArgumentMatchers.anyString(),
+            org.mockito.ArgumentMatchers.anyList(),
+            org.mockito.ArgumentMatchers.any(),
+        )
+    }
+
+    private fun sshWithConnection(bridge: TerminalBridge, connection: Connection): SSH = SSH().apply {
+        setHost(
+            Host(
+                nickname = "target",
+                username = "alice",
+                hostname = "example.com",
+                pubkeyId = HostConstants.PUBKEYID_NEVER,
+            ),
+        )
+        setBridge(bridge)
+        setConnectionForTesting(connection)
+    }
+}

--- a/app/src/test/kotlin/org/connectbot/util/UrlUtilsTest.kt
+++ b/app/src/test/kotlin/org/connectbot/util/UrlUtilsTest.kt
@@ -1,6 +1,6 @@
 /*
  * ConnectBot: simple, powerful, open-source SSH client for Android
- * Copyright 2025 Kenny Root
+ * Copyright 2025-2026 Kenny Root
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -73,6 +73,43 @@ class UrlUtilsTest {
         assertEquals("https://example.com/path://foo", UrlUtils.normalizeUrl("example.com/path://foo"))
         assertEquals("https://localhost:3000", UrlUtils.normalizeUrl("localhost:3000"))
         assertEquals("https://myhost:8080/api/v1", UrlUtils.normalizeUrl("myhost:8080/api/v1"))
+    }
+
+    @Test
+    fun extractUrls_WithTailscaleBanner_ReturnsHttpsUrl() {
+        val banner = "To authenticate, visit https://login.tailscale.com/a/123456"
+
+        assertEquals(
+            listOf("https://login.tailscale.com/a/123456"),
+            UrlUtils.extractUrls(banner),
+        )
+    }
+
+    @Test
+    fun extractUrls_WithMultipleUrls_ReturnsAllUrls() {
+        val banner = "Open https://example.com/one or http://example.org/two"
+
+        assertEquals(
+            listOf("https://example.com/one", "http://example.org/two"),
+            UrlUtils.extractUrls(banner),
+        )
+    }
+
+    @Test
+    fun extractUrls_WithTrailingPunctuation_TrimsPunctuation() {
+        val banner = "Visit (https://example.com/auth), then continue."
+
+        assertEquals(
+            listOf("https://example.com/auth"),
+            UrlUtils.extractUrls(banner),
+        )
+    }
+
+    @Test
+    fun extractUrls_WithUnsupportedSchemes_IgnoresSchemes() {
+        val banner = "Do not link javascript:alert(1) or file:///etc/passwd"
+
+        assertEquals(emptyList<String>(), UrlUtils.extractUrls(banner))
     }
 
     @Test


### PR DESCRIPTION
This is mainly for Tailscale integration (#1150 / #2211). If the server sends a banner during "none" authentication, display it for the user. If it contains a URL, make it linkified safely. The user can then click on the URL and be redirected to their browser of choice.