### PR TITLE
Fix Ctrl-D clean SSH disconnect

### DIFF
--- a/app/src/main/java/org/connectbot/service/DisconnectPolicy.kt
+++ b/app/src/main/java/org/connectbot/service/DisconnectPolicy.kt
@@ -24,6 +24,7 @@ object DisconnectPolicy {
         stayConnected: Boolean,
     ): DisconnectAction {
         if (reason == DisconnectReason.USER_REQUESTED) return DisconnectAction.CloseImmediately
+        if (reason == DisconnectReason.SESSION_EXIT) return DisconnectAction.CloseImmediately
         if (quickDisconnect) return DisconnectAction.CloseImmediately
         // Never auto-reconnect on auth failures — looping would lock accounts
         if (reason == DisconnectReason.AUTH_FAIL) return DisconnectAction.ShowReconnectOverlay

--- a/app/src/main/java/org/connectbot/service/DisconnectReason.kt
+++ b/app/src/main/java/org/connectbot/service/DisconnectReason.kt
@@ -19,6 +19,7 @@ package org.connectbot.service
 
 enum class DisconnectReason {
     USER_REQUESTED,
+    SESSION_EXIT,
     REMOTE_EOF,
     IO_ERROR,
     NETWORK_LOST,

--- a/app/src/main/java/org/connectbot/service/TerminalBridge.kt
+++ b/app/src/main/java/org/connectbot/service/TerminalBridge.kt
@@ -23,6 +23,7 @@ import android.content.Context
 import android.graphics.Paint
 import android.graphics.Typeface
 import android.net.Network
+import android.os.SystemClock
 import androidx.compose.ui.graphics.Color
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -209,6 +210,7 @@ class TerminalBridge {
     var disconnectReason: DisconnectReason = DisconnectReason.UNKNOWN
         private set
     private var awaitingClose = false
+    private val pendingUserEofSentAt = AtomicLong(0L)
 
     private var forcedSize = false
 
@@ -311,7 +313,7 @@ class TerminalBridge {
             defaultForeground = Color(defaultFgColor),
             defaultBackground = Color(defaultBgColor),
             onKeyboardInput = { data ->
-                transportOperations.trySend(TransportOperation.WriteData(data))
+                enqueueWriteData(data, trackUserEof = true)
             },
             onBell = {
                 scope.launch {
@@ -595,9 +597,7 @@ class TerminalBridge {
             return
         }
 
-        transportOperations.trySend(
-            TransportOperation.WriteData(string.toByteArray(charset(encoding))),
-        )
+        enqueueWriteData(string.toByteArray(charset(encoding)), trackUserEof = false)
     }
 
     /**
@@ -605,9 +605,7 @@ class TerminalBridge {
      * channel as [injectString] so keyboard input cannot interleave with paste data.
      */
     fun sendByte(c: Int) {
-        transportOperations.trySend(
-            TransportOperation.WriteData(byteArrayOf(c.toByte())),
-        )
+        enqueueWriteData(byteArrayOf(c.toByte()), trackUserEof = true)
     }
 
     /**
@@ -616,7 +614,30 @@ class TerminalBridge {
      */
     fun sendBytes(data: ByteArray) {
         if (data.isEmpty()) return
+        enqueueWriteData(data, trackUserEof = true)
+    }
+
+    private fun enqueueWriteData(data: ByteArray, trackUserEof: Boolean) {
+        updatePendingUserEof(data, trackUserEof)
         transportOperations.trySend(TransportOperation.WriteData(data))
+    }
+
+    private fun updatePendingUserEof(data: ByteArray, trackUserEof: Boolean) {
+        if (
+            trackUserEof &&
+            data.size == 1 &&
+            data[0].toInt() == USER_EOF_BYTE
+        ) {
+            pendingUserEofSentAt.set(SystemClock.elapsedRealtime())
+        } else if (data.isNotEmpty()) {
+            pendingUserEofSentAt.set(0L)
+        }
+    }
+
+    internal fun consumePendingUserEof(): Boolean {
+        val sentAt = pendingUserEofSentAt.getAndSet(0L)
+        return sentAt > 0 &&
+            SystemClock.elapsedRealtime() - sentAt <= USER_EOF_DISCONNECT_GRACE_MS
     }
 
     /**
@@ -1144,6 +1165,8 @@ class TerminalBridge {
 
         private const val DEFAULT_FONT_SIZE_SP = 10
         private const val FONT_SIZE_STEP = 2
+        private const val USER_EOF_BYTE = 0x04
+        private const val USER_EOF_DISCONNECT_GRACE_MS = 5_000L
     }
 }
 

--- a/app/src/main/java/org/connectbot/transport/Local.kt
+++ b/app/src/main/java/org/connectbot/transport/Local.kt
@@ -70,7 +70,7 @@ class Local @VisibleForTesting constructor(private val killer: Killer) : AbsTran
         shellPid = pids[0]
         val exitWatcher = Runnable {
             Exec.waitFor(shellPid)
-            bridge?.dispatchDisconnect(DisconnectReason.REMOTE_EOF)
+            bridge?.dispatchDisconnect(DisconnectReason.SESSION_EXIT)
         }
 
         val exitWatcherThread = Thread(exitWatcher)

--- a/app/src/main/java/org/connectbot/transport/SSH.kt
+++ b/app/src/main/java/org/connectbot/transport/SSH.kt
@@ -1038,10 +1038,29 @@ class SSH :
     }
 
     @VisibleForTesting
-    internal fun getDisconnectReasonForClosedSession(session: Session): DisconnectReason = if (session.exitStatus != null) {
-        DisconnectReason.SESSION_EXIT
-    } else {
-        DisconnectReason.REMOTE_EOF
+    internal fun getDisconnectReasonForClosedSession(session: Session): DisconnectReason {
+        if (session.exitStatus != null) {
+            return DisconnectReason.SESSION_EXIT
+        }
+
+        val closeStatus = session.waitForCondition(
+            ChannelCondition.EXIT_STATUS or ChannelCondition.EXIT_SIGNAL,
+            EXIT_STATUS_WAIT_MS,
+        )
+
+        if (session.exitStatus != null) {
+            return DisconnectReason.SESSION_EXIT
+        }
+
+        if ((closeStatus and ChannelCondition.EXIT_SIGNAL) != 0 || session.exitSignal != null) {
+            return DisconnectReason.REMOTE_EOF
+        }
+
+        if (bridge?.consumePendingUserEof() == true) {
+            return DisconnectReason.SESSION_EXIT
+        }
+
+        return DisconnectReason.REMOTE_EOF
     }
 
     @Throws(IOException::class)
@@ -1488,6 +1507,7 @@ class SSH :
         private const val AUTH_KEYBOARDINTERACTIVE = "keyboard-interactive"
 
         private const val AUTH_TRIES = 20
+        private const val EXIT_STATUS_WAIT_MS = 250L
 
         private val hostmask = Pattern.compile(
             "^(.+)@((?:[0-9a-z._-]+)|(?:\\[[a-f:0-9]+(?:%[-_.a-z0-9]+)?\\]))(?::(\\d+))?\$",

--- a/app/src/main/java/org/connectbot/transport/SSH.kt
+++ b/app/src/main/java/org/connectbot/transport/SSH.kt
@@ -1037,6 +1037,13 @@ class SSH :
         bridge?.dispatchDisconnect(reason)
     }
 
+    @VisibleForTesting
+    internal fun getDisconnectReasonForClosedSession(session: Session): DisconnectReason = if (session.exitStatus != null) {
+        DisconnectReason.SESSION_EXIT
+    } else {
+        DisconnectReason.REMOTE_EOF
+    }
+
     @Throws(IOException::class)
     override fun flush() {
         stdin?.flush()
@@ -1062,10 +1069,14 @@ class SSH :
         }
 
         if ((newConditions and ChannelCondition.EOF) != 0) {
-            // Dispatch REMOTE_EOF before close(): connection.close() fires
+            if (bytesRead > 0) {
+                return bytesRead
+            }
+
+            // Dispatch before close(): connection.close() fires
             // connectionLost() synchronously, which would otherwise race in
-            // with IO_ERROR and trigger the reconnect overlay.
-            onDisconnect(DisconnectReason.REMOTE_EOF)
+            // with IO_ERROR and trigger the wrong disconnect action.
+            onDisconnect(getDisconnectReasonForClosedSession(currentSession))
             close()
             throw IOException("Remote end closed connection")
         }

--- a/app/src/test/kotlin/org/connectbot/service/DisconnectPolicyTest.kt
+++ b/app/src/test/kotlin/org/connectbot/service/DisconnectPolicyTest.kt
@@ -50,6 +50,23 @@ class DisconnectPolicyTest {
         assertTrue(decide(DisconnectReason.USER_REQUESTED, quickDisconnect = true, stayConnected = true) is DisconnectAction.CloseImmediately)
     }
 
+    // SESSION_EXIT closes immediately because the remote shell ended cleanly
+
+    @Test
+    fun sessionExit_defaultFlags_closesImmediately() {
+        assertTrue(decide(DisconnectReason.SESSION_EXIT) is DisconnectAction.CloseImmediately)
+    }
+
+    @Test
+    fun sessionExit_stayConnected_closesImmediately() {
+        assertTrue(decide(DisconnectReason.SESSION_EXIT, stayConnected = true) is DisconnectAction.CloseImmediately)
+    }
+
+    @Test
+    fun sessionExit_bothFlags_closesImmediately() {
+        assertTrue(decide(DisconnectReason.SESSION_EXIT, quickDisconnect = true, stayConnected = true) is DisconnectAction.CloseImmediately)
+    }
+
     // quickDisconnect=true closes immediately for all non-user reasons
 
     @Test

--- a/app/src/test/kotlin/org/connectbot/transport/SSHDisconnectTest.kt
+++ b/app/src/test/kotlin/org/connectbot/transport/SSHDisconnectTest.kt
@@ -17,10 +17,14 @@
 
 package org.connectbot.transport
 
+import com.trilead.ssh2.ChannelCondition
 import com.trilead.ssh2.Session
 import org.assertj.core.api.Assertions.assertThat
 import org.connectbot.service.DisconnectReason
+import org.connectbot.service.TerminalBridge
 import org.junit.Test
+import org.mockito.ArgumentMatchers.anyLong
+import org.mockito.ArgumentMatchers.eq
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
 
@@ -41,6 +45,51 @@ class SSHDisconnectTest {
         `when`(session.exitStatus).thenReturn(null)
 
         val reason = SSH().getDisconnectReasonForClosedSession(session)
+
+        assertThat(reason).isEqualTo(DisconnectReason.REMOTE_EOF)
+    }
+
+    @Test
+    fun getDisconnectReasonForClosedSession_whenExitStatusArrivesAfterEof_reportsSessionExit() {
+        val session = mock(Session::class.java)
+        `when`(session.exitStatus).thenReturn(null, 0)
+        `when`(
+            session.waitForCondition(
+                eq(ChannelCondition.EXIT_STATUS or ChannelCondition.EXIT_SIGNAL),
+                anyLong(),
+            ),
+        ).thenReturn(ChannelCondition.EXIT_STATUS)
+
+        val reason = SSH().getDisconnectReasonForClosedSession(session)
+
+        assertThat(reason).isEqualTo(DisconnectReason.SESSION_EXIT)
+    }
+
+    @Test
+    fun getDisconnectReasonForClosedSession_afterUserEofWithoutExitStatus_reportsSessionExit() {
+        val session = mock(Session::class.java)
+        val bridge = mock(TerminalBridge::class.java)
+        `when`(session.exitStatus).thenReturn(null)
+        `when`(bridge.consumePendingUserEof()).thenReturn(true)
+
+        val reason = SSH().apply {
+            setBridge(bridge)
+        }.getDisconnectReasonForClosedSession(session)
+
+        assertThat(reason).isEqualTo(DisconnectReason.SESSION_EXIT)
+    }
+
+    @Test
+    fun getDisconnectReasonForClosedSession_withExitSignal_reportsRemoteEof() {
+        val session = mock(Session::class.java)
+        val bridge = mock(TerminalBridge::class.java)
+        `when`(session.exitStatus).thenReturn(null)
+        `when`(session.exitSignal).thenReturn("TERM")
+        `when`(bridge.consumePendingUserEof()).thenReturn(true)
+
+        val reason = SSH().apply {
+            setBridge(bridge)
+        }.getDisconnectReasonForClosedSession(session)
 
         assertThat(reason).isEqualTo(DisconnectReason.REMOTE_EOF)
     }

--- a/app/src/test/kotlin/org/connectbot/transport/SSHDisconnectTest.kt
+++ b/app/src/test/kotlin/org/connectbot/transport/SSHDisconnectTest.kt
@@ -1,0 +1,47 @@
+/*
+ * ConnectBot: simple, powerful, open-source SSH client for Android
+ * Copyright 2026 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.connectbot.transport
+
+import com.trilead.ssh2.Session
+import org.assertj.core.api.Assertions.assertThat
+import org.connectbot.service.DisconnectReason
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+
+class SSHDisconnectTest {
+    @Test
+    fun getDisconnectReasonForClosedSession_withExitStatus_reportsSessionExit() {
+        val session = mock(Session::class.java)
+        `when`(session.exitStatus).thenReturn(0)
+
+        val reason = SSH().getDisconnectReasonForClosedSession(session)
+
+        assertThat(reason).isEqualTo(DisconnectReason.SESSION_EXIT)
+    }
+
+    @Test
+    fun getDisconnectReasonForClosedSession_withoutExitStatus_reportsRemoteEof() {
+        val session = mock(Session::class.java)
+        `when`(session.exitStatus).thenReturn(null)
+
+        val reason = SSH().getDisconnectReasonForClosedSession(session)
+
+        assertThat(reason).isEqualTo(DisconnectReason.REMOTE_EOF)
+    }
+}


### PR DESCRIPTION
 Fixes #2214 and reintroduced #2099.

  This makes SSH sessions closed by `Ctrl+D` behave like sessions closed by the `exit` command. Previously, when EOF was observed before
  `Session.exitStatus` was available, ConnectBot classified the close as `REMOTE_EOF`, which kept the terminal open and showed the reconnect prompt.

  Changes:
  - Wait briefly for SSH `EXIT_STATUS` / `EXIT_SIGNAL` after channel EOF before classifying the disconnect.
  - Track a recent user-sent EOT byte (`0x04`, Ctrl+D) as a clean-session fallback when no exit status is exposed.
  - Preserve `REMOTE_EOF` behavior for ordinary remote closes and exit-signal cases.
