### PR TITLE
Restore page up/down swipe gesture

### DIFF
--- a/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/console/ConsoleScreen.kt
@@ -134,6 +134,7 @@ import org.connectbot.service.TerminalBridge
 import org.connectbot.terminal.ProgressState
 import org.connectbot.terminal.SelectionController
 import org.connectbot.terminal.Terminal
+import org.connectbot.terminal.VTermKey
 import org.connectbot.ui.LoadingScreen
 import org.connectbot.ui.LocalTerminalManager
 import org.connectbot.ui.components.AuthBannerDialog
@@ -275,6 +276,109 @@ internal fun shouldPreserveSoftwareKeyboardForBridgeChange(
     previousBridgeId != currentBridgeId &&
     showSoftwareKeyboard &&
     !hasHardwareKeyboard
+
+/** Terminal rows that must be dragged before another PgUp/PgDn is emitted. */
+private const val PG_UPDN_GESTURE_ROWS = 5
+
+/** Fallback row height used while the bridge has not measured its font yet. */
+private val PG_UPDN_FALLBACK_ROW_HEIGHT = 20.dp
+
+/**
+ * Whether a touch at [x] starts in the strip that pages the terminal.
+ *
+ * The gesture is confined to the left third so the rest of the terminal keeps its
+ * regular scrollback drag.
+ */
+@VisibleForTesting
+internal fun isInPgUpDnZone(x: Float, width: Int): Boolean = width > 0 && x <= width / 3f
+
+/**
+ * Pixels of vertical drag that correspond to a single page.
+ *
+ * [rowHeightPx] is the bridge's measured row height, which is -1 until the font has been
+ * measured; [fallbackRowHeightPx] covers that window.
+ */
+@VisibleForTesting
+internal fun pgUpDnStepPx(rowHeightPx: Int, fallbackRowHeightPx: Float): Float {
+    val row = if (rowHeightPx > 0) rowHeightPx.toFloat() else fallbackRowHeightPx
+    return row * PG_UPDN_GESTURE_ROWS
+}
+
+/**
+ * Whole pages contained in [accumulatedUpPx] pixels of upward drag.
+ *
+ * Positive values page forward (PgDn), negative values page back (PgUp), matching the
+ * direction of the pre-Compose gesture.
+ */
+@VisibleForTesting
+internal fun pgUpDnPageCount(accumulatedUpPx: Float, stepPx: Float): Int = if (stepPx <= 0f) 0 else (accumulatedUpPx / stepPx).toInt()
+
+/**
+ * Dragging vertically over the left third of the terminal sends PgUp/PgDn to the remote
+ * host rather than scrolling the local scrollback.
+ *
+ * Full-screen applications (vim, less, tmux, ...) keep their own scroll history and leave
+ * the emulator's scrollback empty, so paging is the only way to look back at earlier
+ * output. Behaviour matches the pre-Compose implementation that used to live in
+ * TerminalView.onScroll.
+ */
+private fun Modifier.pgUpDnGesture(
+    selectionActive: Boolean,
+    rowHeight: () -> Int,
+    onPage: (Boolean) -> Unit,
+): Modifier = pointerInput(selectionActive) {
+    if (selectionActive) {
+        return@pointerInput
+    }
+
+    val fallbackRowHeightPx = PG_UPDN_FALLBACK_ROW_HEIGHT.toPx()
+
+    awaitEachGesture {
+        val down = awaitFirstDown(requireUnconsumed = false, pass = PointerEventPass.Initial)
+        if (!isInPgUpDnZone(down.position.x, size.width)) {
+            return@awaitEachGesture
+        }
+
+        val pointerId = down.id
+        var dragX = 0f
+        var dragY = 0f
+        var pendingUpPx = 0f
+        var verticalGestureLocked = false
+
+        while (true) {
+            val event = awaitPointerEvent(PointerEventPass.Initial)
+            val change = event.changes.firstOrNull { it.id == pointerId } ?: break
+            if (!change.pressed) {
+                break
+            }
+
+            val delta = change.positionChange()
+            dragX += delta.x
+            dragY += delta.y
+
+            if (!verticalGestureLocked) {
+                val absX = abs(dragX)
+                val absY = abs(dragY)
+                if (absX > viewConfiguration.touchSlop && absX > absY) {
+                    // Horizontal swipe: leave it to session navigation.
+                    break
+                }
+                if (absY > viewConfiguration.touchSlop && absY > absX) {
+                    verticalGestureLocked = true
+                }
+            }
+
+            if (verticalGestureLocked) {
+                pendingUpPx -= delta.y
+                val stepPx = pgUpDnStepPx(rowHeight(), fallbackRowHeightPx)
+                val pages = pgUpDnPageCount(pendingUpPx, stepPx)
+                repeat(abs(pages)) { onPage(pages > 0) }
+                pendingUpPx -= pages * stepPx
+                change.consume()
+            }
+        }
+    }
+}
 
 private fun Modifier.sessionSwipeNavigation(
     currentIndex: Int,
@@ -527,6 +631,9 @@ fun ConsoleScreen(
     val keyboardAlwaysVisible = remember { prefs.getBoolean(PreferenceConstants.KEY_ALWAYS_VISIBLE, false) }
     val swipeSessionsEnabled = remember {
         prefs.getBoolean(PreferenceConstants.SWIPE_SESSIONS, false)
+    }
+    val pgUpDnGestureEnabled = remember {
+        prefs.getBoolean(PreferenceConstants.PG_UPDN_GESTURE, false)
     }
     var fullscreen by remember { mutableStateOf(prefs.getBoolean(PreferenceConstants.FULLSCREEN, false)) }
     var titleBarHide by remember { mutableStateOf(prefs.getBoolean(PreferenceConstants.TITLEBARHIDE, false)) }
@@ -926,16 +1033,27 @@ fun ConsoleScreen(
                             .weight(1f),
                     ) {
                         val bridge = uiState.bridges[uiState.currentBridgeIndex]
-                        val terminalModifier = if (swipeBetweenSessions) {
-                            Modifier.sessionSwipeNavigation(
+                        var terminalModifier: Modifier = Modifier
+                        if (pgUpDnGestureEnabled) {
+                            terminalModifier = terminalModifier.pgUpDnGesture(
+                                selectionActive = terminalSelectionActive,
+                                rowHeight = { bridge.charHeight },
+                                onPage = { forward ->
+                                    bridge.keyHandler.sendPressedKey(
+                                        if (forward) VTermKey.PAGEDOWN else VTermKey.PAGEUP,
+                                    )
+                                    bridge.tryKeyVibrate()
+                                },
+                            )
+                        }
+                        if (swipeBetweenSessions) {
+                            terminalModifier = terminalModifier.sessionSwipeNavigation(
                                 currentIndex = uiState.currentBridgeIndex,
                                 sessionCount = uiState.bridges.size,
                                 selectionActive = terminalSelectionActive,
                                 onSwipeToSession = { index -> selectBridgePreservingKeyboard(index) },
                                 onInteraction = { handleTerminalInteraction(isInteraction = false) },
                             )
-                        } else {
-                            Modifier
                         }
 
                         key(bridge.host.id) {

--- a/app/src/test/kotlin/org/connectbot/ui/screens/console/PgUpDnGestureTest.kt
+++ b/app/src/test/kotlin/org/connectbot/ui/screens/console/PgUpDnGestureTest.kt
@@ -1,0 +1,90 @@
+/*
+ * ConnectBot: simple, powerful, open-source SSH client for Android
+ * Copyright 2026 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.connectbot.ui.screens.console
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PgUpDnGestureTest {
+    @Test
+    fun isInPgUpDnZone_acceptsLeftThird() {
+        assertTrue(isInPgUpDnZone(x = 0f, width = 900))
+        assertTrue(isInPgUpDnZone(x = 300f, width = 900))
+    }
+
+    @Test
+    fun isInPgUpDnZone_rejectsRestOfTerminal() {
+        assertFalse(isInPgUpDnZone(x = 301f, width = 900))
+        assertFalse(isInPgUpDnZone(x = 899f, width = 900))
+    }
+
+    @Test
+    fun isInPgUpDnZone_rejectsUnmeasuredTerminal() {
+        assertFalse(isInPgUpDnZone(x = 0f, width = 0))
+    }
+
+    @Test
+    fun pgUpDnStepPx_usesMeasuredRowHeight() {
+        assertEquals(100f, pgUpDnStepPx(rowHeightPx = 20, fallbackRowHeightPx = 60f), 0f)
+    }
+
+    @Test
+    fun pgUpDnStepPx_fallsBackWhileRowHeightIsUnmeasured() {
+        // TerminalBridge.charHeight is -1 until the font has been measured.
+        assertEquals(300f, pgUpDnStepPx(rowHeightPx = -1, fallbackRowHeightPx = 60f), 0f)
+    }
+
+    @Test
+    fun pgUpDnPageCount_pagesForwardWhenDraggingUp() {
+        assertEquals(1, pgUpDnPageCount(accumulatedUpPx = 100f, stepPx = 100f))
+        assertEquals(2, pgUpDnPageCount(accumulatedUpPx = 250f, stepPx = 100f))
+    }
+
+    @Test
+    fun pgUpDnPageCount_pagesBackWhenDraggingDown() {
+        assertEquals(-1, pgUpDnPageCount(accumulatedUpPx = -100f, stepPx = 100f))
+        assertEquals(-2, pgUpDnPageCount(accumulatedUpPx = -250f, stepPx = 100f))
+    }
+
+    @Test
+    fun pgUpDnPageCount_ignoresDragShorterThanOnePage() {
+        assertEquals(0, pgUpDnPageCount(accumulatedUpPx = 99f, stepPx = 100f))
+        assertEquals(0, pgUpDnPageCount(accumulatedUpPx = -99f, stepPx = 100f))
+    }
+
+    @Test
+    fun pgUpDnPageCount_ignoresDegenerateStep() {
+        assertEquals(0, pgUpDnPageCount(accumulatedUpPx = 500f, stepPx = 0f))
+    }
+
+    @Test
+    fun pgUpDnPageCount_leavesRemainderForTheNextDrag() {
+        val stepPx = 100f
+        var pending = 250f
+
+        val pages = pgUpDnPageCount(pending, stepPx)
+        pending -= pages * stepPx
+
+        assertEquals(2, pages)
+        assertEquals(50f, pending, 0f)
+        // The leftover alone must not page again.
+        assertEquals(0, pgUpDnPageCount(pending, stepPx))
+    }
+}


### PR DESCRIPTION
## Summary

Restores the page up/down swipe gesture, which stopped working when the console was
rewritten in Compose. The `pgupdngesture` preference is still shown in settings and still
persisted, but nothing reads it any more, so toggling it has no effect.

The gesture used to live in `TerminalView.onScroll`:

```java
boolean pgUpDnGestureEnabled =
        prefs.getBoolean(PreferenceConstants.PG_UPDN_GESTURE, false);
if (pgUpDnGestureEnabled && e2.getX() <= getWidth() / 3) {
    if (moved > 5) {
        ((vt320) bridge.buffer).keyPressed(vt320.KEY_PAGE_DOWN, ' ', 0);
        ...
```

That file went away with the Compose console and the behaviour was not carried over.

This matters most for full-screen applications. vim, less, tmux and agentic CLIs such as
Claude Code keep their own scroll history and leave the emulator's scrollback empty, so the
regular scrollback drag has nothing to show and paging is the only way to look back at
earlier output. That is what #2334 ran into: the special-key strip's PgUp/PgDn buttons work
there, but the swipe does nothing, because the buttons still reach the terminal while the
gesture no longer exists.

Fixes #2334.

## Changes

- Add `Modifier.pgUpDnGesture` in `ConsoleScreen.kt`: a vertical drag that starts in the
  left third sends `VTermKey.PAGEUP` / `VTermKey.PAGEDOWN` every 5 terminal rows, keeping
  the original threshold and direction.
- Read `PreferenceConstants.PG_UPDN_GESTURE` in `ConsoleScreen` and apply the modifier
  independently of `swipeSessions`. Previously the terminal only received a gesture
  modifier at all when session swiping was enabled.
- Yield to `sessionSwipeNavigation` as soon as a drag turns out to be horizontal, and skip
  the gesture entirely while a selection is active.
- Fall back to a fixed row height while `TerminalBridge.charHeight` is still -1, so an
  early drag cannot divide by a negative row height.

## Testing

- `./gradlew spotlessApply lint check test`
- New `PgUpDnGestureTest` covers the zone check, the row-height fallback, page counting in
  both directions, sub-page drags, and that the leftover distance carries into the next
  drag instead of paging twice.
- Verified by hand on a physical device against Claude Code over SSH, the case from #2334:
  paging works with the preference on, and the terminal keeps its normal scrollback drag
  with the preference off and outside the left third.
