### PR TITLE
Reduce network queries during startup

### DIFF
--- a/app/src/main/java/org/connectbot/service/ConnectivityMonitor.kt
+++ b/app/src/main/java/org/connectbot/service/ConnectivityMonitor.kt
@@ -1,6 +1,6 @@
 /*
  * ConnectBot: simple, powerful, open-source SSH client for Android
- * Copyright 2025 Kenny Root
+ * Copyright 2025-2026 Kenny Root
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -130,9 +130,11 @@ class ConnectivityMonitor(
         connectivityManager.registerNetworkCallback(request, networkCallback)
         connectivityManager.registerDefaultNetworkCallback(defaultNetworkCallback)
 
-        // Initialize all active networks
-        for (network in connectivityManager.allNetworks) {
-            updateNetworkInfo(network)
+        // Initialize the active network. Other matching networks will be
+        // populated by networkCallback.
+        val activeNetwork = connectivityManager.activeNetwork
+        if (activeNetwork != null) {
+            updateNetworkInfo(activeNetwork)
         }
     }
 

--- a/app/src/test/kotlin/org/connectbot/service/ConnectivityMonitorTest.kt
+++ b/app/src/test/kotlin/org/connectbot/service/ConnectivityMonitorTest.kt
@@ -26,6 +26,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
@@ -85,6 +86,18 @@ class ConnectivityMonitorTest {
 
         // Verify notification
         verify(terminalManager).onConnectivityLost(network, ipAddresses)
+    }
+
+    @Test
+    fun `init should query only the active network`() {
+        val activeNetwork = mock(Network::class.java)
+        `when`(connectivityManager.allNetworks).thenReturn(emptyArray())
+        `when`(connectivityManager.activeNetwork).thenReturn(activeNetwork)
+
+        connectivityMonitor.init()
+
+        verify(connectivityManager).activeNetwork
+        verify(connectivityManager, never()).allNetworks
     }
 
     private fun anyString(): String = org.mockito.ArgumentMatchers.anyString()


### PR DESCRIPTION
Fixes #2296 using Option 2.
- initialize connectivity state from only the active network instead of enumerating every network during startup
- let the registered network callback populate other matching networks asynchronously
- add a Robolectric regression test verifying startup queries activeNetwork and does not use allNetworks

This reduces synchronous Binder transactions during startup and removes use of the deprecated allNetworks API from initialization.
