### PR TITLE
fix: case insensitive match for algorithm

### DIFF
--- a/app/src/main/java/org/connectbot/util/SshKeyType.kt
+++ b/app/src/main/java/org/connectbot/util/SshKeyType.kt
@@ -29,13 +29,13 @@ enum class SshKeyType(
     ;
 
     companion object {
-        fun fromStoredType(value: String?): SshKeyType? = when (value) {
-            "RSA", "ssh-rsa", "rsa-sha2-256", "rsa-sha2-512" -> RSA
-            "DSA", "ssh-dss" -> DSA
-            "EC", "ECDSA" -> EC
-            "Ed25519", "EdDSA", "ssh-ed25519" -> ED25519
-            "IMPORTED" -> LEGACY_IMPORTED
-            else -> if (value?.startsWith("ecdsa-sha2-") == true) EC else null
+        fun fromStoredType(value: String?): SshKeyType? = when (val normalizedValue = value?.lowercase()) {
+            "rsa", "ssh-rsa", "rsa-sha2-256", "rsa-sha2-512" -> RSA
+            "dsa", "ssh-dss" -> DSA
+            "ec", "ecdsa" -> EC
+            "ed25519", "eddsa", "ssh-ed25519" -> ED25519
+            "imported" -> LEGACY_IMPORTED
+            else -> if (normalizedValue?.startsWith("ecdsa-sha2-") == true) EC else null
         }
 
         fun fromOpenSshType(value: String): SshKeyType? = when (value) {
@@ -45,11 +45,11 @@ enum class SshKeyType(
             else -> if (value.startsWith("ecdsa-sha2-")) EC else null
         }
 
-        fun fromJavaAlgorithm(value: String): SshKeyType? = when (value) {
-            "RSA" -> RSA
-            "DSA" -> DSA
-            "EC", "ECDSA" -> EC
-            "Ed25519", "EdDSA" -> ED25519
+        fun fromJavaAlgorithm(value: String): SshKeyType? = when (value.lowercase()) {
+            "rsa" -> RSA
+            "dsa" -> DSA
+            "ec", "ecdsa" -> EC
+            "ed25519", "eddsa" -> ED25519
             else -> null
         }
     }

--- a/app/src/test/kotlin/org/connectbot/util/PubkeyUtilsTest.kt
+++ b/app/src/test/kotlin/org/connectbot/util/PubkeyUtilsTest.kt
@@ -44,6 +44,48 @@ class PubkeyUtilsTest {
     }
 
     @Test
+    fun decodePrivate_lowercaseEd25519StoredType_returnsSshlibKey() {
+        val privateKey = PubkeyUtils.decodePrivate(ed25519KeyPair.private.encoded, "ed25519")
+
+        assertThat(privateKey).isInstanceOf(Ed25519PrivateKey::class.java)
+    }
+
+    @Test
+    fun decodePublic_lowercaseEd25519StoredType_returnsSshlibKey() {
+        val publicKey = PubkeyUtils.decodePublic(ed25519KeyPair.public.encoded, "ed25519")
+
+        assertThat(publicKey).isInstanceOf(Ed25519PublicKey::class.java)
+    }
+
+    @Test
+    fun decodePrivate_lowercaseLegacyEdDsaType_returnsSshlibKey() {
+        val privateKey = PubkeyUtils.decodePrivate(ed25519KeyPair.private.encoded, "eddsa")
+
+        assertThat(privateKey).isInstanceOf(Ed25519PrivateKey::class.java)
+    }
+
+    @Test
+    fun decodePublic_lowercaseLegacyEdDsaType_returnsSshlibKey() {
+        val publicKey = PubkeyUtils.decodePublic(ed25519KeyPair.public.encoded, "eddsa")
+
+        assertThat(publicKey).isInstanceOf(Ed25519PublicKey::class.java)
+    }
+
+    @Test
+    fun decodePrivate_uppercaseLegacyEdDsaType_returnsSshlibKey() {
+        val privateKey = PubkeyUtils.decodePrivate(ed25519KeyPair.private.encoded, "EDDSA")
+
+        assertThat(privateKey).isInstanceOf(Ed25519PrivateKey::class.java)
+    }
+
+    @Test
+    fun decodePublic_uppercaseLegacyEdDsaType_returnsSshlibKey() {
+        val publicKey = PubkeyUtils.decodePublic(ed25519KeyPair.public.encoded, "EDDSA")
+
+        assertThat(publicKey).isInstanceOf(Ed25519PublicKey::class.java)
+    }
+
+    @Test
     fun decodePrivate_legacyOpenSshEd25519Type_returnsSshlibKey() {
         val privateKey = PubkeyUtils.decodePrivate(ed25519KeyPair.private.encoded, "ssh-ed25519")
 

--- a/app/src/test/kotlin/org/connectbot/util/SshKeyTypeTest.kt
+++ b/app/src/test/kotlin/org/connectbot/util/SshKeyTypeTest.kt
@@ -28,6 +28,10 @@ class SshKeyTypeTest {
         assertThat(SshKeyType.fromStoredType("DSA")).isEqualTo(SshKeyType.DSA)
         assertThat(SshKeyType.fromStoredType("EC")).isEqualTo(SshKeyType.EC)
         assertThat(SshKeyType.fromStoredType("Ed25519")).isEqualTo(SshKeyType.ED25519)
+        assertThat(SshKeyType.fromStoredType("ed25519")).isEqualTo(SshKeyType.ED25519)
+        assertThat(SshKeyType.fromStoredType("EdDSA")).isEqualTo(SshKeyType.ED25519)
+        assertThat(SshKeyType.fromStoredType("EDDSA")).isEqualTo(SshKeyType.ED25519)
+        assertThat(SshKeyType.fromStoredType("eddsa")).isEqualTo(SshKeyType.ED25519)
         assertThat(SshKeyType.fromStoredType("IMPORTED")).isEqualTo(SshKeyType.LEGACY_IMPORTED)
     }
 
@@ -41,12 +45,21 @@ class SshKeyTypeTest {
     }
 
     @Test
+    fun fromOpenSshType_isCaseSensitive() {
+        assertThat(SshKeyType.fromOpenSshType("ssh-rsa")).isEqualTo(SshKeyType.RSA)
+        assertThat(SshKeyType.fromOpenSshType("SSH-RSA")).isNull()
+    }
+
+    @Test
     fun fromJavaAlgorithm_mapsProviderAlgorithms() {
         assertThat(SshKeyType.fromJavaAlgorithm("RSA")).isEqualTo(SshKeyType.RSA)
         assertThat(SshKeyType.fromJavaAlgorithm("EC")).isEqualTo(SshKeyType.EC)
         assertThat(SshKeyType.fromJavaAlgorithm("ECDSA")).isEqualTo(SshKeyType.EC)
         assertThat(SshKeyType.fromJavaAlgorithm("EdDSA")).isEqualTo(SshKeyType.ED25519)
+        assertThat(SshKeyType.fromJavaAlgorithm("EDDSA")).isEqualTo(SshKeyType.ED25519)
+        assertThat(SshKeyType.fromJavaAlgorithm("eddsa")).isEqualTo(SshKeyType.ED25519)
         assertThat(SshKeyType.fromJavaAlgorithm("Ed25519")).isEqualTo(SshKeyType.ED25519)
+        assertThat(SshKeyType.fromJavaAlgorithm("ed25519")).isEqualTo(SshKeyType.ED25519)
     }
 
     @Test


### PR DESCRIPTION
The algorithm name is for Java providers is case insensitive. Additionally we can be a little lenient with our database stored values to make sure that things continue to work from old Java providers (including our own).

But we keep wire algorithms as case sensitive as indicated by RFC 4251 section 6: "Names MUST be case-sensitive."

Fixes #2259