### PR TITLE
fix(pubkey): export Ed25519 private keys

### DIFF
--- a/app/src/main/java/org/connectbot/transport/SSH.kt
+++ b/app/src/main/java/org/connectbot/transport/SSH.kt
@@ -58,6 +58,7 @@ import org.connectbot.service.requestHostKeyFingerprintPrompt
 import org.connectbot.service.requestStringPrompt
 import org.connectbot.util.HostConstants
 import org.connectbot.util.PubkeyUtils
+import org.connectbot.util.SshKeyType
 import org.connectbot.util.UrlUtils
 import timber.log.Timber
 import java.io.IOException
@@ -209,12 +210,7 @@ class SSH :
     }
 
     @VisibleForTesting
-    internal fun getKeyType(openSshKeyType: String): String? = when (openSshKeyType) {
-        "ssh-rsa", "rsa-sha2-256", "rsa-sha2-512" -> "RSA"
-        "ssh-dss" -> "DSA"
-        "ssh-ed25519" -> "Ed25519"
-        else -> if (openSshKeyType.startsWith("ecdsa-sha2-")) "EC" else null
-    }
+    internal fun getKeyType(openSshKeyType: String): String? = SshKeyType.fromOpenSshType(openSshKeyType)?.storedName
 
     inner class HostKeyVerifier(private val verifyHost: Host? = host) : ExtendedServerHostKeyVerifier() {
         @Throws(IOException::class)

--- a/app/src/main/java/org/connectbot/ui/screens/pubkeylist/PubkeyListViewModel.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/pubkeylist/PubkeyListViewModel.kt
@@ -1,6 +1,6 @@
 /*
  * ConnectBot: simple, powerful, open-source SSH client for Android
- * Copyright 2025 Kenny Root
+ * Copyright 2025-2026 Kenny Root
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,6 +43,7 @@ import org.connectbot.di.CoroutineDispatchers
 import org.connectbot.service.TerminalManager
 import org.connectbot.util.BiometricKeyManager
 import org.connectbot.util.PubkeyUtils
+import org.connectbot.util.SshKeyType
 import timber.log.Timber
 import java.io.BufferedReader
 import java.io.ByteArrayInputStream
@@ -1015,13 +1016,5 @@ class PubkeyListViewModel @Inject constructor(
         return filename
     }
 
-    /**
-     * Convert algorithm name from Java format to ConnectBot internal format.
-     * EdDSA -> Ed25519
-     */
-    private fun convertAlgorithmName(algorithm: String): String = if (algorithm == "EdDSA") {
-        "Ed25519"
-    } else {
-        algorithm
-    }
+    private fun convertAlgorithmName(algorithm: String): String = SshKeyType.fromJavaAlgorithm(algorithm)?.storedName ?: algorithm
 }

--- a/app/src/main/java/org/connectbot/util/PubkeyUtils.kt
+++ b/app/src/main/java/org/connectbot/util/PubkeyUtils.kt
@@ -18,7 +18,9 @@
 package org.connectbot.util
 
 import com.trilead.ssh2.crypto.PEMDecoder
+import com.trilead.ssh2.crypto.keys.Ed25519PrivateKey
 import com.trilead.ssh2.crypto.keys.Ed25519Provider
+import com.trilead.ssh2.crypto.keys.Ed25519PublicKey
 import org.connectbot.data.entity.Pubkey
 import timber.log.Timber
 import java.security.Key
@@ -96,8 +98,17 @@ object PubkeyUtils {
 
     @Throws(NoSuchAlgorithmException::class, InvalidKeySpecException::class)
     fun decodePrivate(encoded: ByteArray?, keyType: String?): PrivateKey? {
-        val privKeySpec = PKCS8EncodedKeySpec(encoded)
-        val kf = KeyFactory.getInstance(keyType)
+        val privateKeyBytes = encoded ?: throw InvalidKeySpecException("Missing private key data")
+        val sshKeyType = SshKeyType.fromStoredType(keyType)
+            ?: throw NoSuchAlgorithmException("Unsupported key type: $keyType")
+        if (sshKeyType == SshKeyType.ED25519) {
+            return Ed25519PrivateKey(PKCS8EncodedKeySpec(privateKeyBytes))
+        }
+
+        val algorithm = sshKeyType.keyFactoryAlgorithm
+            ?: throw NoSuchAlgorithmException("Unsupported key type: $keyType")
+        val privKeySpec = PKCS8EncodedKeySpec(privateKeyBytes)
+        val kf = KeyFactory.getInstance(algorithm)
         return kf.generatePrivate(privKeySpec)
     }
 
@@ -113,8 +124,17 @@ object PubkeyUtils {
 
     @Throws(NoSuchAlgorithmException::class, InvalidKeySpecException::class)
     fun decodePublic(encoded: ByteArray?, keyType: String?): PublicKey {
-        val pubKeySpec = X509EncodedKeySpec(encoded)
-        val kf = KeyFactory.getInstance(keyType)
+        val publicKeyBytes = encoded ?: throw InvalidKeySpecException("Missing public key data")
+        val sshKeyType = SshKeyType.fromStoredType(keyType)
+            ?: throw NoSuchAlgorithmException("Unsupported key type: $keyType")
+        if (sshKeyType == SshKeyType.ED25519) {
+            return Ed25519PublicKey(X509EncodedKeySpec(publicKeyBytes))
+        }
+
+        val algorithm = sshKeyType.keyFactoryAlgorithm
+            ?: throw NoSuchAlgorithmException("Unsupported key type: $keyType")
+        val pubKeySpec = X509EncodedKeySpec(publicKeyBytes)
+        val kf = KeyFactory.getInstance(algorithm)
         return kf.generatePublic(pubKeySpec)
     }
 

--- a/app/src/main/java/org/connectbot/util/SshKeyType.kt
+++ b/app/src/main/java/org/connectbot/util/SshKeyType.kt
@@ -1,0 +1,56 @@
+/*
+ * ConnectBot: simple, powerful, open-source SSH client for Android
+ * Copyright 2026 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.connectbot.util
+
+enum class SshKeyType(
+    val storedName: String,
+    val keyFactoryAlgorithm: String?,
+) {
+    RSA("RSA", "RSA"),
+    DSA("DSA", "DSA"),
+    EC("EC", "EC"),
+    ED25519("Ed25519", null),
+    LEGACY_IMPORTED("IMPORTED", null),
+    ;
+
+    companion object {
+        fun fromStoredType(value: String?): SshKeyType? = when (value) {
+            "RSA", "ssh-rsa", "rsa-sha2-256", "rsa-sha2-512" -> RSA
+            "DSA", "ssh-dss" -> DSA
+            "EC", "ECDSA" -> EC
+            "Ed25519", "EdDSA", "ssh-ed25519" -> ED25519
+            "IMPORTED" -> LEGACY_IMPORTED
+            else -> if (value?.startsWith("ecdsa-sha2-") == true) EC else null
+        }
+
+        fun fromOpenSshType(value: String): SshKeyType? = when (value) {
+            "ssh-rsa", "rsa-sha2-256", "rsa-sha2-512" -> RSA
+            "ssh-dss" -> DSA
+            "ssh-ed25519" -> ED25519
+            else -> if (value.startsWith("ecdsa-sha2-")) EC else null
+        }
+
+        fun fromJavaAlgorithm(value: String): SshKeyType? = when (value) {
+            "RSA" -> RSA
+            "DSA" -> DSA
+            "EC", "ECDSA" -> EC
+            "Ed25519", "EdDSA" -> ED25519
+            else -> null
+        }
+    }
+}

--- a/app/src/test/kotlin/org/connectbot/util/PubkeyUtilsTest.kt
+++ b/app/src/test/kotlin/org/connectbot/util/PubkeyUtilsTest.kt
@@ -1,0 +1,64 @@
+/*
+ * ConnectBot: simple, powerful, open-source SSH client for Android
+ * Copyright 2026 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.connectbot.util
+
+import com.trilead.ssh2.crypto.OpenSSHKeyEncoder
+import com.trilead.ssh2.crypto.PEMEncoder
+import com.trilead.ssh2.crypto.keys.Ed25519KeyPairGenerator
+import com.trilead.ssh2.crypto.keys.Ed25519PrivateKey
+import com.trilead.ssh2.crypto.keys.Ed25519PublicKey
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class PubkeyUtilsTest {
+
+    private val ed25519KeyPair = Ed25519KeyPairGenerator().generateKeyPair()
+
+    @Test
+    fun decodePrivate_ed25519StoredType_returnsSshlibKey() {
+        val privateKey = PubkeyUtils.decodePrivate(ed25519KeyPair.private.encoded, "Ed25519")
+
+        assertThat(privateKey).isInstanceOf(Ed25519PrivateKey::class.java)
+    }
+
+    @Test
+    fun decodePublic_ed25519StoredType_returnsSshlibKey() {
+        val publicKey = PubkeyUtils.decodePublic(ed25519KeyPair.public.encoded, "Ed25519")
+
+        assertThat(publicKey).isInstanceOf(Ed25519PublicKey::class.java)
+    }
+
+    @Test
+    fun decodePrivate_legacyOpenSshEd25519Type_returnsSshlibKey() {
+        val privateKey = PubkeyUtils.decodePrivate(ed25519KeyPair.private.encoded, "ssh-ed25519")
+
+        assertThat(privateKey).isInstanceOf(Ed25519PrivateKey::class.java)
+    }
+
+    @Test
+    fun decodedEd25519Key_canBeEncodedAsOpenSshAndPem() {
+        val privateKey = PubkeyUtils.decodePrivate(ed25519KeyPair.private.encoded, "Ed25519")
+        val publicKey = PubkeyUtils.decodePublic(ed25519KeyPair.public.encoded, "Ed25519")
+
+        val openSsh = OpenSSHKeyEncoder.exportOpenSSH(privateKey, publicKey, "test-key")
+        val pem = PEMEncoder.encodePrivateKey(privateKey, null)
+
+        assertThat(openSsh).contains("-----BEGIN OPENSSH PRIVATE KEY-----")
+        assertThat(pem).contains("-----BEGIN PRIVATE KEY-----")
+    }
+}

--- a/app/src/test/kotlin/org/connectbot/util/SshKeyTypeTest.kt
+++ b/app/src/test/kotlin/org/connectbot/util/SshKeyTypeTest.kt
@@ -1,0 +1,61 @@
+/*
+ * ConnectBot: simple, powerful, open-source SSH client for Android
+ * Copyright 2026 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.connectbot.util
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class SshKeyTypeTest {
+
+    @Test
+    fun fromStoredType_mapsCanonicalTypes() {
+        assertThat(SshKeyType.fromStoredType("RSA")).isEqualTo(SshKeyType.RSA)
+        assertThat(SshKeyType.fromStoredType("DSA")).isEqualTo(SshKeyType.DSA)
+        assertThat(SshKeyType.fromStoredType("EC")).isEqualTo(SshKeyType.EC)
+        assertThat(SshKeyType.fromStoredType("Ed25519")).isEqualTo(SshKeyType.ED25519)
+        assertThat(SshKeyType.fromStoredType("IMPORTED")).isEqualTo(SshKeyType.LEGACY_IMPORTED)
+    }
+
+    @Test
+    fun fromStoredType_mapsLegacyOpenSshTypes() {
+        assertThat(SshKeyType.fromStoredType("ssh-rsa")).isEqualTo(SshKeyType.RSA)
+        assertThat(SshKeyType.fromStoredType("rsa-sha2-256")).isEqualTo(SshKeyType.RSA)
+        assertThat(SshKeyType.fromStoredType("ssh-dss")).isEqualTo(SshKeyType.DSA)
+        assertThat(SshKeyType.fromStoredType("ecdsa-sha2-nistp256")).isEqualTo(SshKeyType.EC)
+        assertThat(SshKeyType.fromStoredType("ssh-ed25519")).isEqualTo(SshKeyType.ED25519)
+    }
+
+    @Test
+    fun fromJavaAlgorithm_mapsProviderAlgorithms() {
+        assertThat(SshKeyType.fromJavaAlgorithm("RSA")).isEqualTo(SshKeyType.RSA)
+        assertThat(SshKeyType.fromJavaAlgorithm("EC")).isEqualTo(SshKeyType.EC)
+        assertThat(SshKeyType.fromJavaAlgorithm("ECDSA")).isEqualTo(SshKeyType.EC)
+        assertThat(SshKeyType.fromJavaAlgorithm("EdDSA")).isEqualTo(SshKeyType.ED25519)
+        assertThat(SshKeyType.fromJavaAlgorithm("Ed25519")).isEqualTo(SshKeyType.ED25519)
+    }
+
+    @Test
+    fun ed25519_hasNoGenericKeyFactoryAlgorithm() {
+        assertThat(SshKeyType.ED25519.keyFactoryAlgorithm).isNull()
+    }
+
+    @Test
+    fun unknownType_returnsNull() {
+        assertThat(SshKeyType.fromStoredType("sk-ecdsa-sha2-nistp256@openssh.com")).isNull()
+    }
+}


### PR DESCRIPTION
- centralize SSH key type normalization in `SshKeyType`
- decode Ed25519 keys using sshlib key classes instead of provider-specific Conscrypt classes
- fix OpenSSH and PEM private key copy/export for Ed25519 keys
- add targeted tests for key type mapping and Ed25519 encoding

should fix #2233