### PR TITLE
Add touch-driven mouse reporting for terminal programs

### DIFF
--- a/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
@@ -131,6 +131,7 @@ import org.connectbot.service.AuthBanner
 import org.connectbot.service.DisconnectReason
 import org.connectbot.service.PromptRequest
 import org.connectbot.service.TerminalBridge
+import org.connectbot.terminal.MouseTracking
 import org.connectbot.terminal.ProgressState
 import org.connectbot.terminal.SelectionController
 import org.connectbot.terminal.Terminal
@@ -343,6 +344,7 @@ private fun ConsoleTerminalPage(
     bridge: TerminalBridge,
     isActive: Boolean,
     keyboardAlwaysVisible: Boolean,
+    mouseReportingEnabled: Boolean,
     showSoftwareKeyboard: Boolean,
     forceSize: Pair<Int, Int>?,
     termFocusRequester: FocusRequester,
@@ -369,6 +371,7 @@ private fun ConsoleTerminalPage(
         val coroutineScope = rememberCoroutineScope()
         val fontSize by bridge.fontSizeFlow.collectAsState()
         val delKeyMode by bridge.delKeyModeFlow.collectAsState()
+        val mouseTracking by bridge.terminalEmulator.mouseTracking.collectAsState()
 
         LaunchedEffect(fontResult.loadFailed, fontResult.isLoading) {
             if (fontResult.loadFailed && !fontResult.isLoading) {
@@ -387,6 +390,7 @@ private fun ConsoleTerminalPage(
                 .padding(
                     bottom = if (keyboardAlwaysVisible) TERMINAL_KEYBOARD_HEIGHT_DP.dp else 0.dp,
                 )
+                .terminalMouseReporting(bridge, mouseReportingEnabled && mouseTracking != MouseTracking.None)
                 .then(terminalModifier)
                 .testTag("terminal"),
             typeface = fontResult.typeface,
@@ -527,6 +531,9 @@ fun ConsoleScreen(
     val keyboardAlwaysVisible = remember { prefs.getBoolean(PreferenceConstants.KEY_ALWAYS_VISIBLE, false) }
     val swipeSessionsEnabled = remember {
         prefs.getBoolean(PreferenceConstants.SWIPE_SESSIONS, false)
+    }
+    val mouseReportingEnabled = remember {
+        prefs.getBoolean(PreferenceConstants.MOUSE_REPORTING, false)
     }
     var fullscreen by remember { mutableStateOf(prefs.getBoolean(PreferenceConstants.FULLSCREEN, false)) }
     var titleBarHide by remember { mutableStateOf(prefs.getBoolean(PreferenceConstants.TITLEBARHIDE, false)) }
@@ -943,6 +950,7 @@ fun ConsoleScreen(
                                 bridge = bridge,
                                 isActive = true,
                                 keyboardAlwaysVisible = keyboardAlwaysVisible,
+                                mouseReportingEnabled = mouseReportingEnabled,
                                 showSoftwareKeyboard = showSoftwareKeyboard,
                                 forceSize = forceSize,
                                 termFocusRequester = termFocusRequester,

--- a/app/src/main/java/org/connectbot/ui/screens/console/TerminalMouseInput.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/console/TerminalMouseInput.kt
@@ -1,0 +1,221 @@
+/*
+ * ConnectBot: simple, powerful, open-source SSH client for Android
+ * Copyright 2026 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.connectbot.ui.screens.console
+
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.changedToDown
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.input.pointer.positionChange
+import org.connectbot.service.TerminalBridge
+import kotlin.math.abs
+import kotlin.math.floor
+
+// libvterm button numbering: 1-3 are left/middle/right, 4/5 are wheel up/down.
+private const val MOUSE_BUTTON_LEFT = 1
+private const val MOUSE_WHEEL_UP = 4
+private const val MOUSE_WHEEL_DOWN = 5
+
+/**
+ * Maps a pixel coordinate within a composable of the given size to a 1-based
+ * terminal cell coordinate, clamped to the terminal grid bounds.
+ */
+internal fun pixelToCell(
+    x: Float,
+    y: Float,
+    widthPx: Int,
+    heightPx: Int,
+    cols: Int,
+    rows: Int,
+): Pair<Int, Int> {
+    val col = if (widthPx <= 0 || cols <= 0) {
+        1
+    } else {
+        val cellWidth = widthPx.toFloat() / cols
+        (floor(x / cellWidth).toInt() + 1).coerceIn(1, cols)
+    }
+    val row = if (heightPx <= 0 || rows <= 0) {
+        1
+    } else {
+        val cellHeight = heightPx.toFloat() / rows
+        (floor(y / cellHeight).toInt() + 1).coerceIn(1, rows)
+    }
+    return col to row
+}
+
+/**
+ * The states of the per-gesture state machine driven by [terminalMouseReporting].
+ */
+private enum class MouseGestureState {
+    /** No decision made yet: waiting to see if this becomes a tap, scroll, or long-press. */
+    UNDETERMINED,
+
+    /** Vertical drag beyond touch slop: reporting mouse wheel events for the rest of the gesture. */
+    SCROLL,
+
+    /** Stationary long-press: handing the gesture over to termlib's own text selection. */
+    SELECTION,
+
+    /** Pinch (second pointer) or horizontal drag: falling through to termlib/session-swipe. */
+    ABORTED,
+}
+
+/**
+ * Translates touch gestures into xterm mouse escape sequences sent to [bridge] when the
+ * remote program has enabled mouse reporting.
+ *
+ * When [enabled] is false, this is a no-op that returns the receiver unchanged so that
+ * termlib's own gesture handling (tap-to-focus, scrollback drag, long-press selection,
+ * pinch-to-zoom) is completely unaffected.
+ *
+ * When enabled, gestures are observed on [PointerEventPass.Initial], i.e. before termlib's
+ * own gesture detectors see them. Crucially, none of the pointer changes are consumed: that
+ * lets termlib's own gesture detector (which runs afterwards, on [PointerEventPass.Main])
+ * still see the real movement, so it classifies a drag as its own scroll gesture and cancels
+ * its long-press timer. If we consumed instead, [androidx.compose.ui.input.pointer.PointerInputChange.positionChange]
+ * would report zero to termlib, its long-press would fire mid-drag, and a magnifier loupe and
+ * text selection would appear on top of the scroll. Leaving events unconsumed avoids that; the
+ * only cost is that termlib also scrolls its local scrollback, which is a no-op on the
+ * alternate screen where mouse-reporting programs (tmux, vim, htop, less, …) run.
+ *
+ * The gesture is classified from the unconsumed movement:
+ * - A second pointer going down aborts mouse-reporting handling entirely so pinch-to-zoom and
+ *   other multi-touch gestures still work.
+ * - Movement beyond touch slop that is mostly horizontal aborts so session-swipe navigation
+ *   still works.
+ * - Movement beyond touch slop that is mostly vertical is reported as mouse wheel events, one
+ *   per cell-height of accumulated movement, at the cell under the current pointer position.
+ *   Moving the finger down sends wheel-up events. termlib concurrently treats the same drag as
+ *   a scroll gesture (so no long-press, magnifier, or selection is started).
+ * - Holding still past the long-press timeout without exceeding touch slop hands the gesture to
+ *   termlib: nothing is reported for the remainder of the gesture, so termlib can start and own
+ *   its own text selection, including drag-to-extend.
+ * - Otherwise, releasing the pointer before the long-press timeout is a tap: a mouse press
+ *   and release are sent for the cell under the down position.
+ */
+internal fun Modifier.terminalMouseReporting(
+    bridge: TerminalBridge,
+    enabled: Boolean,
+): Modifier {
+    if (!enabled) {
+        return this
+    }
+
+    return pointerInput(bridge, enabled) {
+        awaitEachGesture {
+            val down = awaitFirstDown(requireUnconsumed = false, pass = PointerEventPass.Initial)
+            val pointerId = down.id
+            val downPosition = down.position
+            val downTimeMillis = down.uptimeMillis
+            var dragX = 0f
+            var dragY = 0f
+            var state = MouseGestureState.UNDETERMINED
+
+            while (true) {
+                val event = awaitPointerEvent(PointerEventPass.Initial)
+
+                if (event.changes.any { it.id != pointerId && it.changedToDown() }) {
+                    state = MouseGestureState.ABORTED
+                }
+
+                val change = event.changes.firstOrNull { it.id == pointerId }
+
+                if (state == MouseGestureState.ABORTED) {
+                    if (event.changes.none { it.pressed }) {
+                        break
+                    }
+                    continue
+                }
+
+                if (change == null || !change.pressed) {
+                    if (state == MouseGestureState.UNDETERMINED) {
+                        val elapsed = (change?.uptimeMillis ?: downTimeMillis) - downTimeMillis
+                        if (
+                            elapsed < viewConfiguration.longPressTimeoutMillis &&
+                            abs(dragX) <= viewConfiguration.touchSlop &&
+                            abs(dragY) <= viewConfiguration.touchSlop
+                        ) {
+                            val emulator = bridge.terminalEmulator
+                            val dimensions = emulator.dimensions
+                            val (col, row) = pixelToCell(
+                                downPosition.x,
+                                downPosition.y,
+                                size.width,
+                                size.height,
+                                dimensions.columns,
+                                dimensions.rows,
+                            )
+                            // pixelToCell is 1-based; libvterm wants 0-based (row, col).
+                            emulator.dispatchMouseMove(row - 1, col - 1)
+                            emulator.dispatchMouseButton(MOUSE_BUTTON_LEFT, pressed = true)
+                            emulator.dispatchMouseButton(MOUSE_BUTTON_LEFT, pressed = false)
+                        }
+                    }
+                    break
+                }
+
+                val delta = change.positionChange()
+                dragX += delta.x
+                dragY += delta.y
+
+                if (state == MouseGestureState.UNDETERMINED) {
+                    val elapsed = change.uptimeMillis - downTimeMillis
+                    val absX = abs(dragX)
+                    val absY = abs(dragY)
+
+                    if (
+                        elapsed >= viewConfiguration.longPressTimeoutMillis &&
+                        absX <= viewConfiguration.touchSlop &&
+                        absY <= viewConfiguration.touchSlop
+                    ) {
+                        state = MouseGestureState.SELECTION
+                    } else if (absX > viewConfiguration.touchSlop || absY > viewConfiguration.touchSlop) {
+                        state = if (absY > absX) {
+                            MouseGestureState.SCROLL
+                        } else {
+                            MouseGestureState.ABORTED
+                        }
+                    }
+                }
+
+                if (state == MouseGestureState.SCROLL) {
+                    val emulator = bridge.terminalEmulator
+                    val dimensions = emulator.dimensions
+                    val cellHeightPx = size.height.toFloat() / dimensions.rows.coerceAtLeast(1)
+                    while (cellHeightPx > 0f && abs(dragY) >= cellHeightPx) {
+                        val up = dragY > 0f
+                        dragY -= if (up) cellHeightPx else -cellHeightPx
+                        val (col, row) = pixelToCell(
+                            change.position.x,
+                            change.position.y,
+                            size.width,
+                            size.height,
+                            dimensions.columns,
+                            dimensions.rows,
+                        )
+                        // pixelToCell is 1-based; libvterm wants 0-based (row, col).
+                        emulator.dispatchMouseMove(row - 1, col - 1)
+                        emulator.dispatchMouseButton(if (up) MOUSE_WHEEL_UP else MOUSE_WHEEL_DOWN, pressed = true)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/connectbot/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/settings/SettingsScreen.kt
@@ -173,6 +173,7 @@ fun SettingsScreen(
         onWifilockChange = viewModel::updateWifilock,
         onBackupkeysChange = viewModel::updateBackupkeys,
         onScrollbackChange = viewModel::updateScrollback,
+        onMouseReportingChange = viewModel::updateMouseReporting,
         onAddCustomTerminalType = viewModel::addCustomTerminalType,
         onRemoveCustomTerminalType = viewModel::removeCustomTerminalType,
         onFontFamilyChange = viewModel::updateFontFamily,
@@ -218,6 +219,7 @@ fun SettingsScreenContent(
     onWifilockChange: (Boolean) -> Unit,
     onBackupkeysChange: (Boolean) -> Unit,
     onScrollbackChange: (String) -> Unit,
+    onMouseReportingChange: (Boolean) -> Unit,
     onAddCustomTerminalType: (String) -> Unit,
     onRemoveCustomTerminalType: (String) -> Unit,
     onFontFamilyChange: (String) -> Unit,
@@ -413,6 +415,15 @@ fun SettingsScreenContent(
                     onImportFont = onImportLocalFont,
                     onDeleteFont = onDeleteLocalFont,
                     onClearError = onClearImportError,
+                )
+            }
+
+            item {
+                SwitchPreference(
+                    title = stringResource(R.string.pref_mousereporting_title),
+                    summary = stringResource(R.string.pref_mousereporting_summary),
+                    checked = uiState.mousereporting,
+                    onCheckedChange = onMouseReportingChange,
                 )
             }
 
@@ -1583,6 +1594,7 @@ private fun SettingsScreenPreview() {
             onWifilockChange = {},
             onBackupkeysChange = {},
             onScrollbackChange = {},
+            onMouseReportingChange = {},
             onAddCustomTerminalType = {},
             onRemoveCustomTerminalType = {},
             onFontFamilyChange = {},

--- a/app/src/main/java/org/connectbot/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/settings/SettingsViewModel.kt
@@ -63,6 +63,7 @@ data class SettingsUiState(
     val fullscreen: Boolean = false,
     val pgupdngesture: Boolean = false,
     val swipeSessions: Boolean = false,
+    val mousereporting: Boolean = false,
     val volumefont: Boolean = true,
     val keepalive: Boolean = true,
     val alwaysvisible: Boolean = false,
@@ -201,6 +202,7 @@ class SettingsViewModel @Inject constructor(
             fullscreen = prefs.getBoolean("fullscreen", false),
             pgupdngesture = prefs.getBoolean("pgupdngesture", false),
             swipeSessions = prefs.getBoolean(PreferenceConstants.SWIPE_SESSIONS, false),
+            mousereporting = prefs.getBoolean(PreferenceConstants.MOUSE_REPORTING, false),
             volumefont = prefs.getBoolean("volumefont", true),
             keepalive = prefs.getBoolean("keepalive", true),
             alwaysvisible = prefs.getBoolean("alwaysvisible", false),
@@ -287,6 +289,10 @@ class SettingsViewModel @Inject constructor(
 
     fun updateBackupkeys(value: Boolean) {
         updateBooleanPref(PreferenceConstants.BACKUP_KEYS, value) { copy(backupkeys = value) }
+    }
+
+    fun updateMouseReporting(value: Boolean) {
+        updateBooleanPref(PreferenceConstants.MOUSE_REPORTING, value) { copy(mousereporting = value) }
     }
 
     fun updateFullscreen(value: Boolean) {

--- a/app/src/main/java/org/connectbot/util/PreferenceConstants.kt
+++ b/app/src/main/java/org/connectbot/util/PreferenceConstants.kt
@@ -39,6 +39,7 @@ object PreferenceConstants {
     const val TITLEBARHIDE: String = "titlebarhide"
     const val PG_UPDN_GESTURE: String = "pgupdngesture"
     const val SWIPE_SESSIONS: String = "swipeSessions"
+    const val MOUSE_REPORTING: String = "mousereporting"
 
     const val KEYMODE: String = "keymode"
     const val KEY_ALWAYS_VISIBLE: String = "alwaysvisible"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -225,6 +225,11 @@
 	<!-- Description of the scrollback size preference -->
 	<string name="pref_scrollback_summary">"Size of scrollback buffer to keep in memory for each console"</string>
 
+	<!-- Name for the mouse reporting preference, shown in the Terminal emulation settings category. -->
+	<string name="pref_mousereporting_title">"Mouse reporting"</string>
+	<!-- Description of the mouse reporting preference: when enabled, taps and scroll gestures are sent as mouse events to remote programs (such as tmux or nano) that have requested them. -->
+	<string name="pref_mousereporting_summary">"Send taps and scroll gestures as mouse events to remote programs that request them"</string>
+
 	<!-- Name for the font family preference -->
 	<string name="pref_fontfamily_title">"Font"</string>
 	<!-- Description of the font family preference -->

--- a/app/src/test/kotlin/org/connectbot/SettingsScreenTest.kt
+++ b/app/src/test/kotlin/org/connectbot/SettingsScreenTest.kt
@@ -156,6 +156,26 @@ class SettingsScreenTest {
     }
 
     @Test
+    fun settingsScreenContent_clickingMouseReportingRowCallsCallback() {
+        var mouseReportingValue: Boolean? = null
+        val mouseReporting = composeTestRule.activity.getString(R.string.pref_mousereporting_title)
+
+        setSettingsContent(
+            uiState = SettingsUiState(mousereporting = false),
+            onMouseReportingChange = { mouseReportingValue = it },
+        )
+
+        composeTestRule
+            .onNode(hasScrollAction())
+            .performScrollToNode(hasText(mouseReporting))
+        composeTestRule
+            .onNodeWithText(mouseReporting)
+            .performClick()
+
+        assertTrue(mouseReportingValue == true)
+    }
+
+    @Test
     fun settingsScreenContent_scrollbackDialogConfirmsUpdatedValue() {
         var scrollbackValue: String? = null
         val scrollback = composeTestRule.activity.getString(R.string.pref_scrollback_title)
@@ -258,6 +278,7 @@ class SettingsScreenTest {
         onWifilockChange: (Boolean) -> Unit = {},
         onBackupkeysChange: (Boolean) -> Unit = {},
         onScrollbackChange: (String) -> Unit = {},
+        onMouseReportingChange: (Boolean) -> Unit = {},
         onAddCustomTerminalType: (String) -> Unit = {},
         onRemoveCustomTerminalType: (String) -> Unit = {},
         onDefaultProfileChange: (Long) -> Unit = {},
@@ -273,6 +294,7 @@ class SettingsScreenTest {
                     onWifilockChange = onWifilockChange,
                     onBackupkeysChange = onBackupkeysChange,
                     onScrollbackChange = onScrollbackChange,
+                    onMouseReportingChange = onMouseReportingChange,
                     onAddCustomTerminalType = onAddCustomTerminalType,
                     onRemoveCustomTerminalType = onRemoveCustomTerminalType,
                     onFontFamilyChange = {},

--- a/app/src/test/kotlin/org/connectbot/ui/screens/console/TerminalMouseInputTest.kt
+++ b/app/src/test/kotlin/org/connectbot/ui/screens/console/TerminalMouseInputTest.kt
@@ -1,0 +1,97 @@
+/*
+ * ConnectBot: simple, powerful, open-source SSH client for Android
+ * Copyright 2026 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.connectbot.ui.screens.console
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class TerminalMouseInputTest {
+    @Test
+    fun pixelToCell_topLeftPixel_mapsToFirstCell() {
+        assertEquals(
+            Pair(1, 1),
+            pixelToCell(x = 0f, y = 0f, widthPx = 800, heightPx = 400, cols = 80, rows = 40),
+        )
+    }
+
+    @Test
+    fun pixelToCell_midCellPixel_roundsDownToContainingCell() {
+        // Each cell is 10px wide and 10px tall; (25, 15) falls inside the third
+        // column and second row (0-indexed: col 2, row 1).
+        assertEquals(
+            Pair(3, 2),
+            pixelToCell(x = 25f, y = 15f, widthPx = 800, heightPx = 400, cols = 80, rows = 40),
+        )
+    }
+
+    @Test
+    fun pixelToCell_lastPixel_mapsToLastCell() {
+        assertEquals(
+            Pair(80, 40),
+            pixelToCell(x = 795f, y = 395f, widthPx = 800, heightPx = 400, cols = 80, rows = 40),
+        )
+    }
+
+    @Test
+    fun pixelToCell_pixelBeyondBounds_clampsToLastCell() {
+        assertEquals(
+            Pair(80, 40),
+            pixelToCell(x = 10000f, y = 10000f, widthPx = 800, heightPx = 400, cols = 80, rows = 40),
+        )
+    }
+
+    @Test
+    fun pixelToCell_negativePixel_clampsToFirstCell() {
+        assertEquals(
+            Pair(1, 1),
+            pixelToCell(x = -50f, y = -50f, widthPx = 800, heightPx = 400, cols = 80, rows = 40),
+        )
+    }
+
+    @Test
+    fun pixelToCell_zeroWidthOrHeight_doesNotDivideByZero() {
+        assertEquals(
+            Pair(1, 1),
+            pixelToCell(x = 25f, y = 15f, widthPx = 0, heightPx = 0, cols = 80, rows = 40),
+        )
+        assertEquals(
+            Pair(1, 2),
+            pixelToCell(x = 25f, y = 15f, widthPx = 0, heightPx = 400, cols = 80, rows = 40),
+        )
+        assertEquals(
+            Pair(3, 1),
+            pixelToCell(x = 25f, y = 15f, widthPx = 800, heightPx = 0, cols = 80, rows = 40),
+        )
+    }
+
+    @Test
+    fun pixelToCell_zeroColsOrRows_doesNotDivideByZero() {
+        assertEquals(
+            Pair(1, 1),
+            pixelToCell(x = 25f, y = 15f, widthPx = 800, heightPx = 400, cols = 0, rows = 0),
+        )
+        assertEquals(
+            Pair(1, 2),
+            pixelToCell(x = 25f, y = 15f, widthPx = 800, heightPx = 400, cols = 0, rows = 40),
+        )
+        assertEquals(
+            Pair(3, 1),
+            pixelToCell(x = 25f, y = 15f, widthPx = 800, heightPx = 400, cols = 80, rows = 0),
+        )
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,7 +23,7 @@ navigationCompose = "2.9.8"
 activityCompose = "1.13.0"
 
 sshlib = "2.2.48"
-termlib = "0.1.0"
+termlib = "0.1.1-SNAPSHOT"
 playServicesBasement = "18.10.0"
 playFeatureDelivery = "2.1.0"
 conscrypt = "2.5.3"


### PR DESCRIPTION
Adds support for xterm-style mouse reporting driven by touch, so terminal programs that ask for the mouse can respond to taps and scrolling (e.g. `tmux`, `herdr`, `nano`, `vim`, `less`). With this you can tap to move the cursor or click a pane, and drag to scroll.

It's off by default. There's a new "Mouse reporting" switch at the bottom of the terminal emulation settings; when it's off, touch behaves exactly as it did before.

Once mouse reporting is enabled *and* the remote program has actually requested it (via the DECSET sequences the app watches for), touch maps to mouse events like this:

- **Tap** → a left-button press and release at the cell you touched (a click).
- **Vertical drag** → mouse wheel events, one per row of movement, at the cell under your finger. Dragging down scrolls up, matching how scrolling feels everywhere else on the phone.
- **Long-press and hold still** → this is the escape hatch for selecting text. Holding without moving hands the gesture back to the terminal's own text selection (magnifier, handles, drag-to-extend, the works), and no mouse events are sent for the rest of that gesture. So you can still copy text out of a mouse-aware program.
- **Horizontal drag** → left alone, so swiping between sessions still works.
- **Two fingers** → left alone, so pinch-to-zoom still works.

When mouse reporting isn't active, none of this pointer handling is installed at all, so there's zero change to existing touch behaviour.