### PR TITLE
Fix post-login automation being sent too early and never entered

### DIFF
--- a/app/schemas/org.connectbot.data.ConnectBotDatabase/9.json
+++ b/app/schemas/org.connectbot.data.ConnectBotDatabase/9.json
@@ -1,0 +1,675 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 9,
+    "identityHash": "f27f2bf92b5ef129e66e9f45ecfcec8e",
+    "entities": [
+      {
+        "tableName": "hosts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `nickname` TEXT NOT NULL, `protocol` TEXT NOT NULL, `username` TEXT NOT NULL, `hostname` TEXT NOT NULL, `port` INTEGER NOT NULL, `host_key_algo` TEXT, `last_connect` INTEGER NOT NULL, `color` TEXT, `use_keys` INTEGER NOT NULL, `use_auth_agent` TEXT, `post_login` TEXT, `post_login_wait_for` TEXT, `pubkey_id` INTEGER NOT NULL, `want_session` INTEGER NOT NULL, `compression` INTEGER NOT NULL, `stay_connected` INTEGER NOT NULL, `quick_disconnect` INTEGER NOT NULL, `scrollback_lines` INTEGER NOT NULL, `use_ctrl_alt_as_meta_key` INTEGER NOT NULL, `jump_host_id` INTEGER, `profile_id` INTEGER, `ip_version` TEXT NOT NULL DEFAULT 'IPV4_AND_IPV6')",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nickname",
+            "columnName": "nickname",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "protocol",
+            "columnName": "protocol",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hostname",
+            "columnName": "hostname",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "port",
+            "columnName": "port",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hostKeyAlgo",
+            "columnName": "host_key_algo",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastConnect",
+            "columnName": "last_connect",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "useKeys",
+            "columnName": "use_keys",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "useAuthAgent",
+            "columnName": "use_auth_agent",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "postLogin",
+            "columnName": "post_login",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "postLoginWaitFor",
+            "columnName": "post_login_wait_for",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pubkeyId",
+            "columnName": "pubkey_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "wantSession",
+            "columnName": "want_session",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "compression",
+            "columnName": "compression",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stayConnected",
+            "columnName": "stay_connected",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "quickDisconnect",
+            "columnName": "quick_disconnect",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scrollbackLines",
+            "columnName": "scrollback_lines",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "useCtrlAltAsMetaKey",
+            "columnName": "use_ctrl_alt_as_meta_key",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "jumpHostId",
+            "columnName": "jump_host_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "profileId",
+            "columnName": "profile_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "ipVersion",
+            "columnName": "ip_version",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'IPV4_AND_IPV6'"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_hosts_nickname",
+            "unique": true,
+            "columnNames": [
+              "nickname"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_hosts_nickname` ON `${TABLE_NAME}` (`nickname`)"
+          },
+          {
+            "name": "index_hosts_protocol_username_hostname_port",
+            "unique": false,
+            "columnNames": [
+              "protocol",
+              "username",
+              "hostname",
+              "port"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_hosts_protocol_username_hostname_port` ON `${TABLE_NAME}` (`protocol`, `username`, `hostname`, `port`)"
+          }
+        ]
+      },
+      {
+        "tableName": "pubkeys",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `nickname` TEXT NOT NULL, `type` TEXT NOT NULL, `private_key` BLOB, `public_key` BLOB NOT NULL, `encrypted` INTEGER NOT NULL, `startup` INTEGER NOT NULL, `confirmation` INTEGER NOT NULL, `created_date` INTEGER NOT NULL, `storage_type` TEXT NOT NULL, `allow_backup` INTEGER NOT NULL, `keystore_alias` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nickname",
+            "columnName": "nickname",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "privateKey",
+            "columnName": "private_key",
+            "affinity": "BLOB"
+          },
+          {
+            "fieldPath": "publicKey",
+            "columnName": "public_key",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "encrypted",
+            "columnName": "encrypted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startup",
+            "columnName": "startup",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "confirmation",
+            "columnName": "confirmation",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdDate",
+            "columnName": "created_date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storageType",
+            "columnName": "storage_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "allowBackup",
+            "columnName": "allow_backup",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "keystoreAlias",
+            "columnName": "keystore_alias",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_pubkeys_nickname",
+            "unique": true,
+            "columnNames": [
+              "nickname"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_pubkeys_nickname` ON `${TABLE_NAME}` (`nickname`)"
+          },
+          {
+            "name": "index_pubkeys_storage_type",
+            "unique": false,
+            "columnNames": [
+              "storage_type"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_pubkeys_storage_type` ON `${TABLE_NAME}` (`storage_type`)"
+          },
+          {
+            "name": "index_pubkeys_allow_backup",
+            "unique": false,
+            "columnNames": [
+              "allow_backup"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_pubkeys_allow_backup` ON `${TABLE_NAME}` (`allow_backup`)"
+          }
+        ]
+      },
+      {
+        "tableName": "port_forwards",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `host_id` INTEGER NOT NULL, `nickname` TEXT NOT NULL, `type` TEXT NOT NULL, `source_addr` TEXT NOT NULL DEFAULT 'localhost', `source_port` INTEGER NOT NULL, `dest_addr` TEXT, `dest_port` INTEGER NOT NULL, FOREIGN KEY(`host_id`) REFERENCES `hosts`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hostId",
+            "columnName": "host_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nickname",
+            "columnName": "nickname",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceAddr",
+            "columnName": "source_addr",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'localhost'"
+          },
+          {
+            "fieldPath": "sourcePort",
+            "columnName": "source_port",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "destAddr",
+            "columnName": "dest_addr",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "destPort",
+            "columnName": "dest_port",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_port_forwards_host_id",
+            "unique": false,
+            "columnNames": [
+              "host_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_port_forwards_host_id` ON `${TABLE_NAME}` (`host_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "hosts",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "host_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "known_hosts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `host_id` INTEGER, `hostname` TEXT NOT NULL, `port` INTEGER NOT NULL, `host_key_algo` TEXT NOT NULL, `host_key` BLOB NOT NULL, FOREIGN KEY(`host_id`) REFERENCES `hosts`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hostId",
+            "columnName": "host_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "hostname",
+            "columnName": "hostname",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "port",
+            "columnName": "port",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hostKeyAlgo",
+            "columnName": "host_key_algo",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hostKey",
+            "columnName": "host_key",
+            "affinity": "BLOB",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_known_hosts_host_id",
+            "unique": false,
+            "columnNames": [
+              "host_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_known_hosts_host_id` ON `${TABLE_NAME}` (`host_id`)"
+          },
+          {
+            "name": "index_known_hosts_host_id_host_key",
+            "unique": false,
+            "columnNames": [
+              "host_id",
+              "host_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_known_hosts_host_id_host_key` ON `${TABLE_NAME}` (`host_id`, `host_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "hosts",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "host_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "color_schemes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `is_built_in` INTEGER NOT NULL, `description` TEXT NOT NULL, `foreground` INTEGER NOT NULL, `background` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isBuiltIn",
+            "columnName": "is_built_in",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "foreground",
+            "columnName": "foreground",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "background",
+            "columnName": "background",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_color_schemes_name",
+            "unique": true,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_color_schemes_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "color_palette",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `scheme_id` INTEGER NOT NULL, `color_index` INTEGER NOT NULL, `color` INTEGER NOT NULL, FOREIGN KEY(`scheme_id`) REFERENCES `color_schemes`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "schemeId",
+            "columnName": "scheme_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "colorIndex",
+            "columnName": "color_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_color_palette_scheme_id",
+            "unique": false,
+            "columnNames": [
+              "scheme_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_color_palette_scheme_id` ON `${TABLE_NAME}` (`scheme_id`)"
+          },
+          {
+            "name": "index_color_palette_scheme_id_color_index",
+            "unique": true,
+            "columnNames": [
+              "scheme_id",
+              "color_index"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_color_palette_scheme_id_color_index` ON `${TABLE_NAME}` (`scheme_id`, `color_index`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "color_schemes",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "scheme_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "profiles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `icon_color` TEXT, `color_scheme_id` INTEGER NOT NULL DEFAULT -1, `font_family` TEXT, `font_size` INTEGER NOT NULL DEFAULT 10, `del_key` TEXT NOT NULL DEFAULT 'del', `encoding` TEXT NOT NULL DEFAULT 'UTF-8', `emulation` TEXT NOT NULL DEFAULT 'xterm-256color', `force_size_rows` INTEGER, `force_size_columns` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "iconColor",
+            "columnName": "icon_color",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "colorSchemeId",
+            "columnName": "color_scheme_id",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "-1"
+          },
+          {
+            "fieldPath": "fontFamily",
+            "columnName": "font_family",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fontSize",
+            "columnName": "font_size",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "10"
+          },
+          {
+            "fieldPath": "delKey",
+            "columnName": "del_key",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'del'"
+          },
+          {
+            "fieldPath": "encoding",
+            "columnName": "encoding",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'UTF-8'"
+          },
+          {
+            "fieldPath": "emulation",
+            "columnName": "emulation",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'xterm-256color'"
+          },
+          {
+            "fieldPath": "forceSizeRows",
+            "columnName": "force_size_rows",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "forceSizeColumns",
+            "columnName": "force_size_columns",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_profiles_name",
+            "unique": true,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_profiles_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'f27f2bf92b5ef129e66e9f45ecfcec8e')"
+    ]
+  }
+}

--- a/app/src/main/java/org/connectbot/data/ConnectBotDatabase.kt
+++ b/app/src/main/java/org/connectbot/data/ConnectBotDatabase.kt
@@ -1,6 +1,6 @@
 /*
  * ConnectBot: simple, powerful, open-source SSH client for Android
- * Copyright 2025 Kenny Root
+ * Copyright 2025-2026 Kenny Root
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,6 +57,7 @@ import org.connectbot.data.entity.Pubkey
  * - Version 5: Added profiles table and profile_id column to hosts (manual migration)
  * - Version 6: Added force_size_rows and force_size_columns to profiles (AutoMigration)
  * - Version 7: Added ip_version column to hosts for IP version preference (AutoMigration)
+ * - Version 9: Added post_login_wait_for column to hosts for post-login timing (AutoMigration)
  * - Future versions: Use Room AutoMigration when possible for simple schema changes
  *
  * Security Considerations:
@@ -73,7 +74,7 @@ import org.connectbot.data.entity.Pubkey
         ColorPalette::class,
         Profile::class,
     ],
-    version = 8,
+    version = 9,
     exportSchema = true,
     autoMigrations = [
         AutoMigration(from = 1, to = 2),
@@ -82,6 +83,7 @@ import org.connectbot.data.entity.Pubkey
         AutoMigration(from = 5, to = 6),
         AutoMigration(from = 6, to = 7),
         AutoMigration(from = 7, to = 8),
+        AutoMigration(from = 8, to = 9),
     ],
 )
 @TypeConverters(Converters::class)

--- a/app/src/main/java/org/connectbot/data/entity/Host.kt
+++ b/app/src/main/java/org/connectbot/data/entity/Host.kt
@@ -64,6 +64,18 @@ data class Host(
     @ColumnInfo(name = "post_login")
     val postLogin: String? = null,
 
+    /**
+     * Text to wait for in the remote output before [postLogin] is sent.
+     *
+     * Logins that need another step after authentication, such as a Tailscale
+     * SSH check that waits on a browser, are not ready to read anything when
+     * the shell is requested. Naming a piece of the shell prompt holds the
+     * commands back until that step is done. Null sends them once the remote
+     * has gone quiet instead.
+     */
+    @ColumnInfo(name = "post_login_wait_for")
+    val postLoginWaitFor: String? = null,
+
     @ColumnInfo(name = "pubkey_id")
     val pubkeyId: Long = -1L,
 

--- a/app/src/main/java/org/connectbot/service/PostLoginWaiter.kt
+++ b/app/src/main/java/org/connectbot/service/PostLoginWaiter.kt
@@ -1,0 +1,120 @@
+/*
+ * ConnectBot: simple, powerful, open-source SSH client for Android
+ * Copyright 2026 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.connectbot.service
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.withTimeoutOrNull
+
+/**
+ * Decides when a host's post-login commands may be written to the remote.
+ *
+ * The commands used to go out the instant the SSH shell request was sent, which
+ * loses them whenever the far end is not a shell yet: a Tailscale SSH check
+ * still waiting on its browser approval, a slow login script, or a login that
+ * flushes pending terminal input before handing over to the shell. The bytes
+ * are swallowed, so nothing is echoed and nothing runs.
+ *
+ * Waiting for the remote to look ready avoids that. With [waitFor] set, the
+ * commands go out once that text turns up in the remote output, which is what
+ * makes the interactive cases work: the wait outlasts the browser round trip
+ * and ends on the real shell prompt. With [waitFor] empty they go out once the
+ * remote has said something and then stayed quiet for [idleMillis]. Either way
+ * a timeout caps the wait, so a host whose trigger never arrives still runs its
+ * commands instead of silently skipping them.
+ *
+ * Matching is a plain substring test against the raw output, escape sequences
+ * included, so a coloured prompt still matches on its visible tail.
+ */
+class PostLoginWaiter(
+    waitFor: String?,
+    private val idleMillis: Long = DEFAULT_IDLE_MILLIS,
+    idleTimeoutMillis: Long = DEFAULT_IDLE_TIMEOUT_MILLIS,
+    waitForTimeoutMillis: Long = DEFAULT_WAIT_FOR_TIMEOUT_MILLIS,
+) {
+    private val target = waitFor?.takeIf { it.isNotEmpty() }
+
+    private val timeoutMillis = if (target == null) idleTimeoutMillis else waitForTimeoutMillis
+
+    /** Tail of the remote output, only as much of it as a [target] match can still need. */
+    private val tail = StringBuilder()
+
+    /** Signals that output arrived. Conflated, so a burst nobody is reading counts once. */
+    private val output = Channel<Unit>(Channel.CONFLATED)
+
+    private val targetSeen = CompletableDeferred<Unit>()
+
+    /**
+     * Feed a chunk of decoded remote output. Called from the relay for every
+     * chunk it decodes, so it stays cheap and never suspends.
+     */
+    fun onOutput(text: String) {
+        if (text.isEmpty()) return
+
+        output.trySend(Unit)
+
+        val target = this.target ?: return
+        if (targetSeen.isCompleted) return
+
+        synchronized(tail) {
+            tail.append(text)
+            if (tail.indexOf(target) >= 0) {
+                tail.setLength(0)
+                targetSeen.complete(Unit)
+                return
+            }
+            // Keep only what the next chunk could still complete a match with.
+            val keep = target.length - 1
+            if (tail.length > keep) {
+                tail.delete(0, tail.length - keep)
+            }
+        }
+    }
+
+    /**
+     * Suspends until the remote looks ready for the commands.
+     *
+     * @return true if the remote became ready, false if the wait timed out and
+     *   the caller should send the commands anyway
+     */
+    suspend fun awaitReady(): Boolean {
+        val ready = withTimeoutOrNull(timeoutMillis) {
+            if (target != null) {
+                targetSeen.await()
+            } else {
+                // Wait for the remote to say something, then for it to stop talking.
+                output.receive()
+                while (withTimeoutOrNull(idleMillis) { output.receive() } != null) {
+                    // More output arrived, so the remote is still busy.
+                }
+            }
+        }
+        return ready != null
+    }
+
+    companion object {
+        /** How long the remote must stay quiet before it counts as ready. */
+        const val DEFAULT_IDLE_MILLIS = 500L
+
+        /** Caps the idle wait, so a remote that never says anything still gets its commands. */
+        const val DEFAULT_IDLE_TIMEOUT_MILLIS = 10_000L
+
+        /** Caps the [waitFor] wait. Generous, because it can span a browser round trip. */
+        const val DEFAULT_WAIT_FOR_TIMEOUT_MILLIS = 120_000L
+    }
+}

--- a/app/src/main/java/org/connectbot/service/PostLoginWaiter.kt
+++ b/app/src/main/java/org/connectbot/service/PostLoginWaiter.kt
@@ -22,6 +22,25 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.withTimeoutOrNull
 
 /**
+ * Turn the post-login field into the keystrokes the user would have typed.
+ *
+ * Typing a command is not the same as running it: with no terminator the last
+ * one just sits on the prompt. The text box also produces plain line feeds,
+ * which a Unix tty accepts as a line terminator but Windows OpenSSH ignores,
+ * so post-login never ran there even when newlines were added by hand.
+ *
+ * The Enter key sends a carriage return, so send that: every line ending
+ * becomes one, and the text always ends in one. The remote tty turns it back
+ * into the newline the shell reads, and Windows gets the character it waits
+ * for.
+ */
+internal fun postLoginAsTyped(commands: String): String {
+    val typed = commands.replace("\r\n", "\r").replace('\n', '\r')
+    if (typed.endsWith('\r')) return typed
+    return typed + '\r'
+}
+
+/**
  * Decides when a host's post-login commands may be written to the remote.
  *
  * The commands used to go out the instant the SSH shell request was sent, which

--- a/app/src/main/java/org/connectbot/service/Relay.kt
+++ b/app/src/main/java/org/connectbot/service/Relay.kt
@@ -1,6 +1,6 @@
 /*
  * ConnectBot: simple, powerful, open-source SSH client for Android
- * Copyright 2025 Kenny Root
+ * Copyright 2025-2026 Kenny Root
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -135,6 +135,7 @@ class Relay(
 
                     if (destBuffer.hasRemaining()) {
                         bridge.terminalEmulator.writeInput(destBuffer.array(), 0, destBuffer.limit())
+                        bridge.onRemoteOutput(destBuffer.array(), destBuffer.limit())
                     }
                     destBuffer.clear()
                     charBuffer.compact()

--- a/app/src/main/java/org/connectbot/service/TerminalBridge.kt
+++ b/app/src/main/java/org/connectbot/service/TerminalBridge.kt
@@ -222,6 +222,11 @@ class TerminalBridge {
     private var networkGracePeriodJob: Job? = null
     private var inGracePeriod: Boolean = false
 
+    // Post-login automation, held back until the remote is ready to read it
+    @Volatile
+    private var postLoginWaiter: PostLoginWaiter? = null
+    private var postLoginJob: Job? = null
+
     private val keyListener: TerminalKeyListener
 
     var charWidth = -1
@@ -657,6 +662,10 @@ class TerminalBridge {
 //        else
 //            (buffer as vt320).setBackspace(vt320.DELETE_IS_DEL)
 
+        // queue up any post-login string before the relay can deliver the
+        // output it waits on
+        schedulePostLogin()
+
         if (isSessionOpen) {
             // create thread to relay incoming connection data to buffer
             transport?.let { t ->
@@ -670,14 +679,58 @@ class TerminalBridge {
         // force font-size to make sure we resizePTY as needed
         setFontSize(fontSizeSp)
 
-        // finally send any post-login string, if requested
-        injectString(host.postLogin)
-
         // Capture network state after successful connection
         captureNetworkState()
 
         // Notify manager so the UI recomposes with updated connection state
         manager.notifyBridgeStateChanged()
+    }
+
+    /**
+     * Send the host's post-login commands once the remote is ready for them.
+     *
+     * Writing them straight after the shell request races anything that delays
+     * the remote shell, so [PostLoginWaiter] holds them until the remote looks
+     * ready to read.
+     */
+    private fun schedulePostLogin() {
+        val commands = host.postLogin
+        if (commands.isNullOrEmpty()) return
+
+        if (!isSessionOpen) {
+            // Without a session there is nothing on the far end to read them.
+            Timber.d("No session for ${host.nickname}, skipping post-login automation")
+            return
+        }
+
+        postLoginJob?.cancel()
+
+        val waiter = PostLoginWaiter(host.postLoginWaitFor)
+        postLoginWaiter = waiter
+        postLoginJob = scope.launch {
+            try {
+                if (!waiter.awaitReady()) {
+                    Timber.i("Post-login wait for ${host.nickname} timed out, sending anyway")
+                }
+                injectString(commands)
+            } finally {
+                // Only stand down if a later connection has not taken over.
+                if (postLoginWaiter === waiter) {
+                    postLoginWaiter = null
+                }
+            }
+        }
+    }
+
+    /**
+     * Hand a chunk of decoded remote output to whatever is still waiting on it.
+     * Called by the relay for every chunk, so it costs a volatile read once
+     * post-login automation has run.
+     */
+    internal fun onRemoteOutput(data: ByteArray, length: Int) {
+        if (length <= 0) return
+        val waiter = postLoginWaiter ?: return
+        waiter.onOutput(String(data, 0, length, Charsets.UTF_8))
     }
 
     /**
@@ -722,6 +775,10 @@ class TerminalBridge {
 
         // Cancel any pending prompts
         promptManager.cancelPrompt()
+
+        // Drop post-login automation that never got its go-ahead
+        postLoginJob?.cancel()
+        postLoginWaiter = null
 
         // disconnection request hangs if we havent really connected to a host yet
         // temporary fix is to just spawn disconnection into a thread

--- a/app/src/main/java/org/connectbot/service/TerminalBridge.kt
+++ b/app/src/main/java/org/connectbot/service/TerminalBridge.kt
@@ -694,14 +694,18 @@ class TerminalBridge {
      * ready to read.
      */
     private fun schedulePostLogin() {
-        val commands = host.postLogin
-        if (commands.isNullOrEmpty()) return
+        val postLogin = host.postLogin
+        if (postLogin.isNullOrEmpty()) return
 
         if (!isSessionOpen) {
             // Without a session there is nothing on the far end to read them.
             Timber.d("No session for ${host.nickname}, skipping post-login automation")
             return
         }
+
+        // Only post-login is entered for the user; a clipboard paste through
+        // injectString must never enter itself.
+        val commands = postLoginAsTyped(postLogin)
 
         postLoginJob?.cancel()
 

--- a/app/src/main/java/org/connectbot/ui/screens/hosteditor/HostEditorScreen.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/hosteditor/HostEditorScreen.kt
@@ -106,6 +106,7 @@ fun HostEditorScreen(
         onStayConnectedChange = viewModel::updateStayConnected,
         onQuickDisconnectChange = viewModel::updateQuickDisconnect,
         onPostLoginChange = viewModel::updatePostLogin,
+        onPostLoginWaitForChange = viewModel::updatePostLoginWaitFor,
         onJumpHostChange = viewModel::updateJumpHostId,
         onIpVersionChange = viewModel::updateIpVersion,
         onPasswordChange = viewModel::updatePassword,
@@ -136,6 +137,7 @@ fun HostEditorScreenContent(
     onStayConnectedChange: (Boolean) -> Unit,
     onQuickDisconnectChange: (Boolean) -> Unit,
     onPostLoginChange: (String) -> Unit,
+    onPostLoginWaitForChange: (String) -> Unit,
     onJumpHostChange: (Long?) -> Unit,
     onIpVersionChange: (String) -> Unit,
     onPasswordChange: (String) -> Unit,
@@ -482,6 +484,18 @@ fun HostEditorScreenContent(
                 supportingText = { Text(stringResource(R.string.hostpref_postlogin_summary)) },
                 minLines = 3,
                 maxLines = 8,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 8.dp),
+            )
+
+            // Text to wait for before the post-login commands are sent
+            OutlinedTextField(
+                value = uiState.postLoginWaitFor,
+                onValueChange = onPostLoginWaitForChange,
+                label = { Text(stringResource(R.string.hostpref_postloginwaitfor_title)) },
+                supportingText = { Text(stringResource(R.string.hostpref_postloginwaitfor_summary)) },
+                singleLine = true,
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(top = 8.dp),
@@ -1260,6 +1274,7 @@ private fun HostEditorScreenPreview() {
                 stayConnected = false,
                 quickDisconnect = false,
                 postLogin = "cd /var/www",
+                postLoginWaitFor = "$ ",
             ),
             onNavigateBack = {},
             onQuickConnectChange = {},
@@ -1277,6 +1292,7 @@ private fun HostEditorScreenPreview() {
             onStayConnectedChange = {},
             onQuickDisconnectChange = {},
             onPostLoginChange = {},
+            onPostLoginWaitForChange = {},
             onJumpHostChange = {},
             onIpVersionChange = {},
             onPasswordChange = {},

--- a/app/src/main/java/org/connectbot/ui/screens/hosteditor/HostEditorViewModel.kt
+++ b/app/src/main/java/org/connectbot/ui/screens/hosteditor/HostEditorViewModel.kt
@@ -56,6 +56,7 @@ data class HostEditorUiState(
     val stayConnected: Boolean = false,
     val quickDisconnect: Boolean = false,
     val postLogin: String = "",
+    val postLoginWaitFor: String = "",
     val jumpHostId: Long? = null,
     val availableJumpHosts: List<Host> = emptyList(),
     val ipVersion: String = "IPV4_AND_IPV6",
@@ -208,6 +209,7 @@ class HostEditorViewModel @Inject constructor(
                             stayConnected = host.stayConnected,
                             quickDisconnect = host.quickDisconnect,
                             postLogin = host.postLogin ?: "",
+                            postLoginWaitFor = host.postLoginWaitFor ?: "",
                             jumpHostId = host.jumpHostId,
                             ipVersion = host.ipVersion,
                             hasExistingPassword = hasPassword,
@@ -355,6 +357,10 @@ class HostEditorViewModel @Inject constructor(
         _uiState.update { it.copy(postLogin = value) }
     }
 
+    fun updatePostLoginWaitFor(value: String) {
+        _uiState.update { it.copy(postLoginWaitFor = value) }
+    }
+
     fun updateJumpHostId(value: Long?) {
         _uiState.update { it.copy(jumpHostId = value) }
     }
@@ -407,6 +413,7 @@ class HostEditorViewModel @Inject constructor(
                     stayConnected = state.stayConnected,
                     quickDisconnect = state.quickDisconnect,
                     postLogin = state.postLogin.ifBlank { null },
+                    postLoginWaitFor = state.postLoginWaitFor.ifBlank { null },
                     lastConnect = existingHost?.lastConnect ?: System.currentTimeMillis(),
                     hostKeyAlgo = existingHost?.hostKeyAlgo,
                     useKeys = existingHost?.useKeys ?: true,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -458,6 +458,11 @@
 	<!-- Host post-login automation preference summary -->
 	<string name="hostpref_postlogin_summary">"Commands to run on remote server once authenticated"</string>
 
+	<!-- Title of the host preference naming the text to wait for before the post-login commands are sent -->
+	<string name="hostpref_postloginwaitfor_title">"Wait for text"</string>
+	<!-- Summary explaining when to fill in the wait-for-text preference and what an empty value does -->
+	<string name="hostpref_postloginwaitfor_summary">"Hold the commands until this text arrives, for logins that need a browser check or another step first. Leave empty to send them once the server stops sending output."</string>
+
 	<!-- Host compression preference title -->
 	<string name="hostpref_compression_title">"Compression"</string>
 	<!-- Summary for compression preference -->

--- a/app/src/test/kotlin/org/connectbot/service/PostLoginWaiterTest.kt
+++ b/app/src/test/kotlin/org/connectbot/service/PostLoginWaiterTest.kt
@@ -142,6 +142,27 @@ class PostLoginWaiterTest {
     }
 
     @Test
+    fun `unterminated commands get entered`() {
+        assertThat(postLoginAsTyped("tmux attach")).isEqualTo("tmux attach\r")
+    }
+
+    @Test
+    fun `every line of multi-line commands gets entered`() {
+        assertThat(postLoginAsTyped("cd /var/www\nls -l")).isEqualTo("cd /var/www\rls -l\r")
+    }
+
+    @Test
+    fun `line feeds become carriage returns for windows openssh`() {
+        assertThat(postLoginAsTyped("dir\n")).isEqualTo("dir\r")
+        assertThat(postLoginAsTyped("dir\r\n")).isEqualTo("dir\r")
+    }
+
+    @Test
+    fun `commands already ending in a carriage return are unchanged`() {
+        assertThat(postLoginAsTyped("tmux attach\r")).isEqualTo("tmux attach\r")
+    }
+
+    @Test
     fun `empty wait for text falls back to the idle wait`() = runTest {
         val waiter = PostLoginWaiter(waitFor = "", idleMillis = 500L)
 

--- a/app/src/test/kotlin/org/connectbot/service/PostLoginWaiterTest.kt
+++ b/app/src/test/kotlin/org/connectbot/service/PostLoginWaiterTest.kt
@@ -1,0 +1,154 @@
+/*
+ * ConnectBot: simple, powerful, open-source SSH client for Android
+ * Copyright 2026 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.connectbot.service
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class PostLoginWaiterTest {
+
+    @Test
+    fun `idle wait holds until the remote stops talking`() = runTest {
+        val waiter = PostLoginWaiter(waitFor = null, idleMillis = 500L)
+
+        val ready = async { waiter.awaitReady() }
+        runCurrent()
+        assertThat(ready.isCompleted).isFalse()
+
+        waiter.onOutput("Welcome to the machine\r\n")
+        advanceTimeBy(400L)
+        runCurrent()
+        assertThat(ready.isCompleted).isFalse()
+
+        // Still talking, so the quiet period starts over.
+        waiter.onOutput("Last login: today\r\n")
+        advanceTimeBy(400L)
+        runCurrent()
+        assertThat(ready.isCompleted).isFalse()
+
+        advanceTimeBy(200L)
+        runCurrent()
+        assertThat(ready.await()).isTrue()
+    }
+
+    @Test
+    fun `idle wait does not fire before the remote says anything`() = runTest {
+        val waiter = PostLoginWaiter(waitFor = null, idleMillis = 500L, idleTimeoutMillis = 10_000L)
+
+        val ready = async { waiter.awaitReady() }
+
+        advanceTimeBy(5_000L)
+        runCurrent()
+        assertThat(ready.isCompleted).isFalse()
+
+        waiter.onOutput("$ ")
+        advanceTimeBy(500L)
+        assertThat(ready.await()).isTrue()
+    }
+
+    @Test
+    fun `idle wait gives up once the timeout expires`() = runTest {
+        val waiter = PostLoginWaiter(waitFor = null, idleMillis = 500L, idleTimeoutMillis = 10_000L)
+
+        val ready = async { waiter.awaitReady() }
+
+        advanceTimeBy(10_001L)
+        assertThat(ready.await()).isFalse()
+    }
+
+    @Test
+    fun `wait for text ignores output that does not match`() = runTest {
+        val waiter = PostLoginWaiter(waitFor = "user@host:~$ ")
+
+        val ready = async { waiter.awaitReady() }
+
+        // A Tailscale check prints a URL and then waits on the browser.
+        waiter.onOutput("# Tailscale SSH requires an additional check.\r\n")
+        waiter.onOutput("# To authenticate, visit: https://login.example.com/a/0123456789ab\r\n")
+        advanceTimeBy(30_000L)
+        runCurrent()
+        assertThat(ready.isCompleted).isFalse()
+
+        waiter.onOutput("user@host:~$ ")
+        runCurrent()
+        assertThat(ready.await()).isTrue()
+    }
+
+    @Test
+    fun `wait for text matches across chunk boundaries`() = runTest {
+        val waiter = PostLoginWaiter(waitFor = "ready>")
+
+        val ready = async { waiter.awaitReady() }
+
+        waiter.onOutput("system is rea")
+        runCurrent()
+        assertThat(ready.isCompleted).isFalse()
+
+        waiter.onOutput("dy> ")
+        runCurrent()
+        assertThat(ready.await()).isTrue()
+    }
+
+    @Test
+    fun `wait for text matches through escape sequences on a coloured prompt`() = runTest {
+        val waiter = PostLoginWaiter(waitFor = "$ ")
+
+        val ready = async { waiter.awaitReady() }
+
+        waiter.onOutput("\u001B[1;32muser@host\u001B[0m:\u001B[1;34m~\u001B[0m$ ")
+        runCurrent()
+        assertThat(ready.await()).isTrue()
+    }
+
+    @Test
+    fun `wait for text that already arrived is not missed`() = runTest {
+        val waiter = PostLoginWaiter(waitFor = "ready>")
+
+        waiter.onOutput("ready> ")
+
+        assertThat(waiter.awaitReady()).isTrue()
+    }
+
+    @Test
+    fun `wait for text gives up once the timeout expires`() = runTest {
+        val waiter = PostLoginWaiter(waitFor = "never appears", waitForTimeoutMillis = 120_000L)
+
+        val ready = async { waiter.awaitReady() }
+
+        waiter.onOutput("something else entirely\r\n")
+        advanceTimeBy(120_001L)
+        assertThat(ready.await()).isFalse()
+    }
+
+    @Test
+    fun `empty wait for text falls back to the idle wait`() = runTest {
+        val waiter = PostLoginWaiter(waitFor = "", idleMillis = 500L)
+
+        val ready = async { waiter.awaitReady() }
+
+        waiter.onOutput("$ ")
+        advanceTimeBy(500L)
+        assertThat(ready.await()).isTrue()
+    }
+}


### PR DESCRIPTION
Post-login automation has two independent bugs that combine to make it look flaky. One commit each.

## 1. Sent before anything can read it

`TerminalBridge.onConnected()` called `injectString(host.postLogin)` the instant `SSH.finishConnection()` had sent the shell request. `startShell()` only sends that request, it doesn't wait for the remote to spawn anything, so the bytes go out before there is a shell to read them.

Whatever is on the far end at that moment eats them. The clearest case is Tailscale SSH in check mode: tailscaled accepts the session, prints its "visit this URL to authenticate" text, and only spawns the PTY once the browser approval lands. Anything sent beforehand is consumed by the check handler or lost when the real PTY appears, so the command is never echoed and never runs. When the check is still cached no interaction happens, the shell starts immediately, and the same code works. Hence "only sometimes".

Worth ruling out, since it looks like the obvious culprit: this is **not** a missing flush. `TerminalBridge.requestFlush()` has no callers, but sshlib's `ChannelOutputStream.write()` sends a channel-data packet immediately, and its `flush()` is a no-op that only checks the closed flag. The bytes really do leave the device; the remote discards them.

So hold the commands until the remote looks ready:

- A new per-host **Wait for text** field names something to watch for in the remote output. Plain substring against the raw stream, escape sequences included, so a coloured prompt matches on its visible tail. Capped at 120 s, which comfortably outlasts a browser round trip.
- Left empty, the commands go out once the remote has sent something and then stayed quiet for 500 ms. Capped at 10 s.
- Both caps fall back to sending anyway, so a trigger that never matches costs latency rather than a silently skipped command. Existing hosts keep working with no configuration.

The waiter is armed before the relay starts, otherwise a local shell's first prompt can beat it.

This should also cover #75, the same race on the local shell transport, though I haven't reproduced that one.

## 2. Typed but never entered

`injectString()` sends the field verbatim, with no line terminator, so the last command lands on the prompt without running. That was invisible while the string was being swallowed; once it reliably arrives, it just sits there typed.

The field also carries plain line feeds, since that is what the text box produces. A Unix tty takes those as line terminators, but Windows OpenSSH does not, which is why post-login has never worked there even for people who added newlines by hand (#1128, #729).

So send what the Enter key sends: normalise every line ending to a carriage return, and make sure the text ends in one. The remote tty turns it back into the newline the shell reads, and Windows gets the character it was waiting for.

This happens in `schedulePostLogin()` rather than `injectString()`, because that same call pastes the clipboard, and a paste must never enter itself.

## Schema

Adds `post_login_wait_for` to `hosts`. Room 8 to 9 via AutoMigration, schema JSON committed.

## Testing

13 new unit tests cover the waiter and the line-ending conversion: idle settle and its restart on further output, both timeouts, substring match across chunk boundaries, match through escape sequences on a coloured prompt, and the LF / CRLF / CR cases. The coroutine tests use virtual time, so they don't sleep.

`./gradlew :app:testOssDebugUnitTest :app:testGoogleDebugUnitTest :app:lintOssDebug` is green.

`./gradlew check test` fails for me in the `lintAnalyze*UnitTest` / `lintAnalyze*AndroidTest` tasks, but that looks flaky and unrelated to this change: the same command fails the same way on an unmodified `main` here, and re-running it on an unchanged tree flips between pass and fail. It is a Kotlin FIR crash inside lint ("this is a bug in lint or one of the libraries it depends on") while analysing `AppStateScreensTest.kt` and `HiltTestRunner.kt`, neither of which this PR touches. Mentioning it in case it is already known.

Also ran on a device against a Tailscale SSH host that requires the browser check, which is where I hit this: post-login now runs reliably after the round trip.
