### PR TITLE
chore: expand shortcuts to IMEs as well

### DIFF
--- a/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
@@ -89,6 +89,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.isCtrlPressed
 import androidx.compose.ui.input.key.isShiftPressed
@@ -159,6 +160,56 @@ const val AUTO_HIDE_DELAY_MS = 3000L
 
 internal object ConsoleTestTags {
     const val AUTH_BANNER_MESSAGE = "auth_banner_message"
+}
+
+internal fun handleConsoleShortcut(
+    keyEvent: KeyEvent,
+    volumeKeysChangeFontSize: Boolean,
+    copySelection: () -> Unit,
+    pasteClipboardContents: () -> Unit,
+    increaseFontSize: () -> Unit,
+    decreaseFontSize: () -> Unit,
+): Boolean {
+    if (keyEvent.type != KeyEventType.KeyDown) return false
+
+    return when {
+        // Ctrl+Shift+C: copy selection
+        keyEvent.key == Key.C && keyEvent.isCtrlPressed && keyEvent.isShiftPressed -> {
+            copySelection()
+            true
+        }
+
+        // Ctrl+Shift+V: paste clipboard content
+        keyEvent.key == Key.V && keyEvent.isCtrlPressed && keyEvent.isShiftPressed -> {
+            pasteClipboardContents()
+            true
+        }
+
+        // Ctrl+Shift+= (Ctrl++): increase font size
+        keyEvent.isCtrlPressed && keyEvent.isShiftPressed && keyEvent.key == Key.Equals -> {
+            increaseFontSize()
+            true
+        }
+
+        // Ctrl+Shift+-: decrease font size
+        keyEvent.isCtrlPressed && keyEvent.isShiftPressed && keyEvent.key == Key.Minus -> {
+            decreaseFontSize()
+            true
+        }
+
+        // Volume keys: change font size
+        volumeKeysChangeFontSize && keyEvent.key == Key.VolumeUp -> {
+            increaseFontSize()
+            true
+        }
+
+        volumeKeysChangeFontSize && keyEvent.key == Key.VolumeDown -> {
+            decreaseFontSize()
+            true
+        }
+
+        else -> false
+    }
 }
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
@@ -511,6 +562,17 @@ fun ConsoleScreen(
             }
         }
 
+        val handleShortcut: (KeyEvent) -> Boolean = { keyEvent ->
+            handleConsoleShortcut(
+                keyEvent = keyEvent,
+                volumeKeysChangeFontSize = volumeKeysChangeFontSize,
+                copySelection = { selectionController?.copySelection() },
+                pasteClipboardContents = { pasteClipboardContents() },
+                increaseFontSize = { currentBridge?.increaseFontSize() },
+                decreaseFontSize = { currentBridge?.decreaseFontSize() },
+            )
+        }
+
         // Terminal content with keyboard overlay
         // This Box is transparent to accessibility - it's just for layout
         val layoutDirection = LocalLayoutDirection.current
@@ -525,50 +587,7 @@ fun ConsoleScreen(
                     bottom = innerPadding.calculateBottomPadding(),
                 )
                 .windowInsetsPadding(WindowInsets.imeAnimationTarget)
-                .onPreviewKeyEvent { keyEvent ->
-                    if (keyEvent.type == KeyEventType.KeyDown) {
-                        when {
-                            // Ctrl+Shift+C: copy selection
-                            keyEvent.key == Key.C && keyEvent.isCtrlPressed && keyEvent.isShiftPressed -> {
-                                selectionController?.copySelection()
-                                true
-                            }
-
-                            // Ctrl+Shift+V: paste clipboard content
-                            keyEvent.key == Key.V && keyEvent.isCtrlPressed && keyEvent.isShiftPressed -> {
-                                pasteClipboardContents()
-                                true
-                            }
-
-                            // Ctrl+Shift+= (Ctrl++): increase font size
-                            keyEvent.isCtrlPressed && keyEvent.isShiftPressed && keyEvent.key == Key.Equals -> {
-                                currentBridge?.increaseFontSize()
-                                true
-                            }
-
-                            // Ctrl+Shift+-: decrease font size
-                            keyEvent.isCtrlPressed && keyEvent.isShiftPressed && keyEvent.key == Key.Minus -> {
-                                currentBridge?.decreaseFontSize()
-                                true
-                            }
-
-                            // Volume keys: change font size
-                            volumeKeysChangeFontSize && keyEvent.key == Key.VolumeUp -> {
-                                currentBridge?.increaseFontSize()
-                                true
-                            }
-
-                            volumeKeysChangeFontSize && keyEvent.key == Key.VolumeDown -> {
-                                currentBridge?.decreaseFontSize()
-                                true
-                            }
-
-                            else -> false
-                        }
-                    } else {
-                        false
-                    }
-                },
+                .onPreviewKeyEvent(handleShortcut),
         ) {
             when {
                 uiState.isLoading -> {
@@ -638,6 +657,7 @@ fun ConsoleScreen(
                             onPasteRequest = {
                                 pasteClipboardContents()
                             },
+                            onInterceptKey = handleShortcut,
                         )
 
                         // Set up text input request callback from bridge (for camera button)

--- a/app/src/test/kotlin/org/connectbot/ui/screens/console/ConsoleShortcutHandlerTest.kt
+++ b/app/src/test/kotlin/org/connectbot/ui/screens/console/ConsoleShortcutHandlerTest.kt
@@ -1,0 +1,120 @@
+/*
+ * ConnectBot: simple, powerful, open-source SSH client for Android
+ * Copyright 2026 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.connectbot.ui.screens.console
+
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import android.view.KeyEvent as AndroidKeyEvent
+
+@RunWith(AndroidJUnit4::class)
+class ConsoleShortcutHandlerTest {
+    @Test
+    fun handleConsoleShortcut_invokesCtrlShiftActions() {
+        val callbacks = ShortcutCallbacks()
+
+        assertTrue(callbacks.handle(keyDown(AndroidKeyEvent.KEYCODE_C, CTRL_SHIFT_META_STATE)))
+        assertEquals(1, callbacks.copyCount)
+
+        assertTrue(callbacks.handle(keyDown(AndroidKeyEvent.KEYCODE_V, CTRL_SHIFT_META_STATE)))
+        assertEquals(1, callbacks.pasteCount)
+
+        assertTrue(callbacks.handle(keyDown(AndroidKeyEvent.KEYCODE_EQUALS, CTRL_SHIFT_META_STATE)))
+        assertEquals(1, callbacks.increaseCount)
+
+        assertTrue(callbacks.handle(keyDown(AndroidKeyEvent.KEYCODE_MINUS, CTRL_SHIFT_META_STATE)))
+        assertEquals(1, callbacks.decreaseCount)
+    }
+
+    @Test
+    fun handleConsoleShortcut_invokesEnabledVolumeKeyActions() {
+        val callbacks = ShortcutCallbacks(volumeKeysChangeFontSize = true)
+
+        assertTrue(callbacks.handle(keyDown(AndroidKeyEvent.KEYCODE_VOLUME_UP)))
+        assertEquals(1, callbacks.increaseCount)
+
+        assertTrue(callbacks.handle(keyDown(AndroidKeyEvent.KEYCODE_VOLUME_DOWN)))
+        assertEquals(1, callbacks.decreaseCount)
+    }
+
+    @Test
+    fun handleConsoleShortcut_ignoresKeyUpEvents() {
+        val callbacks = ShortcutCallbacks()
+
+        assertFalse(callbacks.handle(keyUp(AndroidKeyEvent.KEYCODE_C, CTRL_SHIFT_META_STATE)))
+        callbacks.assertNoActions()
+    }
+
+    @Test
+    fun handleConsoleShortcut_ignoresIncompleteModifiersAndUnrelatedKeys() {
+        val callbacks = ShortcutCallbacks()
+
+        assertFalse(callbacks.handle(keyDown(AndroidKeyEvent.KEYCODE_C, AndroidKeyEvent.META_CTRL_ON)))
+        assertFalse(callbacks.handle(keyDown(AndroidKeyEvent.KEYCODE_V, AndroidKeyEvent.META_SHIFT_ON)))
+        assertFalse(callbacks.handle(keyDown(AndroidKeyEvent.KEYCODE_A, CTRL_SHIFT_META_STATE)))
+        callbacks.assertNoActions()
+    }
+
+    @Test
+    fun handleConsoleShortcut_ignoresVolumeKeysWhenPreferenceDisabled() {
+        val callbacks = ShortcutCallbacks(volumeKeysChangeFontSize = false)
+
+        assertFalse(callbacks.handle(keyDown(AndroidKeyEvent.KEYCODE_VOLUME_UP)))
+        assertFalse(callbacks.handle(keyDown(AndroidKeyEvent.KEYCODE_VOLUME_DOWN)))
+        callbacks.assertNoActions()
+    }
+
+    private class ShortcutCallbacks(
+        private val volumeKeysChangeFontSize: Boolean = false,
+    ) {
+        var copyCount = 0
+        var pasteCount = 0
+        var increaseCount = 0
+        var decreaseCount = 0
+
+        fun handle(keyEvent: KeyEvent): Boolean = handleConsoleShortcut(
+            keyEvent = keyEvent,
+            volumeKeysChangeFontSize = volumeKeysChangeFontSize,
+            copySelection = { copyCount++ },
+            pasteClipboardContents = { pasteCount++ },
+            increaseFontSize = { increaseCount++ },
+            decreaseFontSize = { decreaseCount++ },
+        )
+
+        fun assertNoActions() {
+            assertEquals(0, copyCount)
+            assertEquals(0, pasteCount)
+            assertEquals(0, increaseCount)
+            assertEquals(0, decreaseCount)
+        }
+    }
+
+    private companion object {
+        const val CTRL_SHIFT_META_STATE = AndroidKeyEvent.META_CTRL_ON or AndroidKeyEvent.META_SHIFT_ON
+
+        fun keyDown(keyCode: Int, metaState: Int = 0): KeyEvent = composeKeyEvent(AndroidKeyEvent.ACTION_DOWN, keyCode, metaState)
+
+        fun keyUp(keyCode: Int, metaState: Int = 0): KeyEvent = composeKeyEvent(AndroidKeyEvent.ACTION_UP, keyCode, metaState)
+
+        fun composeKeyEvent(action: Int, keyCode: Int, metaState: Int): KeyEvent = KeyEvent(AndroidKeyEvent(0L, 0L, action, keyCode, 0, metaState))
+    }
+}


### PR DESCRIPTION
Use the new termlib API to intercept keys to apply our app-specific shortcuts!

Fixes #2156