### PR TITLE
minor translation corrections

### DIFF
--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -227,7 +227,7 @@
   <string name="profile_list_create_profile">创建配置文件</string>
   <string name="profile_list_empty_message">目前还没有配置文件。点击“+”来创建一个。</string>
   <string name="profile_list_more_options">更多选项</string>
-  <string name="profile_list_duplicate">重复</string>
+  <string name="profile_list_duplicate">复制</string>
   <string name="profile_list_delete">删除</string>
   <string name="profile_create_dialog_title">创建配置文件</string>
   <string name="profile_create_name_label">配置文件名称</string>
@@ -266,7 +266,7 @@
   <string name="list_host_edit">编辑主机</string>
   <string name="list_host_portforwards">编辑端口转发</string>
   <string name="list_host_delete">删除主机</string>
-  <string name="list_host_duplicate">重复的主机名</string>
+  <string name="list_host_duplicate">复制主机</string>
   <string name="list_host_forget_keys">忘记主机密钥</string>
   <string name="list_rotation_default">默认</string>
   <string name="list_rotation_land">强制横屏显示</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -227,7 +227,7 @@
   <string name="profile_list_create_profile">建立設定檔</string>
   <string name="profile_list_empty_message">目前沒有設定任何設定檔。點擊「+」按鈕來建立一個。</string>
   <string name="profile_list_more_options">更多選項</string>
-  <string name="profile_list_duplicate">重複</string>
+  <string name="profile_list_duplicate">複製</string>
   <string name="profile_list_delete">刪除</string>
   <string name="profile_create_dialog_title">建立設定檔</string>
   <string name="profile_create_name_label">個人檔案名稱</string>
@@ -266,7 +266,7 @@
   <string name="list_host_edit">編輯主機</string>
   <string name="list_host_portforwards">編輯連接埠轉址</string>
   <string name="list_host_delete">刪除主機</string>
-  <string name="list_host_duplicate">主機名稱重複</string>
+  <string name="list_host_duplicate">複製主機</string>
   <string name="list_host_forget_keys">忘記主機金鑰</string>
   <string name="list_rotation_default">預設值</string>
   <string name="list_rotation_land">強制橫屏顯示</string>


### PR DESCRIPTION
"重复"(Siml. Chinese)/"重複"(Trad. Chinese) means "to repeat" as a verb, which itself isn't a very appropriate translation, and it's erroneously used as a adjective here: then "重复的主机名"/"主機名稱重複" actually means "repeated host names" in English, obviously wrong!
"复制"(Siml. Chinese)/'複製"(Trad. Chinese) means "to copy" as a verb, which should be appropriate.